### PR TITLE
Enforce tenant isolation across all API endpoints

### DIFF
--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -23,9 +23,7 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     logger.info("ensuring_database_indexes")
 
     # Users: unique email for global email uniqueness
-    await db[settings.mongodb_collection_users].create_index(
-        "email", unique=True, background=True
-    )
+    await db[settings.mongodb_collection_users].create_index("email", unique=True, background=True)
 
     # Documents: tenant-scoped listing
     await db[settings.mongodb_collection_documents].create_index(
@@ -43,9 +41,7 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     )
 
     # API keys: tenant-scoped listing
-    await db[settings.mongodb_collection_api_keys].create_index(
-        "tenant_id", background=True
-    )
+    await db[settings.mongodb_collection_api_keys].create_index("tenant_id", background=True)
 
     # Reset tokens: unique hash lookup
     await db[settings.mongodb_collection_reset_tokens].create_index(

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -4,39 +4,56 @@ import logging
 
 from pymongo.asynchronous.database import AsyncDatabase
 
+from src.core.settings import Settings
+
 logger = logging.getLogger(__name__)
 
 
-async def ensure_indexes(db: AsyncDatabase) -> None:
+async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     """Create required indexes on all collections.
 
     Safe to call on every startup — create_index is idempotent.
+    Uses collection names from Settings for consistency with the rest
+    of the codebase.
 
     Args:
         db: The async MongoDB database instance.
+        settings: Application settings with collection name config.
     """
     logger.info("ensuring_database_indexes")
 
     # Users: unique email for global email uniqueness
-    await db["users"].create_index("email", unique=True, background=True)
+    await db[settings.mongodb_collection_users].create_index(
+        "email", unique=True, background=True
+    )
 
     # Documents: tenant-scoped listing
-    await db["documents"].create_index([("tenant_id", 1), ("created_at", -1)], background=True)
+    await db[settings.mongodb_collection_documents].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
 
     # Chunks: tenant-scoped lookups by document
-    await db["chunks"].create_index([("tenant_id", 1), ("document_id", 1)], background=True)
+    await db[settings.mongodb_collection_chunks].create_index(
+        [("tenant_id", 1), ("document_id", 1)], background=True
+    )
 
     # Conversations: tenant-scoped listing
-    await db["conversations"].create_index([("tenant_id", 1), ("created_at", -1)], background=True)
+    await db[settings.mongodb_collection_conversations].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
 
     # API keys: tenant-scoped listing
-    await db["api_keys"].create_index("tenant_id", background=True)
+    await db[settings.mongodb_collection_api_keys].create_index(
+        "tenant_id", background=True
+    )
 
-    # Reset tokens: hash lookup
-    await db["password_reset_tokens"].create_index("token_hash", background=True)
+    # Reset tokens: unique hash lookup
+    await db[settings.mongodb_collection_reset_tokens].create_index(
+        "token_hash", unique=True, background=True
+    )
 
     # Reset tokens: auto-cleanup after 24 hours
-    await db["password_reset_tokens"].create_index(
+    await db[settings.mongodb_collection_reset_tokens].create_index(
         "expires_at", expireAfterSeconds=86400, background=True
     )
 

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -10,35 +10,49 @@ from src.core.settings import Settings
 
 logger = logging.getLogger(__name__)
 
-# IndexKeySpecsConflict error code — raised when an index exists with
-# the same key pattern but different options (e.g. adding unique=True).
-_INDEX_CONFLICT_CODE = 86
+# MongoDB error codes for index spec/option conflicts.
+_INDEX_CONFLICT_CODES = {
+    85,  # IndexOptionsConflict — same key pattern, different options
+    86,  # IndexKeySpecsConflict — same name, different key spec
+}
+
+
+def _normalize_key_pattern(keys) -> list[tuple[str, int]]:
+    """Normalize index keys to a list of (field, direction) tuples."""
+    if isinstance(keys, str):
+        return [(keys, 1)]
+    return [(k, v) for k, v in keys]
+
+
+async def _find_index_name(collection: AsyncCollection, keys) -> str | None:
+    """Find the name of an existing index matching the given key pattern."""
+    target = _normalize_key_pattern(keys)
+    indexes = await collection.index_information()
+    for name, info in indexes.items():
+        if info.get("key") == target:
+            return name
+    return None
 
 
 async def _create_index_safe(collection: AsyncCollection, keys, **kwargs) -> None:
     """Create an index, handling spec conflicts by drop-and-recreate.
 
     If an index with the same key pattern but different options exists,
-    drops it and recreates with the new options. This handles migrations
-    like adding unique=True to an existing index.
+    discovers the conflicting index name via index_information(), drops
+    it, and recreates with the new options. Handles both code 85
+    (IndexOptionsConflict) and 86 (IndexKeySpecsConflict).
     """
     try:
         await collection.create_index(keys, **kwargs)
     except OperationFailure as e:
-        if e.code == _INDEX_CONFLICT_CODE:
-            # Drop the conflicting index and recreate with new options.
+        if e.code in _INDEX_CONFLICT_CODES:
             logger.warning(
                 "index_spec_conflict_recreating",
                 extra={"collection": collection.name, "keys": str(keys)},
             )
-            # Build the auto-generated index name the same way MongoDB does:
-            # for "email" → "email_1", for [("a",1),("b",-1)] → "a_1_b_-1"
-            if isinstance(keys, str):
-                idx_name = f"{keys}_1"
-            else:
-                parts = [f"{k}_{v}" for k, v in keys]
-                idx_name = "_".join(parts)
-            await collection.drop_index(idx_name)
+            idx_name = await _find_index_name(collection, keys)
+            if idx_name:
+                await collection.drop_index(idx_name)
             await collection.create_index(keys, **kwargs)
         else:
             raise

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -15,9 +15,7 @@ logger = logging.getLogger(__name__)
 _INDEX_CONFLICT_CODE = 86
 
 
-async def _create_index_safe(
-    collection: AsyncCollection, keys, **kwargs
-) -> None:
+async def _create_index_safe(collection: AsyncCollection, keys, **kwargs) -> None:
     """Create an index, handling spec conflicts by drop-and-recreate.
 
     If an index with the same key pattern but different options exists,
@@ -28,9 +26,7 @@ async def _create_index_safe(
         await collection.create_index(keys, **kwargs)
     except OperationFailure as e:
         if e.code == _INDEX_CONFLICT_CODE:
-            # Extract the conflicting index name from the error details
-            # and drop it before recreating with new options.
-            existing = e.details.get("errmsg", "")
+            # Drop the conflicting index and recreate with new options.
             logger.warning(
                 "index_spec_conflict_recreating",
                 extra={"collection": collection.name, "keys": str(keys)},
@@ -92,6 +88,16 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     # Reset tokens: auto-cleanup after 24 hours
     await db[settings.mongodb_collection_reset_tokens].create_index(
         "expires_at", expireAfterSeconds=86400, background=True
+    )
+
+    # WS tickets: unique hash lookup
+    await db[settings.mongodb_collection_ws_tickets].create_index(
+        "ticket_hash", unique=True, background=True
+    )
+
+    # WS tickets: auto-cleanup after 60 seconds (tickets expire in 30s)
+    await db[settings.mongodb_collection_ws_tickets].create_index(
+        "expires_at", expireAfterSeconds=60, background=True
     )
 
     logger.info("database_indexes_ensured")

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -2,19 +2,58 @@
 
 import logging
 
+from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import OperationFailure
 
 from src.core.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+# IndexKeySpecsConflict error code — raised when an index exists with
+# the same key pattern but different options (e.g. adding unique=True).
+_INDEX_CONFLICT_CODE = 86
+
+
+async def _create_index_safe(
+    collection: AsyncCollection, keys, **kwargs
+) -> None:
+    """Create an index, handling spec conflicts by drop-and-recreate.
+
+    If an index with the same key pattern but different options exists,
+    drops it and recreates with the new options. This handles migrations
+    like adding unique=True to an existing index.
+    """
+    try:
+        await collection.create_index(keys, **kwargs)
+    except OperationFailure as e:
+        if e.code == _INDEX_CONFLICT_CODE:
+            # Extract the conflicting index name from the error details
+            # and drop it before recreating with new options.
+            existing = e.details.get("errmsg", "")
+            logger.warning(
+                "index_spec_conflict_recreating",
+                extra={"collection": collection.name, "keys": str(keys)},
+            )
+            # Build the auto-generated index name the same way MongoDB does:
+            # for "email" → "email_1", for [("a",1),("b",-1)] → "a_1_b_-1"
+            if isinstance(keys, str):
+                idx_name = f"{keys}_1"
+            else:
+                parts = [f"{k}_{v}" for k, v in keys]
+                idx_name = "_".join(parts)
+            await collection.drop_index(idx_name)
+            await collection.create_index(keys, **kwargs)
+        else:
+            raise
+
 
 async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     """Create required indexes on all collections.
 
-    Safe to call on every startup — create_index is idempotent.
-    Uses collection names from Settings for consistency with the rest
-    of the codebase.
+    Safe to call on every startup — create_index is idempotent when
+    options match. Handles spec conflicts (e.g. upgrading to unique)
+    by dropping and recreating the index.
 
     Args:
         db: The async MongoDB database instance.
@@ -23,7 +62,9 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
     logger.info("ensuring_database_indexes")
 
     # Users: unique email for global email uniqueness
-    await db[settings.mongodb_collection_users].create_index("email", unique=True, background=True)
+    await _create_index_safe(
+        db[settings.mongodb_collection_users], "email", unique=True, background=True
+    )
 
     # Documents: tenant-scoped listing
     await db[settings.mongodb_collection_documents].create_index(

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -1,0 +1,43 @@
+"""Database index management."""
+
+import logging
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_indexes(db: AsyncDatabase) -> None:
+    """Create required indexes on all collections.
+
+    Safe to call on every startup — create_index is idempotent.
+
+    Args:
+        db: The async MongoDB database instance.
+    """
+    logger.info("ensuring_database_indexes")
+
+    # Users: unique email for global email uniqueness
+    await db["users"].create_index("email", unique=True, background=True)
+
+    # Documents: tenant-scoped listing
+    await db["documents"].create_index([("tenant_id", 1), ("created_at", -1)], background=True)
+
+    # Chunks: tenant-scoped lookups by document
+    await db["chunks"].create_index([("tenant_id", 1), ("document_id", 1)], background=True)
+
+    # Conversations: tenant-scoped listing
+    await db["conversations"].create_index([("tenant_id", 1), ("created_at", -1)], background=True)
+
+    # API keys: tenant-scoped listing
+    await db["api_keys"].create_index("tenant_id", background=True)
+
+    # Reset tokens: hash lookup
+    await db["password_reset_tokens"].create_index("token_hash", background=True)
+
+    # Reset tokens: auto-cleanup after 24 hours
+    await db["password_reset_tokens"].create_index(
+        "expires_at", expireAfterSeconds=86400, background=True
+    )
+
+    logger.info("database_indexes_ensured")

--- a/apps/api/src/core/dependencies.py
+++ b/apps/api/src/core/dependencies.py
@@ -121,6 +121,10 @@ class AgentDependencies:
     def reset_tokens_collection(self) -> AsyncCollection:
         return self._get_collection(self.settings.mongodb_collection_reset_tokens)
 
+    @property
+    def ws_tickets_collection(self) -> AsyncCollection:
+        return self._get_collection(self.settings.mongodb_collection_ws_tickets)
+
     # -- Core methods --
 
     async def cleanup(self) -> None:

--- a/apps/api/src/core/middleware.py
+++ b/apps/api/src/core/middleware.py
@@ -43,6 +43,11 @@ class TenantGuardMiddleware(BaseHTTPMiddleware):
         if not path.startswith("/api/v1/"):
             return response
 
+        # Only warn on successful responses — 401/403 are expected when
+        # auth fails, and warning on those creates noise.
+        if response.status_code >= 400:
+            return response
+
         # Check if tenant context was set
         tenant_id = getattr(request.state, "tenant_id", None)
         if not tenant_id:

--- a/apps/api/src/core/middleware.py
+++ b/apps/api/src/core/middleware.py
@@ -1,0 +1,54 @@
+"""Tenant guard middleware -- safety net for missing tenant context."""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Routes exempt from tenant guard checks
+_EXEMPT_PREFIXES = (
+    "/api/v1/auth",
+    "/health",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+)
+
+
+class TenantGuardMiddleware(BaseHTTPMiddleware):
+    """Log a warning if a protected route completes without tenant context.
+
+    This is a safety net, not primary enforcement. Primary enforcement
+    is the get_tenant_id() dependency injected into route handlers.
+
+    Never blocks requests -- observability only.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        # Initialize tenant_id state so hasattr checks work
+        request.state.tenant_id = None
+
+        response = await call_next(request)
+
+        path = request.url.path
+
+        # Skip exempt routes
+        if any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES):
+            return response
+
+        # Only check /api/v1/ routes
+        if not path.startswith("/api/v1/"):
+            return response
+
+        # Check if tenant context was set
+        tenant_id = getattr(request.state, "tenant_id", None)
+        if not tenant_id:
+            logger.warning(
+                "tenant_id not set for protected route",
+                extra={"path": path, "method": request.method},
+            )
+
+        return response

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -66,6 +66,11 @@ class Settings(BaseSettings):
         description="Collection for password reset tokens",
     )
 
+    mongodb_collection_ws_tickets: str = Field(
+        default="ws_tickets",
+        description="Collection for short-lived WebSocket auth tickets",
+    )
+
     # LLM Configuration (OpenAI-compatible)
     llm_provider: str = Field(
         default="openrouter",

--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -116,6 +116,26 @@ async def get_tenant_id_from_jwt(
     return _resolve_jwt(token)
 
 
+async def resolve_token(raw_token: str, deps: AgentDependencies) -> str:
+    """Resolve a raw token (JWT or API key) to a tenant_id.
+
+    Used by WebSocket handlers where FastAPI Depends is not available.
+
+    Args:
+        raw_token: JWT or API key string (without 'Bearer ' prefix).
+        deps: Application dependencies for DB access.
+
+    Returns:
+        Validated tenant_id string.
+
+    Raises:
+        HTTPException: 401 if token is invalid.
+    """
+    if raw_token.startswith(_API_KEY_PREFIX):
+        return await _resolve_api_key(raw_token, deps)
+    return _resolve_jwt(raw_token)
+
+
 def _resolve_jwt(token: str) -> str:
     """Validate a JWT and return its tenant_id.
 

--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, Header, HTTPException, Request
 
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
@@ -18,6 +18,7 @@ _API_KEY_PREFIX = "mrag_"
 
 
 async def get_tenant_id(
+    request: Request,
     authorization: Optional[str] = Header(default=None),
     deps: AgentDependencies = Depends(get_deps),
 ) -> str:
@@ -28,6 +29,7 @@ async def get_tenant_id(
     - Otherwise → JWT path (decode with nextauth_secret)
 
     Args:
+        request: The incoming request (used to set tenant context on state).
         authorization: Authorization header value.
         deps: Application dependencies for DB access.
 
@@ -46,9 +48,12 @@ async def get_tenant_id(
     token = authorization[7:]  # Strip "Bearer "
 
     if token.startswith(_API_KEY_PREFIX):
-        return await _resolve_api_key(token, deps)
+        tenant_id = await _resolve_api_key(token, deps)
+    else:
+        tenant_id = _resolve_jwt(token)
 
-    return _resolve_jwt(token)
+    request.state.tenant_id = tenant_id
+    return tenant_id
 
 
 async def _resolve_api_key(raw_key: str, deps: AgentDependencies) -> str:
@@ -83,6 +88,7 @@ async def _resolve_api_key(raw_key: str, deps: AgentDependencies) -> str:
 
 
 async def get_tenant_id_from_jwt(
+    request: Request,
     authorization: Optional[str] = Header(default=None),
 ) -> str:
     """Extract tenant_id from JWT only. Rejects API keys.
@@ -91,6 +97,7 @@ async def get_tenant_id_from_jwt(
     sessions (e.g., key management), not via API keys.
 
     Args:
+        request: The incoming request (used to set tenant context on state).
         authorization: Authorization header value.
 
     Returns:
@@ -113,7 +120,9 @@ async def get_tenant_id_from_jwt(
             detail="API keys cannot access this endpoint",
         )
 
-    return _resolve_jwt(token)
+    tenant_id = _resolve_jwt(token)
+    request.state.tenant_id = tenant_id
+    return tenant_id
 
 
 async def resolve_token(raw_token: str, deps: AgentDependencies) -> str:

--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -125,26 +125,6 @@ async def get_tenant_id_from_jwt(
     return tenant_id
 
 
-async def resolve_token(raw_token: str, deps: AgentDependencies) -> str:
-    """Resolve a raw token (JWT or API key) to a tenant_id.
-
-    Used by WebSocket handlers where FastAPI Depends is not available.
-
-    Args:
-        raw_token: JWT or API key string (without 'Bearer ' prefix).
-        deps: Application dependencies for DB access.
-
-    Returns:
-        Validated tenant_id string.
-
-    Raises:
-        HTTPException: 401 if token is invalid.
-    """
-    if raw_token.startswith(_API_KEY_PREFIX):
-        return await _resolve_api_key(raw_token, deps)
-    return _resolve_jwt(raw_token)
-
-
 def _resolve_jwt(token: str) -> str:
     """Validate a JWT and return its tenant_id.
 

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.core.database import ensure_indexes
 from src.core.dependencies import AgentDependencies
+from src.core.middleware import TenantGuardMiddleware
 from src.routers.auth import router as auth_router
 from src.routers.chat import router as chat_router
 from src.routers.health import router as health_router
@@ -53,6 +54,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Tenant guard middleware (safety net -- logs warnings, never blocks)
+app.add_middleware(TenantGuardMiddleware)
 
 # Include routers
 app.include_router(health_router)

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -28,7 +28,7 @@ async def lifespan(app: FastAPI):
     try:
         await deps.initialize()
         app.state.deps = deps
-        await ensure_indexes(deps.db)
+        await ensure_indexes(deps.db, deps.settings)
         logger.info("MongoRAG API started successfully")
     except Exception as e:
         logger.error("Failed to initialize: %s", e)

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -29,11 +29,16 @@ async def lifespan(app: FastAPI):
     try:
         await deps.initialize()
         app.state.deps = deps
-        await ensure_indexes(deps.db, deps.settings)
-        logger.info("MongoRAG API started successfully")
     except Exception as e:
         logger.error("Failed to initialize: %s", e)
         app.state.deps = deps  # Store even on failure so health can report it
+        yield
+        return
+
+    # Index creation is separate — failure is fatal because tenant
+    # isolation guarantees depend on these indexes (e.g. unique email).
+    await ensure_indexes(deps.db, deps.settings)
+    logger.info("MongoRAG API started successfully")
     yield
     logger.info("Shutting down MongoRAG API...")
     await deps.cleanup()

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -37,7 +37,11 @@ async def lifespan(app: FastAPI):
 
     # Index creation is separate — failure is fatal because tenant
     # isolation guarantees depend on these indexes (e.g. unique email).
-    await ensure_indexes(deps.db, deps.settings)
+    try:
+        await ensure_indexes(deps.db, deps.settings)
+    except Exception:
+        await deps.cleanup()
+        raise
     logger.info("MongoRAG API started successfully")
     yield
     logger.info("Shutting down MongoRAG API...")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.core.database import ensure_indexes
 from src.core.dependencies import AgentDependencies
 from src.routers.auth import router as auth_router
 from src.routers.chat import router as chat_router
@@ -27,6 +28,7 @@ async def lifespan(app: FastAPI):
     try:
         await deps.initialize()
         app.state.deps = deps
+        await ensure_indexes(deps.db)
         logger.info("MongoRAG API started successfully")
     except Exception as e:
         logger.error("Failed to initialize: %s", e)

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -123,6 +123,12 @@ class MessageResponse(BaseModel):
     message: str
 
 
+class WSTicketResponse(BaseModel):
+    """Response containing a short-lived WebSocket ticket."""
+
+    ticket: str
+
+
 # --- API Keys ---
 
 

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -49,6 +49,7 @@ class PasswordResetTokenModel(BaseModel):
     """A password reset token (stored as SHA256 hash)."""
 
     user_id: str = Field(..., description="User this token belongs to")
+    tenant_id: str = Field(..., description="Tenant this token belongs to")
     token_hash: str = Field(..., description="SHA256 hash of the reset token")
     expires_at: datetime = Field(..., description="Token expiry time")
     used: bool = Field(default=False, description="Whether the token has been consumed")

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -49,7 +49,10 @@ class PasswordResetTokenModel(BaseModel):
     """A password reset token (stored as SHA256 hash)."""
 
     user_id: str = Field(..., description="User this token belongs to")
-    tenant_id: str = Field(..., description="Tenant this token belongs to")
+    tenant_id: Optional[str] = Field(
+        default=None,
+        description="Tenant this token belongs to; None for legacy tokens",
+    )
     token_hash: str = Field(..., description="SHA256 hash of the reset token")
     expires_at: datetime = Field(..., description="Token expiry time")
     used: bool = Field(default=False, description="Whether the token has been consumed")

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
 from src.core.settings import Settings
+from src.core.tenant import get_tenant_id
 from src.models.api import (
     ForgotPasswordRequest,
     LoginRequest,
@@ -17,8 +18,10 @@ from src.models.api import (
     ResetPasswordRequest,
     SignupRequest,
     SignupResponse,
+    WSTicketResponse,
 )
 from src.services.auth import AuthService
+from src.services.ws_ticket import WSTicketService
 
 logger = logging.getLogger(__name__)
 
@@ -126,3 +129,20 @@ async def reset_password(
         raise HTTPException(status_code=400, detail=str(e))
 
     return MessageResponse(message="Password has been reset successfully.")
+
+
+@router.post("/ws-ticket", response_model=WSTicketResponse)
+async def create_ws_ticket(
+    tenant_id: str = Depends(get_tenant_id),
+    deps: AgentDependencies = Depends(get_deps),
+):
+    """Exchange a JWT or API key for a short-lived WebSocket ticket.
+
+    The ticket is single-use and expires in 30 seconds. Use it to
+    connect to the WebSocket endpoint: /api/v1/chat/ws?ticket=<ticket>
+
+    This avoids exposing long-lived credentials in the WebSocket URL.
+    """
+    service = WSTicketService(deps.ws_tickets_collection)
+    ticket = await service.create_ticket(tenant_id)
+    return WSTicketResponse(ticket=ticket)

--- a/apps/api/src/routers/chat.py
+++ b/apps/api/src/routers/chat.py
@@ -9,7 +9,7 @@ from fastapi.responses import StreamingResponse
 
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
-from src.core.tenant import get_tenant_id
+from src.core.tenant import get_tenant_id, resolve_token
 from src.models.api import ChatRequest, ChatResponse, WSMessage
 from src.services.chat import ChatService, ConversationNotFoundError
 
@@ -76,20 +76,25 @@ async def chat_endpoint(
 @router.websocket("/chat/ws")
 async def chat_websocket(
     websocket: WebSocket,
-    tenant_id: Optional[str] = None,
+    token: Optional[str] = None,
 ):
     """WebSocket endpoint for real-time chat.
 
-    Tenant ID is passed as query parameter: /api/v1/chat/ws?tenant_id=...
+    Authenticate via query parameter: /api/v1/chat/ws?token=<jwt_or_api_key>
     """
-    if not tenant_id or not tenant_id.strip():
-        await websocket.close(code=4001, reason="tenant_id query parameter required")
+    if not token or not token.strip():
+        await websocket.close(code=4001, reason="token query parameter required")
         return
-    tenant_id = tenant_id.strip()
+
+    # Resolve tenant from token before accepting connection
+    deps: AgentDependencies = websocket.app.state.deps
+    try:
+        tenant_id = await resolve_token(token.strip(), deps)
+    except HTTPException:
+        await websocket.close(code=4001, reason="Invalid or expired token")
+        return
 
     await websocket.accept()
-    # Access deps from app state directly (WebSocket can't use Depends)
-    deps: AgentDependencies = websocket.app.state.deps
     service = ChatService(deps)
 
     try:

--- a/apps/api/src/routers/chat.py
+++ b/apps/api/src/routers/chat.py
@@ -9,9 +9,10 @@ from fastapi.responses import StreamingResponse
 
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
-from src.core.tenant import get_tenant_id, resolve_token
+from src.core.tenant import get_tenant_id
 from src.models.api import ChatRequest, ChatResponse, WSMessage
 from src.services.chat import ChatService, ConversationNotFoundError
+from src.services.ws_ticket import WSTicketService
 
 logger = logging.getLogger(__name__)
 
@@ -76,22 +77,24 @@ async def chat_endpoint(
 @router.websocket("/chat/ws")
 async def chat_websocket(
     websocket: WebSocket,
-    token: Optional[str] = None,
+    ticket: Optional[str] = None,
 ):
     """WebSocket endpoint for real-time chat.
 
-    Authenticate via query parameter: /api/v1/chat/ws?token=<jwt_or_api_key>
+    Authenticate via one-time ticket: /api/v1/chat/ws?ticket=<ticket>
+    Obtain a ticket from POST /api/v1/auth/ws-ticket first.
     """
-    if not token or not token.strip():
-        await websocket.close(code=4001, reason="token query parameter required")
+    if not ticket or not ticket.strip():
+        await websocket.close(code=4001, reason="ticket query parameter required")
         return
 
-    # Resolve tenant from token before accepting connection
+    # Validate and consume the one-time ticket before accepting connection
     deps: AgentDependencies = websocket.app.state.deps
-    try:
-        tenant_id = await resolve_token(token.strip(), deps)
-    except HTTPException:
-        await websocket.close(code=4001, reason="Invalid or expired token")
+    ticket_service = WSTicketService(deps.ws_tickets_collection)
+    tenant_id = await ticket_service.consume_ticket(ticket.strip())
+
+    if not tenant_id:
+        await websocket.close(code=4001, reason="Invalid or expired ticket")
         return
 
     await websocket.accept()

--- a/apps/api/src/services/auth.py
+++ b/apps/api/src/services/auth.py
@@ -208,15 +208,25 @@ class AuthService:
         if not token_doc:
             raise ValueError("Invalid or expired reset token")
 
-        # Defense in depth: verify token tenant matches user tenant
+        # Defense in depth: verify token tenant matches user tenant.
+        # Legacy tokens (created before tenant_id was added) lack the field —
+        # skip the check for those so outstanding reset links are not burned.
         user = await self._users.find_one({"_id": ObjectId(token_doc["user_id"])})
-        if not user or user.get("tenant_id") != token_doc.get("tenant_id"):
+        if not user:
+            logger.error(
+                "password_reset_user_not_found",
+                extra={"user_id": token_doc["user_id"]},
+            )
+            raise ValueError("Invalid or expired reset token")
+
+        token_tenant = token_doc.get("tenant_id")
+        if token_tenant is not None and token_tenant != user.get("tenant_id"):
             logger.error(
                 "password_reset_tenant_mismatch",
                 extra={
                     "user_id": token_doc["user_id"],
-                    "token_tenant": token_doc.get("tenant_id"),
-                    "user_tenant": user.get("tenant_id") if user else None,
+                    "token_tenant": token_tenant,
+                    "user_tenant": user.get("tenant_id"),
                 },
             )
             raise ValueError("Invalid or expired reset token")

--- a/apps/api/src/services/auth.py
+++ b/apps/api/src/services/auth.py
@@ -39,9 +39,7 @@ class AuthService:
         self._tenants = tenants_collection
         self._reset_tokens = reset_tokens_collection
 
-    async def signup(
-        self, email: str, password: str, organization_name: str
-    ) -> dict[str, Any]:
+    async def signup(self, email: str, password: str, organization_name: str) -> dict[str, Any]:
         """Create a new tenant and user.
 
         Args:
@@ -155,6 +153,7 @@ class AuthService:
             return None
 
         user_id = str(user["_id"])
+        tenant_id = user["tenant_id"]
 
         # Invalidate any existing tokens for this user
         await self._reset_tokens.update_many(
@@ -169,6 +168,7 @@ class AuthService:
 
         token_doc = {
             "user_id": user_id,
+            "tenant_id": tenant_id,
             "token_hash": token_hash,
             "expires_at": now + timedelta(hours=1),
             "used": False,
@@ -208,10 +208,23 @@ class AuthService:
         if not token_doc:
             raise ValueError("Invalid or expired reset token")
 
+        # Defense in depth: verify token tenant matches user tenant
+        user = await self._users.find_one({"_id": ObjectId(token_doc["user_id"])})
+        if not user or user.get("tenant_id") != token_doc.get("tenant_id"):
+            logger.error(
+                "password_reset_tenant_mismatch",
+                extra={
+                    "user_id": token_doc["user_id"],
+                    "token_tenant": token_doc.get("tenant_id"),
+                    "user_tenant": user.get("tenant_id") if user else None,
+                },
+            )
+            raise ValueError("Invalid or expired reset token")
+
         # Update the user's password and verify it matched exactly one user
         new_hash = hash_password(new_password)
         result = await self._users.update_one(
-            {"_id": ObjectId(token_doc["user_id"])},
+            {"_id": user["_id"]},
             {"$set": {"hashed_password": new_hash, "updated_at": now}},
         )
 

--- a/apps/api/src/services/ws_ticket.py
+++ b/apps/api/src/services/ws_ticket.py
@@ -1,0 +1,79 @@
+"""WebSocket ticket service — short-lived, one-time-use tickets.
+
+Clients exchange a JWT or API key for a ticket via REST, then connect
+to WebSocket with ?ticket=<ticket>. This avoids exposing long-lived
+credentials in the URL (which leaks into logs, browser history, etc.).
+"""
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from pymongo.asynchronous.collection import AsyncCollection
+
+logger = logging.getLogger(__name__)
+
+# Tickets expire after 30 seconds — just enough to complete the WS handshake.
+_TICKET_TTL_SECONDS = 30
+
+
+class WSTicketService:
+    """Issue and consume one-time WebSocket tickets."""
+
+    def __init__(self, collection: AsyncCollection) -> None:
+        self._tickets = collection
+
+    async def create_ticket(self, tenant_id: str) -> str:
+        """Create a short-lived ticket for the given tenant.
+
+        Args:
+            tenant_id: The authenticated tenant's ID.
+
+        Returns:
+            Raw ticket string (sent to client, never stored).
+        """
+        raw_ticket = secrets.token_urlsafe(32)
+        ticket_hash = hashlib.sha256(raw_ticket.encode()).hexdigest()
+        now = datetime.now(timezone.utc)
+
+        await self._tickets.insert_one(
+            {
+                "ticket_hash": ticket_hash,
+                "tenant_id": tenant_id,
+                "expires_at": now + timedelta(seconds=_TICKET_TTL_SECONDS),
+                "used": False,
+                "created_at": now,
+            }
+        )
+
+        return raw_ticket
+
+    async def consume_ticket(self, raw_ticket: str) -> Optional[str]:
+        """Validate and consume a one-time ticket.
+
+        Atomically marks the ticket as used so it cannot be reused.
+
+        Args:
+            raw_ticket: The raw ticket string from the client.
+
+        Returns:
+            tenant_id if valid, None if invalid/expired/already used.
+        """
+        ticket_hash = hashlib.sha256(raw_ticket.encode()).hexdigest()
+        now = datetime.now(timezone.utc)
+
+        doc = await self._tickets.find_one_and_update(
+            {
+                "ticket_hash": ticket_hash,
+                "used": False,
+                "expires_at": {"$gt": now},
+            },
+            {"$set": {"used": True}},
+        )
+
+        if not doc:
+            return None
+
+        return doc["tenant_id"]

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -15,12 +15,23 @@ from jose import jwt
 JWT_SECRET = "test-secret-for-unit-tests-minimum-32chars"
 
 MOCK_TENANT_ID = "test-tenant-001"
+MOCK_TENANT_B_ID = "test-tenant-002"
 
 
 def make_auth_header(tenant_id: str = MOCK_TENANT_ID) -> dict:
     """Create Authorization header with JWT containing tenant_id."""
     token = jwt.encode(
         {"sub": "test-user", "tenant_id": tenant_id, "role": "owner"},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def make_auth_header_b(tenant_id: str = MOCK_TENANT_B_ID) -> dict:
+    """Create Authorization header for Tenant B."""
+    token = jwt.encode(
+        {"sub": "test-user-b", "tenant_id": tenant_id, "role": "owner"},
         JWT_SECRET,
         algorithm="HS256",
     )

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -51,6 +51,7 @@ def mock_deps():
     deps.chunks_collection = MagicMock()
     deps.conversations_collection = MagicMock()
     deps.api_keys_collection = MagicMock()
+    deps.ws_tickets_collection = MagicMock()
     return deps
 
 

--- a/apps/api/tests/test_auth_service.py
+++ b/apps/api/tests/test_auth_service.py
@@ -403,3 +403,34 @@ async def test_reset_password_validates_tenant_id():
     service = AuthService(users_col, tenants_col, reset_tokens_col)
     with pytest.raises(ValueError, match="Invalid or expired reset token"):
         await service.reset_password("some-token", "new-password")
+
+
+@pytest.mark.unit
+async def test_reset_password_allows_legacy_token_without_tenant_id():
+    """reset_password succeeds for legacy tokens missing tenant_id field."""
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    token_user_id = str(ObjectId())
+
+    # Legacy token: no tenant_id field
+    reset_tokens_col.find_one_and_update = AsyncMock(
+        return_value={
+            "user_id": token_user_id,
+            "token_hash": "abc123",
+        }
+    )
+
+    users_col.find_one = AsyncMock(
+        return_value={
+            "_id": ObjectId(token_user_id),
+            "tenant_id": "tenant-abc",
+        }
+    )
+    users_col.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    # Should NOT raise — legacy tokens without tenant_id are allowed
+    await service.reset_password("some-token", "new-password")
+    users_col.update_one.assert_called_once()

--- a/apps/api/tests/test_auth_service.py
+++ b/apps/api/tests/test_auth_service.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from bson import ObjectId
 
+from src.services.auth import AuthService
+
 MOCK_USER_OID = str(ObjectId())
 
 
@@ -209,6 +211,7 @@ async def test_create_password_reset_token(mock_collections):
     mock_collections["users"].find_one.return_value = {
         "_id": "user-id-123",
         "email": "test@example.com",
+        "tenant_id": "tenant-abc",
     }
 
     service = AuthService(
@@ -230,6 +233,7 @@ async def test_create_password_reset_token(mock_collections):
     expected_hash = hashlib.sha256(raw_token.encode()).hexdigest()
     assert stored["token_hash"] == expected_hash
     assert stored["user_id"] == "user-id-123"
+    assert stored["tenant_id"] == "tenant-abc"
     assert stored["used"] is False
 
 
@@ -262,9 +266,15 @@ async def test_reset_password_success(mock_collections):
     mock_collections["reset_tokens"].find_one_and_update.return_value = {
         "_id": "token-id",
         "user_id": MOCK_USER_OID,
+        "tenant_id": "tenant-abc",
         "token_hash": token_hash,
         "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
         "used": False,
+    }
+    # User lookup for tenant validation
+    mock_collections["users"].find_one.return_value = {
+        "_id": ObjectId(MOCK_USER_OID),
+        "tenant_id": "tenant-abc",
     }
     # user update succeeds (matched_count=1)
     mock_collections["users"].update_one.return_value = MagicMock(matched_count=1)
@@ -322,12 +332,13 @@ async def test_reset_password_user_not_found(mock_collections):
     mock_collections["reset_tokens"].find_one_and_update.return_value = {
         "_id": "token-id",
         "user_id": MOCK_USER_OID,
+        "tenant_id": "tenant-abc",
         "token_hash": hashlib.sha256(raw_token.encode()).hexdigest(),
         "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
         "used": False,
     }
-    # User update matches zero documents
-    mock_collections["users"].update_one.return_value = MagicMock(matched_count=0)
+    # User lookup returns None — user was deleted after token was issued
+    mock_collections["users"].find_one.return_value = None
 
     service = AuthService(
         users_collection=mock_collections["users"],
@@ -335,5 +346,60 @@ async def test_reset_password_user_not_found(mock_collections):
         reset_tokens_collection=mock_collections["reset_tokens"],
     )
 
-    with pytest.raises(ValueError, match="User account not found"):
+    with pytest.raises(ValueError, match="Invalid or expired reset token"):
         await service.reset_password(token=raw_token, new_password="newpassword123")
+
+
+@pytest.mark.unit
+async def test_reset_token_includes_tenant_id():
+    """create_password_reset_token stores tenant_id from user doc."""
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    users_col.find_one = AsyncMock(
+        return_value={
+            "_id": ObjectId(),
+            "email": "alice@example.com",
+            "tenant_id": "tenant-abc",
+        }
+    )
+    reset_tokens_col.update_many = AsyncMock()
+    reset_tokens_col.insert_one = AsyncMock()
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    await service.create_password_reset_token("alice@example.com")
+
+    inserted_doc = reset_tokens_col.insert_one.call_args[0][0]
+    assert inserted_doc["tenant_id"] == "tenant-abc"
+
+
+@pytest.mark.unit
+async def test_reset_password_validates_tenant_id():
+    """reset_password verifies token tenant_id matches user tenant_id."""
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    token_user_id = str(ObjectId())
+
+    reset_tokens_col.find_one_and_update = AsyncMock(
+        return_value={
+            "user_id": token_user_id,
+            "tenant_id": "tenant-abc",
+            "token_hash": "abc123",
+        }
+    )
+
+    # User belongs to a DIFFERENT tenant
+    users_col.find_one = AsyncMock(
+        return_value={
+            "_id": ObjectId(token_user_id),
+            "tenant_id": "tenant-xyz",
+        }
+    )
+    users_col.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    with pytest.raises(ValueError, match="Invalid or expired reset token"):
+        await service.reset_password("some-token", "new-password")

--- a/apps/api/tests/test_chat_router.py
+++ b/apps/api/tests/test_chat_router.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from jose import jwt as jose_jwt
 
-from tests.conftest import make_auth_header
+from tests.conftest import JWT_SECRET, MOCK_TENANT_ID, make_auth_header
 
 
 @pytest.fixture
@@ -99,3 +100,52 @@ def test_chat_conversation_not_found(app_client):
         )
 
         assert response.status_code == 404
+
+
+# --- WebSocket authentication tests ---
+
+
+def _make_ws_token(tenant_id: str = MOCK_TENANT_ID) -> str:
+    """Create a JWT token for WebSocket auth."""
+    return jose_jwt.encode(
+        {"sub": "test-user", "tenant_id": tenant_id, "role": "owner"},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.mark.unit
+def test_websocket_rejects_missing_token(client):
+    """WebSocket without token query param is rejected."""
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/v1/chat/ws"):
+            pass
+
+
+@pytest.mark.unit
+def test_websocket_rejects_invalid_token(client):
+    """WebSocket with invalid token is rejected."""
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/v1/chat/ws?token=invalid-jwt"):
+            pass
+
+
+@pytest.mark.unit
+def test_websocket_rejects_no_tenant_in_token(client):
+    """WebSocket with JWT missing tenant_id claim is rejected."""
+    token = jose_jwt.encode({"sub": "test-user"}, JWT_SECRET, algorithm="HS256")
+    with pytest.raises(Exception):
+        with client.websocket_connect(f"/api/v1/chat/ws?token={token}"):
+            pass
+
+
+@pytest.mark.unit
+def test_websocket_accepts_valid_jwt(client, mock_deps):
+    """WebSocket with valid JWT token is accepted."""
+    token = _make_ws_token()
+    mock_deps.settings = MagicMock()
+
+    with client.websocket_connect(f"/api/v1/chat/ws?token={token}") as ws:
+        ws.send_json({"type": "cancel"})
+        response = ws.receive_json()
+        assert response["type"] == "cancelled"

--- a/apps/api/tests/test_chat_router.py
+++ b/apps/api/tests/test_chat_router.py
@@ -4,9 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from jose import jwt as jose_jwt
 
-from tests.conftest import JWT_SECRET, MOCK_TENANT_ID, make_auth_header
+from tests.conftest import MOCK_TENANT_ID, make_auth_header
 
 
 @pytest.fixture
@@ -102,21 +101,12 @@ def test_chat_conversation_not_found(app_client):
         assert response.status_code == 404
 
 
-# --- WebSocket authentication tests ---
-
-
-def _make_ws_token(tenant_id: str = MOCK_TENANT_ID) -> str:
-    """Create a JWT token for WebSocket auth."""
-    return jose_jwt.encode(
-        {"sub": "test-user", "tenant_id": tenant_id, "role": "owner"},
-        JWT_SECRET,
-        algorithm="HS256",
-    )
+# --- WebSocket ticket-based authentication tests ---
 
 
 @pytest.mark.unit
-def test_websocket_rejects_missing_token(client):
-    """WebSocket without token query param is rejected with code 4001."""
+def test_websocket_rejects_missing_ticket(client):
+    """WebSocket without ticket query param is rejected with code 4001."""
     from starlette.websockets import WebSocketDisconnect
 
     with pytest.raises(WebSocketDisconnect) as exc_info:
@@ -126,35 +116,33 @@ def test_websocket_rejects_missing_token(client):
 
 
 @pytest.mark.unit
-def test_websocket_rejects_invalid_token(client):
-    """WebSocket with invalid token is rejected with code 4001."""
+def test_websocket_rejects_invalid_ticket(client, mock_deps):
+    """WebSocket with invalid ticket is rejected with code 4001."""
     from starlette.websockets import WebSocketDisconnect
 
+    # Mock ws_tickets_collection for consume_ticket lookup
+    mock_ws_tickets = MagicMock()
+    mock_ws_tickets.find_one_and_update = AsyncMock(return_value=None)
+    mock_deps.ws_tickets_collection = mock_ws_tickets
+
     with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect("/api/v1/chat/ws?token=invalid-jwt"):
+        with client.websocket_connect("/api/v1/chat/ws?ticket=invalid-ticket"):
             pass
     assert exc_info.value.code == 4001
 
 
 @pytest.mark.unit
-def test_websocket_rejects_no_tenant_in_token(client):
-    """WebSocket with JWT missing tenant_id claim is rejected with code 4001."""
-    from starlette.websockets import WebSocketDisconnect
-
-    token = jose_jwt.encode({"sub": "test-user"}, JWT_SECRET, algorithm="HS256")
-    with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect(f"/api/v1/chat/ws?token={token}"):
-            pass
-    assert exc_info.value.code == 4001
-
-
-@pytest.mark.unit
-def test_websocket_accepts_valid_jwt(client, mock_deps):
-    """WebSocket with valid JWT token is accepted."""
-    token = _make_ws_token()
+def test_websocket_accepts_valid_ticket(client, mock_deps):
+    """WebSocket with valid ticket is accepted and resolves tenant."""
+    # Mock ws_tickets_collection to return a valid ticket doc
+    mock_ws_tickets = MagicMock()
+    mock_ws_tickets.find_one_and_update = AsyncMock(
+        return_value={"tenant_id": MOCK_TENANT_ID, "ticket_hash": "abc123"}
+    )
+    mock_deps.ws_tickets_collection = mock_ws_tickets
     mock_deps.settings = MagicMock()
 
-    with client.websocket_connect(f"/api/v1/chat/ws?token={token}") as ws:
+    with client.websocket_connect("/api/v1/chat/ws?ticket=valid-ticket") as ws:
         ws.send_json({"type": "cancel"})
         response = ws.receive_json()
         assert response["type"] == "cancelled"

--- a/apps/api/tests/test_chat_router.py
+++ b/apps/api/tests/test_chat_router.py
@@ -116,27 +116,36 @@ def _make_ws_token(tenant_id: str = MOCK_TENANT_ID) -> str:
 
 @pytest.mark.unit
 def test_websocket_rejects_missing_token(client):
-    """WebSocket without token query param is rejected."""
-    with pytest.raises(Exception):
+    """WebSocket without token query param is rejected with code 4001."""
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/api/v1/chat/ws"):
             pass
+    assert exc_info.value.code == 4001
 
 
 @pytest.mark.unit
 def test_websocket_rejects_invalid_token(client):
-    """WebSocket with invalid token is rejected."""
-    with pytest.raises(Exception):
+    """WebSocket with invalid token is rejected with code 4001."""
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/api/v1/chat/ws?token=invalid-jwt"):
             pass
+    assert exc_info.value.code == 4001
 
 
 @pytest.mark.unit
 def test_websocket_rejects_no_tenant_in_token(client):
-    """WebSocket with JWT missing tenant_id claim is rejected."""
+    """WebSocket with JWT missing tenant_id claim is rejected with code 4001."""
+    from starlette.websockets import WebSocketDisconnect
+
     token = jose_jwt.encode({"sub": "test-user"}, JWT_SECRET, algorithm="HS256")
-    with pytest.raises(Exception):
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect(f"/api/v1/chat/ws?token={token}"):
             pass
+    assert exc_info.value.code == 4001
 
 
 @pytest.mark.unit

--- a/apps/api/tests/test_database_indexes.py
+++ b/apps/api/tests/test_database_indexes.py
@@ -19,6 +19,7 @@ async def test_ensure_indexes_creates_expected_indexes():
         "conversations",
         "api_keys",
         "password_reset_tokens",
+        "ws_tickets",
     ]:
         mock_col = MagicMock()
         mock_col.create_index = AsyncMock()
@@ -33,6 +34,7 @@ async def test_ensure_indexes_creates_expected_indexes():
     mock_settings.mongodb_collection_conversations = "conversations"
     mock_settings.mongodb_collection_api_keys = "api_keys"
     mock_settings.mongodb_collection_reset_tokens = "password_reset_tokens"
+    mock_settings.mongodb_collection_ws_tickets = "ws_tickets"
 
     await ensure_indexes(mock_db, mock_settings)
 
@@ -65,4 +67,14 @@ async def test_ensure_indexes_creates_expected_indexes():
     # reset_tokens: TTL on expires_at (24 hours)
     collections["password_reset_tokens"].create_index.assert_any_call(
         "expires_at", expireAfterSeconds=86400, background=True
+    )
+
+    # ws_tickets: unique ticket_hash
+    collections["ws_tickets"].create_index.assert_any_call(
+        "ticket_hash", unique=True, background=True
+    )
+
+    # ws_tickets: TTL on expires_at (60 seconds)
+    collections["ws_tickets"].create_index.assert_any_call(
+        "expires_at", expireAfterSeconds=60, background=True
     )

--- a/apps/api/tests/test_database_indexes.py
+++ b/apps/api/tests/test_database_indexes.py
@@ -26,7 +26,15 @@ async def test_ensure_indexes_creates_expected_indexes():
 
     mock_db.__getitem__ = MagicMock(side_effect=lambda name: collections[name])
 
-    await ensure_indexes(mock_db)
+    mock_settings = MagicMock()
+    mock_settings.mongodb_collection_users = "users"
+    mock_settings.mongodb_collection_documents = "documents"
+    mock_settings.mongodb_collection_chunks = "chunks"
+    mock_settings.mongodb_collection_conversations = "conversations"
+    mock_settings.mongodb_collection_api_keys = "api_keys"
+    mock_settings.mongodb_collection_reset_tokens = "password_reset_tokens"
+
+    await ensure_indexes(mock_db, mock_settings)
 
     # users: unique email index
     collections["users"].create_index.assert_any_call("email", unique=True, background=True)
@@ -49,8 +57,10 @@ async def test_ensure_indexes_creates_expected_indexes():
     # api_keys: tenant_id
     collections["api_keys"].create_index.assert_any_call("tenant_id", background=True)
 
-    # reset_tokens: token_hash
-    collections["password_reset_tokens"].create_index.assert_any_call("token_hash", background=True)
+    # reset_tokens: unique token_hash
+    collections["password_reset_tokens"].create_index.assert_any_call(
+        "token_hash", unique=True, background=True
+    )
 
     # reset_tokens: TTL on expires_at (24 hours)
     collections["password_reset_tokens"].create_index.assert_any_call(

--- a/apps/api/tests/test_database_indexes.py
+++ b/apps/api/tests/test_database_indexes.py
@@ -1,0 +1,58 @@
+"""Tests for database index creation."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+async def test_ensure_indexes_creates_expected_indexes():
+    """ensure_indexes creates all required indexes on startup."""
+    from src.core.database import ensure_indexes
+
+    mock_db = MagicMock()
+    collections = {}
+    for name in [
+        "users",
+        "documents",
+        "chunks",
+        "conversations",
+        "api_keys",
+        "password_reset_tokens",
+    ]:
+        mock_col = MagicMock()
+        mock_col.create_index = AsyncMock()
+        collections[name] = mock_col
+
+    mock_db.__getitem__ = MagicMock(side_effect=lambda name: collections[name])
+
+    await ensure_indexes(mock_db)
+
+    # users: unique email index
+    collections["users"].create_index.assert_any_call("email", unique=True, background=True)
+
+    # documents: tenant + created_at compound
+    collections["documents"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # chunks: tenant + document_id compound
+    collections["chunks"].create_index.assert_any_call(
+        [("tenant_id", 1), ("document_id", 1)], background=True
+    )
+
+    # conversations: tenant + created_at compound
+    collections["conversations"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # api_keys: tenant_id
+    collections["api_keys"].create_index.assert_any_call("tenant_id", background=True)
+
+    # reset_tokens: token_hash
+    collections["password_reset_tokens"].create_index.assert_any_call("token_hash", background=True)
+
+    # reset_tokens: TTL on expires_at (24 hours)
+    collections["password_reset_tokens"].create_index.assert_any_call(
+        "expires_at", expireAfterSeconds=86400, background=True
+    )

--- a/apps/api/tests/test_tenant_guard.py
+++ b/apps/api/tests/test_tenant_guard.py
@@ -1,0 +1,87 @@
+"""Tests for TenantGuardMiddleware."""
+
+import logging
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from src.core.middleware import TenantGuardMiddleware
+
+
+def _create_app(*, debug: bool = False) -> FastAPI:
+    """Create a minimal FastAPI app with the tenant guard middleware."""
+    app = FastAPI(debug=debug)
+    app.add_middleware(TenantGuardMiddleware)
+
+    @app.get("/api/v1/protected")
+    async def protected(request: Request):
+        # Simulate a handler that FORGETS to set tenant context
+        return {"ok": True}
+
+    @app.get("/api/v1/safe")
+    async def safe(request: Request):
+        request.state.tenant_id = "tenant-abc"
+        return {"ok": True}
+
+    @app.get("/api/v1/auth/login")
+    async def login():
+        return {"ok": True}
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.unit
+def test_guard_warns_on_missing_tenant_context(caplog):
+    """Middleware logs warning when protected route lacks tenant context."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/v1/protected")
+
+    assert response.status_code == 200  # Never blocks in prod
+    assert any("tenant_id not set" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_guard_silent_when_tenant_set(caplog):
+    """Middleware stays silent when tenant context is set."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/v1/safe")
+
+    assert response.status_code == 200
+    assert not any("tenant_id not set" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_guard_skips_auth_routes(caplog):
+    """Middleware does not check auth routes."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/v1/auth/login")
+
+    assert response.status_code == 200
+    assert not any("tenant_id not set" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_guard_skips_health(caplog):
+    """Middleware does not check health endpoint."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert not any("tenant_id not set" in r.message for r in caplog.records)

--- a/apps/api/tests/test_tenant_isolation.py
+++ b/apps/api/tests/test_tenant_isolation.py
@@ -1,0 +1,282 @@
+"""Cross-tenant isolation negative tests.
+
+Verifies Tenant A cannot access Tenant B's data across all endpoints.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bson import ObjectId
+
+from tests.conftest import (
+    MOCK_TENANT_B_ID,
+    MOCK_TENANT_ID,
+    make_auth_header,
+    make_auth_header_b,
+)
+
+
+# -- Chat Isolation -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_chat_tenant_a_cannot_see_tenant_b_conversations(client, mock_deps):
+    """Chat endpoint only queries with the authenticated tenant's ID."""
+    captured_tenant_ids: list[str] = []
+
+    class MockChatService:
+        def __init__(self, deps):
+            pass
+
+        async def handle_message(
+            self, *, message, tenant_id, conversation_id=None, search_type=None
+        ):
+            captured_tenant_ids.append(tenant_id)
+            return {
+                "answer": "test",
+                "sources": [],
+                "conversation_id": "conv-1",
+            }
+
+    with patch("src.routers.chat.ChatService", MockChatService):
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "hello"},
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 200
+    assert captured_tenant_ids == [MOCK_TENANT_ID]
+    assert MOCK_TENANT_B_ID not in captured_tenant_ids
+
+
+# -- Document Isolation -------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_document_status_scoped_to_tenant(client, mock_deps):
+    """Document status endpoint filters by authenticated tenant."""
+    doc_id = str(ObjectId())
+
+    with patch("src.routers.ingest.IngestionService") as MockService:
+        instance = MockService.return_value
+        instance.get_document_status = AsyncMock(return_value=None)
+
+        response = client.get(
+            f"/api/v1/documents/{doc_id}/status",
+            headers=make_auth_header(),
+        )
+
+    # Service should be called with tenant A's ID
+    call_args = instance.get_document_status.call_args
+    if call_args:
+        # Check positional or keyword args for tenant_id
+        all_args = list(call_args.args) + list(call_args.kwargs.values())
+        assert MOCK_TENANT_ID in all_args
+
+
+# -- API Key Isolation --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_keys_scoped_to_tenant(client, mock_deps):
+    """List keys only returns keys for authenticated tenant."""
+    with patch("src.routers.keys.APIKeyService") as MockService:
+        instance = MockService.return_value
+        instance.list_keys = AsyncMock(return_value=[])
+
+        response = client.get(
+            "/api/v1/keys",
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 200
+    instance.list_keys.assert_called_once_with(MOCK_TENANT_ID)
+
+
+@pytest.mark.unit
+def test_revoke_key_scoped_to_tenant(client, mock_deps):
+    """Revoke key only works for the authenticated tenant's keys."""
+    key_id = str(ObjectId())
+
+    with patch("src.routers.keys.APIKeyService") as MockService:
+        instance = MockService.return_value
+        instance.revoke_key = AsyncMock(return_value=True)
+
+        response = client.delete(
+            f"/api/v1/keys/{key_id}",
+            headers=make_auth_header(),
+        )
+
+    instance.revoke_key.assert_called_once_with(key_id=key_id, tenant_id=MOCK_TENANT_ID)
+
+
+# -- Search Isolation ---------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_semantic_search_filters_by_tenant():
+    """Semantic search pipeline includes tenant_id in $vectorSearch filter."""
+    from src.services.search import semantic_search
+
+    captured_pipelines: list = []
+    mock_collection = MagicMock()
+
+    async def capture_aggregate(pipeline):
+        captured_pipelines.append(pipeline)
+
+        class EmptyCursor:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        return EmptyCursor()
+
+    mock_collection.aggregate = capture_aggregate
+
+    deps = MagicMock()
+    deps.settings = MagicMock()
+    deps.settings.default_match_count = 10
+    deps.settings.max_match_count = 50
+    deps.settings.mongodb_vector_index = "vector_index"
+    deps.settings.mongodb_collection_documents = "documents"
+    deps.settings.mongodb_collection_chunks = "chunks"
+    deps.get_embedding = AsyncMock(return_value=[0.1] * 1536)
+    deps.db = MagicMock()
+    deps.db.__getitem__ = MagicMock(return_value=mock_collection)
+
+    await semantic_search(deps, "test query", tenant_id=MOCK_TENANT_ID)
+
+    pipeline = captured_pipelines[0]
+    vector_filter = pipeline[0]["$vectorSearch"]["filter"]
+    assert vector_filter == {"tenant_id": MOCK_TENANT_ID}
+    assert MOCK_TENANT_B_ID not in str(pipeline)
+
+
+@pytest.mark.unit
+async def test_text_search_filters_by_tenant():
+    """Text search pipeline includes tenant_id in $search compound filter."""
+    from src.services.search import text_search
+
+    captured_pipelines: list = []
+    mock_collection = MagicMock()
+
+    async def capture_aggregate(pipeline):
+        captured_pipelines.append(pipeline)
+
+        class EmptyCursor:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        return EmptyCursor()
+
+    mock_collection.aggregate = capture_aggregate
+
+    deps = MagicMock()
+    deps.settings = MagicMock()
+    deps.settings.default_match_count = 10
+    deps.settings.max_match_count = 50
+    deps.settings.mongodb_text_index = "text_index"
+    deps.settings.mongodb_collection_documents = "documents"
+    deps.settings.mongodb_collection_chunks = "chunks"
+    deps.db = MagicMock()
+    deps.db.__getitem__ = MagicMock(return_value=mock_collection)
+
+    await text_search(deps, "test query", tenant_id=MOCK_TENANT_ID)
+
+    pipeline = captured_pipelines[0]
+    search_stage = pipeline[0]["$search"]
+    filter_clause = search_stage["compound"]["filter"]
+    tenant_values = [
+        f["equals"]["value"]
+        for f in filter_clause
+        if "equals" in f and f["equals"].get("path") == "tenant_id"
+    ]
+    assert tenant_values == [MOCK_TENANT_ID]
+
+
+# -- Signup Email Uniqueness --------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_signup_rejects_duplicate_email():
+    """Second signup with same email returns error."""
+    from pymongo.errors import DuplicateKeyError
+
+    from src.services.auth import AuthService
+
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    tenants_col.insert_one = AsyncMock()
+    tenants_col.delete_one = AsyncMock()
+    users_col.insert_one = AsyncMock(side_effect=DuplicateKeyError("duplicate email"))
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+
+    with pytest.raises(ValueError, match="Email is already registered"):
+        await service.signup("alice@example.com", "password123", "Org A")
+
+    tenants_col.delete_one.assert_called_once()
+
+
+# -- Reset Token Tenant Scoping -----------------------------------------------
+
+
+@pytest.mark.unit
+async def test_reset_token_stores_tenant_id():
+    """Password reset token includes tenant_id from user document."""
+    from src.services.auth import AuthService
+
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    users_col.find_one = AsyncMock(
+        return_value={
+            "_id": ObjectId(),
+            "email": "alice@example.com",
+            "tenant_id": MOCK_TENANT_ID,
+        }
+    )
+    reset_tokens_col.update_many = AsyncMock()
+    reset_tokens_col.insert_one = AsyncMock()
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    await service.create_password_reset_token("alice@example.com")
+
+    inserted_doc = reset_tokens_col.insert_one.call_args[0][0]
+    assert inserted_doc["tenant_id"] == MOCK_TENANT_ID
+
+
+# -- WebSocket Isolation ------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_websocket_rejects_without_token(client):
+    """WebSocket without token is rejected."""
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/api/v1/chat/ws"):
+            pass
+    assert exc_info.value.code == 4001
+
+
+@pytest.mark.unit
+def test_websocket_rejects_forged_tenant_id(client):
+    """WebSocket cannot use raw tenant_id param (old vulnerable API)."""
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            f"/api/v1/chat/ws?tenant_id={MOCK_TENANT_B_ID}"
+        ):
+            pass
+    assert exc_info.value.code == 4001

--- a/apps/api/tests/test_tenant_isolation.py
+++ b/apps/api/tests/test_tenant_isolation.py
@@ -8,13 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from bson import ObjectId
 
-from tests.conftest import (
-    MOCK_TENANT_B_ID,
-    MOCK_TENANT_ID,
-    make_auth_header,
-    make_auth_header_b,
-)
-
+from tests.conftest import MOCK_TENANT_B_ID, MOCK_TENANT_ID, make_auth_header
 
 # -- Chat Isolation -----------------------------------------------------------
 
@@ -58,11 +52,11 @@ def test_document_status_scoped_to_tenant(client, mock_deps):
     """Document status endpoint filters by authenticated tenant."""
     doc_id = str(ObjectId())
 
-    with patch("src.routers.ingest.IngestionService") as MockService:
-        instance = MockService.return_value
+    with patch("src.routers.ingest.IngestionService") as mock_service:
+        instance = mock_service.return_value
         instance.get_document_status = AsyncMock(return_value=None)
 
-        response = client.get(
+        client.get(
             f"/api/v1/documents/{doc_id}/status",
             headers=make_auth_header(),
         )
@@ -81,8 +75,8 @@ def test_document_status_scoped_to_tenant(client, mock_deps):
 @pytest.mark.unit
 def test_list_keys_scoped_to_tenant(client, mock_deps):
     """List keys only returns keys for authenticated tenant."""
-    with patch("src.routers.keys.APIKeyService") as MockService:
-        instance = MockService.return_value
+    with patch("src.routers.keys.APIKeyService") as mock_service:
+        instance = mock_service.return_value
         instance.list_keys = AsyncMock(return_value=[])
 
         response = client.get(
@@ -99,11 +93,11 @@ def test_revoke_key_scoped_to_tenant(client, mock_deps):
     """Revoke key only works for the authenticated tenant's keys."""
     key_id = str(ObjectId())
 
-    with patch("src.routers.keys.APIKeyService") as MockService:
-        instance = MockService.return_value
+    with patch("src.routers.keys.APIKeyService") as mock_service:
+        instance = mock_service.return_value
         instance.revoke_key = AsyncMock(return_value=True)
 
-        response = client.delete(
+        client.delete(
             f"/api/v1/keys/{key_id}",
             headers=make_auth_header(),
         )
@@ -275,8 +269,6 @@ def test_websocket_rejects_forged_tenant_id(client):
     from starlette.websockets import WebSocketDisconnect
 
     with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect(
-            f"/api/v1/chat/ws?tenant_id={MOCK_TENANT_B_ID}"
-        ):
+        with client.websocket_connect(f"/api/v1/chat/ws?tenant_id={MOCK_TENANT_B_ID}"):
             pass
     assert exc_info.value.code == 4001

--- a/apps/api/tests/test_tenant_isolation.py
+++ b/apps/api/tests/test_tenant_isolation.py
@@ -253,8 +253,8 @@ async def test_reset_token_stores_tenant_id():
 
 
 @pytest.mark.unit
-def test_websocket_rejects_without_token(client):
-    """WebSocket without token is rejected."""
+def test_websocket_rejects_without_ticket(client):
+    """WebSocket without ticket is rejected."""
     from starlette.websockets import WebSocketDisconnect
 
     with pytest.raises(WebSocketDisconnect) as exc_info:

--- a/apps/api/tests/test_ws_ticket.py
+++ b/apps/api/tests/test_ws_ticket.py
@@ -1,0 +1,84 @@
+"""Tests for WebSocket ticket service and endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import MOCK_TENANT_ID, make_auth_header
+
+
+@pytest.mark.unit
+async def test_create_ticket_stores_tenant_id():
+    """create_ticket stores tenant_id in the ticket document."""
+    from src.services.ws_ticket import WSTicketService
+
+    mock_collection = MagicMock()
+    mock_collection.insert_one = AsyncMock()
+
+    service = WSTicketService(mock_collection)
+    ticket = await service.create_ticket(MOCK_TENANT_ID)
+
+    assert ticket  # Non-empty string
+    inserted = mock_collection.insert_one.call_args[0][0]
+    assert inserted["tenant_id"] == MOCK_TENANT_ID
+    assert inserted["used"] is False
+    assert "ticket_hash" in inserted
+    assert "expires_at" in inserted
+
+
+@pytest.mark.unit
+async def test_consume_ticket_returns_tenant_id():
+    """consume_ticket returns tenant_id for valid ticket."""
+    from src.services.ws_ticket import WSTicketService
+
+    mock_collection = MagicMock()
+    mock_collection.find_one_and_update = AsyncMock(
+        return_value={"tenant_id": MOCK_TENANT_ID, "ticket_hash": "abc"}
+    )
+
+    service = WSTicketService(mock_collection)
+    result = await service.consume_ticket("some-ticket")
+
+    assert result == MOCK_TENANT_ID
+    # Verify it atomically marks as used
+    call_args = mock_collection.find_one_and_update.call_args
+    assert call_args[0][1] == {"$set": {"used": True}}
+
+
+@pytest.mark.unit
+async def test_consume_ticket_returns_none_for_invalid():
+    """consume_ticket returns None for invalid/expired/used ticket."""
+    from src.services.ws_ticket import WSTicketService
+
+    mock_collection = MagicMock()
+    mock_collection.find_one_and_update = AsyncMock(return_value=None)
+
+    service = WSTicketService(mock_collection)
+    result = await service.consume_ticket("invalid-ticket")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_ws_ticket_endpoint_requires_auth(client):
+    """POST /api/v1/auth/ws-ticket requires authentication."""
+    response = client.post("/api/v1/auth/ws-ticket")
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+def test_ws_ticket_endpoint_returns_ticket(client, mock_deps):
+    """POST /api/v1/auth/ws-ticket returns a ticket for authenticated user."""
+    mock_ws_tickets = MagicMock()
+    mock_ws_tickets.insert_one = AsyncMock()
+    mock_deps.ws_tickets_collection = mock_ws_tickets
+
+    response = client.post(
+        "/api/v1/auth/ws-ticket",
+        headers=make_auth_header(),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "ticket" in data
+    assert len(data["ticket"]) > 0

--- a/docs/superpowers/plans/2026-04-04-tenant-isolation.md
+++ b/docs/superpowers/plans/2026-04-04-tenant-isolation.md
@@ -1,0 +1,1283 @@
+# Tenant Isolation Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all tenant isolation gaps and add a safety net middleware so no future endpoint can accidentally leak cross-tenant data.
+
+**Architecture:** Surgical fixes to 4 identified gaps (WebSocket auth, email uniqueness, reset token scoping, tenant guard middleware) plus comprehensive negative tests. Keeps the existing explicit `get_tenant_id()` dependency injection pattern — no repository abstraction.
+
+**Tech Stack:** FastAPI, Motor (async MongoDB), pytest + pytest-asyncio, python-jose (JWT)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/core/database.py` | Create | Index management — `ensure_indexes()` called on startup |
+| `src/core/middleware.py` | Create | `TenantGuardMiddleware` — safety net for missing tenant context |
+| `src/core/tenant.py` | Modify | Set `request.state.tenant_id` in auth deps; extract helpers for WS reuse |
+| `src/main.py` | Modify | Register middleware, call `ensure_indexes()` on startup |
+| `src/models/user.py` | Modify | Add `tenant_id` to `PasswordResetTokenModel` |
+| `src/services/auth.py` | Modify | Scope reset tokens with `tenant_id` |
+| `src/routers/chat.py` | Modify | Rewrite WebSocket auth (JWT/API key from `token` query param) |
+| `tests/test_tenant_isolation.py` | Create | Cross-tenant negative tests |
+| `tests/test_tenant_guard.py` | Create | Middleware unit tests |
+| `tests/conftest.py` | Modify | Add `TENANT_B` fixtures |
+
+---
+
+### Task 1: Database Index Management
+
+**Files:**
+- Create: `apps/api/src/core/database.py`
+- Modify: `apps/api/src/main.py:19-36`
+- Test: `apps/api/tests/test_database_indexes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/tests/test_database_indexes.py`:
+
+```python
+"""Tests for database index creation."""
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+
+@pytest.mark.unit
+async def test_ensure_indexes_creates_expected_indexes():
+    """ensure_indexes creates all required indexes on startup."""
+    from src.core.database import ensure_indexes
+
+    mock_db = MagicMock()
+    collections = {}
+    for name in [
+        "users", "documents", "chunks", "conversations",
+        "api_keys", "password_reset_tokens",
+    ]:
+        mock_col = MagicMock()
+        mock_col.create_index = AsyncMock()
+        collections[name] = mock_col
+
+    mock_db.__getitem__ = MagicMock(side_effect=lambda name: collections[name])
+
+    await ensure_indexes(mock_db)
+
+    # users: unique email index
+    collections["users"].create_index.assert_any_call(
+        "email", unique=True, background=True
+    )
+
+    # documents: tenant + created_at compound
+    collections["documents"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # chunks: tenant + document_id compound
+    collections["chunks"].create_index.assert_any_call(
+        [("tenant_id", 1), ("document_id", 1)], background=True
+    )
+
+    # conversations: tenant + created_at compound
+    collections["conversations"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # api_keys: tenant_id
+    collections["api_keys"].create_index.assert_any_call(
+        "tenant_id", background=True
+    )
+
+    # reset_tokens: token_hash
+    collections["password_reset_tokens"].create_index.assert_any_call(
+        "token_hash", background=True
+    )
+
+    # reset_tokens: TTL on expires_at (24 hours)
+    collections["password_reset_tokens"].create_index.assert_any_call(
+        "expires_at", expireAfterSeconds=86400, background=True
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && uv run pytest tests/test_database_indexes.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.core.database'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/core/database.py`:
+
+```python
+"""Database index management."""
+
+import logging
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_indexes(db: AsyncDatabase) -> None:
+    """Create required indexes on all collections.
+
+    Safe to call on every startup — create_index is idempotent.
+
+    Args:
+        db: The async MongoDB database instance.
+    """
+    logger.info("ensuring_database_indexes")
+
+    # Users: unique email for global email uniqueness
+    await db["users"].create_index("email", unique=True, background=True)
+
+    # Documents: tenant-scoped listing
+    await db["documents"].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # Chunks: tenant-scoped lookups by document
+    await db["chunks"].create_index(
+        [("tenant_id", 1), ("document_id", 1)], background=True
+    )
+
+    # Conversations: tenant-scoped listing
+    await db["conversations"].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # API keys: tenant-scoped listing
+    await db["api_keys"].create_index("tenant_id", background=True)
+
+    # Reset tokens: hash lookup
+    await db["password_reset_tokens"].create_index("token_hash", background=True)
+
+    # Reset tokens: auto-cleanup after 24 hours
+    await db["password_reset_tokens"].create_index(
+        "expires_at", expireAfterSeconds=86400, background=True
+    )
+
+    logger.info("database_indexes_ensured")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && uv run pytest tests/test_database_indexes.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Wire into app startup**
+
+Modify `apps/api/src/main.py`. Add import and call `ensure_indexes` inside the lifespan after `deps.initialize()`:
+
+```python
+# Add import at top:
+from src.core.database import ensure_indexes
+
+# Inside lifespan, after deps.initialize() succeeds (after line 29):
+        await ensure_indexes(deps.db)
+```
+
+- [ ] **Step 6: Commit**
+
+```
+feat: add database index management with tenant isolation indexes
+
+Closes step 1 of #9. Creates ensure_indexes() called on startup.
+Adds unique email index, tenant compound indexes, and reset token TTL.
+```
+
+---
+
+### Task 2: Add `tenant_id` to Password Reset Token Model
+
+**Files:**
+- Modify: `apps/api/src/models/user.py:48-55`
+- Modify: `apps/api/src/services/auth.py:170-176` (token creation)
+- Modify: `apps/api/src/services/auth.py:199-206` (token validation)
+- Test: `apps/api/tests/test_auth_service.py` (existing — add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/tests/test_auth_service.py`:
+
+```python
+@pytest.mark.unit
+async def test_reset_token_includes_tenant_id():
+    """create_password_reset_token stores tenant_id from user doc."""
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    users_col.find_one = AsyncMock(return_value={
+        "_id": ObjectId(),
+        "email": "alice@example.com",
+        "tenant_id": "tenant-abc",
+    })
+    reset_tokens_col.update_many = AsyncMock()
+    reset_tokens_col.insert_one = AsyncMock()
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    await service.create_password_reset_token("alice@example.com")
+
+    inserted_doc = reset_tokens_col.insert_one.call_args[0][0]
+    assert inserted_doc["tenant_id"] == "tenant-abc"
+
+
+@pytest.mark.unit
+async def test_reset_password_validates_tenant_id():
+    """reset_password verifies token tenant_id matches user tenant_id."""
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    reset_tokens_col.find_one_and_update = AsyncMock(return_value={
+        "user_id": str(ObjectId()),
+        "tenant_id": "tenant-abc",
+        "token_hash": "abc123",
+    })
+
+    # User belongs to a DIFFERENT tenant
+    users_col.find_one = AsyncMock(return_value={
+        "_id": ObjectId(reset_tokens_col.find_one_and_update.return_value["user_id"]),
+        "tenant_id": "tenant-xyz",
+    })
+    users_col.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    with pytest.raises(ValueError, match="Invalid or expired reset token"):
+        await service.reset_password("some-token", "new-password")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && uv run pytest tests/test_auth_service.py::test_reset_token_includes_tenant_id tests/test_auth_service.py::test_reset_password_validates_tenant_id -v`
+Expected: FAIL — `tenant_id` not in inserted doc / no tenant validation in reset
+
+- [ ] **Step 3: Update the model**
+
+Modify `apps/api/src/models/user.py`. Add `tenant_id` field to `PasswordResetTokenModel`:
+
+```python
+class PasswordResetTokenModel(BaseModel):
+    """A password reset token (stored as SHA256 hash)."""
+
+    user_id: str = Field(..., description="User this token belongs to")
+    tenant_id: str = Field(..., description="Tenant this token belongs to")
+    token_hash: str = Field(..., description="SHA256 hash of the reset token")
+    expires_at: datetime = Field(..., description="Token expiry time")
+    used: bool = Field(default=False, description="Whether the token has been consumed")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+```
+
+- [ ] **Step 4: Update `create_password_reset_token` in auth service**
+
+Modify `apps/api/src/services/auth.py`, the `create_password_reset_token` method. Add `tenant_id` to the token document:
+
+```python
+    async def create_password_reset_token(self, email: str) -> Optional[str]:
+        """Generate a password reset token for the given email.
+
+        Returns None if the email is not found (prevents email enumeration).
+
+        Args:
+            email: User email.
+
+        Returns:
+            Raw token string, or None if email not found.
+        """
+        user = await self._users.find_one({"email": email.lower()})
+        if not user:
+            return None
+
+        user_id = str(user["_id"])
+        tenant_id = user["tenant_id"]
+
+        # Invalidate any existing tokens for this user
+        await self._reset_tokens.update_many(
+            {"user_id": user_id, "used": False},
+            {"$set": {"used": True}},
+        )
+
+        # Generate new token
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        now = datetime.now(timezone.utc)
+
+        token_doc = {
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "token_hash": token_hash,
+            "expires_at": now + timedelta(hours=1),
+            "used": False,
+            "created_at": now,
+        }
+        await self._reset_tokens.insert_one(token_doc)
+
+        logger.info("password_reset_token_created", extra={"user_id": user_id})
+        return raw_token
+```
+
+- [ ] **Step 5: Update `reset_password` with tenant validation**
+
+Modify `apps/api/src/services/auth.py`, the `reset_password` method. After claiming the token, verify tenant_id matches the user:
+
+```python
+    async def reset_password(self, token: str, new_password: str) -> None:
+        """Reset a user's password using a reset token.
+
+        Uses atomic find_one_and_update to claim the token, preventing
+        concurrent use of the same token. Validates tenant_id matches
+        the user for defense in depth.
+
+        Args:
+            token: Raw reset token from the email link.
+            new_password: New plaintext password.
+
+        Raises:
+            ValueError: If token is invalid, expired, or already used.
+        """
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        now = datetime.now(timezone.utc)
+
+        # Atomically claim the token: find unused + unexpired, mark used in one op
+        token_doc = await self._reset_tokens.find_one_and_update(
+            {
+                "token_hash": token_hash,
+                "used": False,
+                "expires_at": {"$gt": now},
+            },
+            {"$set": {"used": True}},
+        )
+
+        if not token_doc:
+            raise ValueError("Invalid or expired reset token")
+
+        # Defense in depth: verify token tenant matches user tenant
+        user = await self._users.find_one({"_id": ObjectId(token_doc["user_id"])})
+        if not user or user.get("tenant_id") != token_doc.get("tenant_id"):
+            logger.error(
+                "password_reset_tenant_mismatch",
+                extra={
+                    "user_id": token_doc["user_id"],
+                    "token_tenant": token_doc.get("tenant_id"),
+                    "user_tenant": user.get("tenant_id") if user else None,
+                },
+            )
+            raise ValueError("Invalid or expired reset token")
+
+        # Update the user's password
+        new_hash = hash_password(new_password)
+        result = await self._users.update_one(
+            {"_id": ObjectId(token_doc["user_id"])},
+            {"$set": {"hashed_password": new_hash, "updated_at": now}},
+        )
+
+        if result.matched_count == 0:
+            logger.error(
+                "password_reset_user_not_found",
+                extra={"user_id": token_doc["user_id"]},
+            )
+            raise ValueError("User account not found")
+
+        logger.info("password_reset_completed", extra={"user_id": token_doc["user_id"]})
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && uv run pytest tests/test_auth_service.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```
+feat: scope password reset tokens to tenant_id
+
+Adds tenant_id field to PasswordResetTokenModel and validates it during
+password reset for defense in depth.
+```
+
+---
+
+### Task 3: WebSocket Authentication
+
+**Files:**
+- Modify: `apps/api/src/routers/chat.py:76-139`
+- Modify: `apps/api/src/core/tenant.py` (expose resolution helpers)
+- Test: `apps/api/tests/test_chat_router.py` (add WS auth tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/tests/test_chat_router.py`:
+
+```python
+from conftest import JWT_SECRET, MOCK_TENANT_ID
+from jose import jwt
+
+
+def _make_ws_token(tenant_id: str = MOCK_TENANT_ID) -> str:
+    """Create a JWT token for WebSocket auth."""
+    return jwt.encode(
+        {"sub": "test-user", "tenant_id": tenant_id, "role": "owner"},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+def test_websocket_rejects_missing_token(client):
+    """WebSocket without token query param is rejected."""
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/v1/chat/ws"):
+            pass
+
+
+def test_websocket_rejects_invalid_token(client):
+    """WebSocket with invalid token is rejected."""
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/v1/chat/ws?token=invalid-jwt"):
+            pass
+
+
+def test_websocket_rejects_no_tenant_in_token(client):
+    """WebSocket with JWT missing tenant_id claim is rejected."""
+    token = jwt.encode({"sub": "test-user"}, JWT_SECRET, algorithm="HS256")
+    with pytest.raises(Exception):
+        with client.websocket_connect(f"/api/v1/chat/ws?token={token}"):
+            pass
+
+
+def test_websocket_accepts_valid_jwt(client, mock_deps):
+    """WebSocket with valid JWT token is accepted."""
+    token = _make_ws_token()
+    # Mock the chat service to avoid real DB calls
+    mock_deps.settings = MagicMock()
+
+    with client.websocket_connect(f"/api/v1/chat/ws?token={token}") as ws:
+        # Connection accepted — send a cancel to cleanly close
+        ws.send_json({"type": "cancel"})
+        response = ws.receive_json()
+        assert response["type"] == "cancelled"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && uv run pytest tests/test_chat_router.py::test_websocket_rejects_missing_token tests/test_chat_router.py::test_websocket_accepts_valid_jwt -v`
+Expected: FAIL — current WS accepts any `tenant_id` param, doesn't use `token`
+
+- [ ] **Step 3: Expose auth resolution functions for WebSocket use**
+
+Modify `apps/api/src/core/tenant.py`. Make `_resolve_api_key` and `_resolve_jwt` importable by renaming to public functions (keeping underscore-prefixed aliases for backward compat is unnecessary — no external consumers):
+
+Add a new async function for WebSocket auth that doesn't depend on FastAPI's `Depends`:
+
+```python
+async def resolve_token(raw_token: str, deps: AgentDependencies) -> str:
+    """Resolve a raw token (JWT or API key) to a tenant_id.
+
+    Used by WebSocket handlers where FastAPI Depends is not available.
+
+    Args:
+        raw_token: JWT or API key string (without 'Bearer ' prefix).
+        deps: Application dependencies for DB access.
+
+    Returns:
+        Validated tenant_id string.
+
+    Raises:
+        HTTPException: 401 if token is invalid.
+    """
+    if raw_token.startswith(_API_KEY_PREFIX):
+        return await _resolve_api_key(raw_token, deps)
+    return _resolve_jwt(raw_token)
+```
+
+- [ ] **Step 4: Rewrite WebSocket handler**
+
+Modify `apps/api/src/routers/chat.py`. Replace the WebSocket handler (lines 76-139):
+
+```python
+@router.websocket("/chat/ws")
+async def chat_websocket(
+    websocket: WebSocket,
+    token: Optional[str] = None,
+):
+    """WebSocket endpoint for real-time chat.
+
+    Authenticate via query parameter: /api/v1/chat/ws?token=<jwt_or_api_key>
+    """
+    if not token or not token.strip():
+        await websocket.close(code=4001, reason="token query parameter required")
+        return
+
+    # Resolve tenant from token before accepting connection
+    deps: AgentDependencies = websocket.app.state.deps
+    try:
+        tenant_id = await resolve_token(token.strip(), deps)
+    except HTTPException:
+        await websocket.close(code=4001, reason="Invalid or expired token")
+        return
+
+    await websocket.accept()
+    service = ChatService(deps)
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+
+            try:
+                data = json.loads(raw)
+                msg = WSMessage(**data)
+            except json.JSONDecodeError:
+                await websocket.send_json({"type": "error", "message": "Invalid JSON"})
+                continue
+            except (ValueError, TypeError) as e:
+                logger.warning("WebSocket invalid message: %s", str(e))
+                await websocket.send_json({"type": "error", "message": "Invalid message format"})
+                continue
+
+            if msg.type == "cancel":
+                await websocket.send_json({"type": "cancelled"})
+                continue
+
+            if msg.type == "message" and msg.content:
+                try:
+                    async for event in service.handle_message_stream(
+                        message=msg.content,
+                        tenant_id=tenant_id,
+                        conversation_id=msg.conversation_id,
+                    ):
+                        await websocket.send_json(event)
+                except Exception as e:
+                    logger.exception("WebSocket chat error: %s", str(e))
+                    await websocket.send_json(
+                        {"type": "error", "message": "An internal error occurred"}
+                    )
+            else:
+                await websocket.send_json(
+                    {"type": "error", "message": "Expected type 'message' with content"}
+                )
+
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected: tenant=%s", tenant_id)
+    except Exception as e:
+        logger.exception("WebSocket error: %s", str(e))
+        try:
+            await websocket.close(code=1011, reason="Internal error")
+        except Exception:
+            pass
+```
+
+Update the imports at the top of `chat.py`:
+
+```python
+from src.core.tenant import get_tenant_id, resolve_token
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && uv run pytest tests/test_chat_router.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```
+fix(security): authenticate WebSocket with JWT/API key token
+
+Replaces raw tenant_id query param with token-based auth.
+Client sends JWT or API key as ?token= param, server validates
+before accepting the connection.
+
+Closes the critical WebSocket isolation bypass in #9.
+```
+
+---
+
+### Task 4: Tenant Guard Middleware
+
+**Files:**
+- Create: `apps/api/src/core/middleware.py`
+- Modify: `apps/api/src/core/tenant.py:20-51` (set `request.state.tenant_id`)
+- Modify: `apps/api/src/main.py` (register middleware)
+- Test: `apps/api/tests/test_tenant_guard.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/tests/test_tenant_guard.py`:
+
+```python
+"""Tests for TenantGuardMiddleware."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from src.core.middleware import TenantGuardMiddleware
+
+
+def _create_app(*, debug: bool = False) -> FastAPI:
+    """Create a minimal FastAPI app with the tenant guard middleware."""
+    app = FastAPI(debug=debug)
+    app.add_middleware(TenantGuardMiddleware)
+
+    @app.get("/api/v1/protected")
+    async def protected(request: Request):
+        # Simulate a handler that FORGETS to set tenant context
+        return {"ok": True}
+
+    @app.get("/api/v1/safe")
+    async def safe(request: Request):
+        request.state.tenant_id = "tenant-abc"
+        return {"ok": True}
+
+    @app.get("/api/v1/auth/login")
+    async def login():
+        return {"ok": True}
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.unit
+def test_guard_warns_on_missing_tenant_context(caplog):
+    """Middleware logs warning when protected route lacks tenant context."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/v1/protected")
+
+    assert response.status_code == 200  # Never blocks in prod
+    assert any("tenant_id not set" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_guard_silent_when_tenant_set():
+    """Middleware stays silent when tenant context is set."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with pytest.raises(AssertionError):
+        # Should NOT find any warning
+        response = client.get("/api/v1/safe")
+        assert response.status_code == 200
+
+
+@pytest.mark.unit
+def test_guard_skips_auth_routes(caplog):
+    """Middleware does not check auth routes."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/v1/auth/login")
+
+    assert response.status_code == 200
+    assert not any("tenant_id not set" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_guard_skips_health(caplog):
+    """Middleware does not check health endpoint."""
+    app = _create_app(debug=False)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert not any("tenant_id not set" in r.message for r in caplog.records)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && uv run pytest tests/test_tenant_guard.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.core.middleware'`
+
+- [ ] **Step 3: Write the middleware**
+
+Create `apps/api/src/core/middleware.py`:
+
+```python
+"""Tenant guard middleware — safety net for missing tenant context."""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Routes exempt from tenant guard checks
+_EXEMPT_PREFIXES = (
+    "/api/v1/auth",
+    "/health",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+)
+
+
+class TenantGuardMiddleware(BaseHTTPMiddleware):
+    """Log a warning if a protected route completes without tenant context.
+
+    This is a safety net, not primary enforcement. Primary enforcement
+    is the get_tenant_id() dependency injected into route handlers.
+
+    In production: logs a warning (never blocks).
+    In debug mode: logs a warning (never blocks — avoidance of false
+    positives on routes that legitimately don't need tenant context).
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        # Initialize tenant_id state so hasattr checks work
+        request.state.tenant_id = None
+
+        response = await call_next(request)
+
+        path = request.url.path
+
+        # Skip exempt routes
+        if any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES):
+            return response
+
+        # Only check /api/v1/ routes
+        if not path.startswith("/api/v1/"):
+            return response
+
+        # Check if tenant context was set
+        tenant_id = getattr(request.state, "tenant_id", None)
+        if not tenant_id:
+            logger.warning(
+                "tenant_id not set for protected route",
+                extra={"path": path, "method": request.method},
+            )
+
+        return response
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && uv run pytest tests/test_tenant_guard.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Update `get_tenant_id` to set `request.state.tenant_id`**
+
+Modify `apps/api/src/core/tenant.py`. Update `get_tenant_id` to accept `Request` and set state:
+
+```python
+async def get_tenant_id(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+    deps: AgentDependencies = Depends(get_deps),
+) -> str:
+    """Extract tenant_id from JWT or API key in the Authorization header.
+
+    Also sets request.state.tenant_id for the TenantGuardMiddleware.
+
+    Detects auth method by the 'mrag_' prefix:
+    - 'mrag_...' → API key path (hash and look up in api_keys collection)
+    - Otherwise → JWT path (decode with nextauth_secret)
+
+    Args:
+        request: FastAPI request (used to set tenant state).
+        authorization: Authorization header value.
+        deps: Application dependencies for DB access.
+
+    Returns:
+        Validated tenant_id string.
+
+    Raises:
+        HTTPException: 401 if token is missing, invalid, or lacks tenant_id.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header with Bearer token is required",
+        )
+
+    token = authorization[7:]  # Strip "Bearer "
+
+    if token.startswith(_API_KEY_PREFIX):
+        tenant_id = await _resolve_api_key(token, deps)
+    else:
+        tenant_id = _resolve_jwt(token)
+
+    request.state.tenant_id = tenant_id
+    return tenant_id
+```
+
+Update `get_tenant_id_from_jwt` similarly:
+
+```python
+async def get_tenant_id_from_jwt(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+) -> str:
+    """Extract tenant_id from JWT only. Rejects API keys.
+
+    Also sets request.state.tenant_id for the TenantGuardMiddleware.
+
+    Args:
+        request: FastAPI request (used to set tenant state).
+        authorization: Authorization header value.
+
+    Returns:
+        Validated tenant_id string.
+
+    Raises:
+        HTTPException: 401 if token is missing, invalid, or an API key.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header with Bearer token is required",
+        )
+
+    token = authorization[7:]  # Strip "Bearer "
+
+    if token.startswith(_API_KEY_PREFIX):
+        raise HTTPException(
+            status_code=403,
+            detail="API keys cannot access this endpoint",
+        )
+
+    tenant_id = _resolve_jwt(token)
+    request.state.tenant_id = tenant_id
+    return tenant_id
+```
+
+Add `Request` to the imports:
+
+```python
+from fastapi import Depends, Header, HTTPException, Request
+```
+
+- [ ] **Step 6: Register middleware in main.py**
+
+Modify `apps/api/src/main.py`. Add import and register middleware after CORS:
+
+```python
+# Add import at top:
+from src.core.middleware import TenantGuardMiddleware
+
+# After the CORS middleware block (after line 53), add:
+app.add_middleware(TenantGuardMiddleware)
+```
+
+- [ ] **Step 7: Run all tests to verify nothing broke**
+
+Run: `cd apps/api && uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```
+feat: add tenant guard middleware as safety net
+
+Logs warnings when protected /api/v1/ routes complete without
+tenant_id in request.state. Auth dependencies now set
+request.state.tenant_id automatically.
+
+Never blocks requests — observability only.
+```
+
+---
+
+### Task 5: Cross-Tenant Negative Tests
+
+**Files:**
+- Modify: `apps/api/tests/conftest.py`
+- Create: `apps/api/tests/test_tenant_isolation.py`
+
+- [ ] **Step 1: Add Tenant B fixtures to conftest**
+
+Modify `apps/api/tests/conftest.py`. Add second tenant constant and helper:
+
+```python
+MOCK_TENANT_B_ID = "test-tenant-002"
+
+
+def make_auth_header_b(tenant_id: str = MOCK_TENANT_B_ID) -> dict:
+    """Create Authorization header for Tenant B."""
+    token = jwt.encode(
+        {"sub": "test-user-b", "tenant_id": tenant_id, "role": "owner"},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+```
+
+- [ ] **Step 2: Write cross-tenant isolation tests**
+
+Create `apps/api/tests/test_tenant_isolation.py`:
+
+```python
+"""Cross-tenant isolation negative tests.
+
+Verifies Tenant A cannot access Tenant B's data across all endpoints.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bson import ObjectId
+from jose import jwt
+
+from conftest import (
+    JWT_SECRET,
+    MOCK_TENANT_ID,
+    MOCK_TENANT_B_ID,
+    make_auth_header,
+    make_auth_header_b,
+)
+
+
+# ── Chat Isolation ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_chat_tenant_a_cannot_see_tenant_b_conversations(client, mock_deps):
+    """Chat endpoint only queries with the authenticated tenant's ID."""
+    captured_tenant_ids = []
+    original_service = None
+
+    class MockChatService:
+        def __init__(self, deps):
+            pass
+
+        async def handle_message(self, *, message, tenant_id, conversation_id=None, search_type=None):
+            captured_tenant_ids.append(tenant_id)
+            return {
+                "answer": "test",
+                "sources": [],
+                "conversation_id": "conv-1",
+            }
+
+    with patch("src.routers.chat.ChatService", MockChatService):
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "hello"},
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 200
+    assert captured_tenant_ids == [MOCK_TENANT_ID]
+    assert MOCK_TENANT_B_ID not in captured_tenant_ids
+
+
+# ── Document Isolation ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_document_status_scoped_to_tenant(client, mock_deps):
+    """Document status endpoint filters by authenticated tenant."""
+    doc_id = str(ObjectId())
+    mock_deps.documents_collection.find_one = AsyncMock(return_value=None)
+
+    with patch("src.routers.ingest.IngestionService") as MockService:
+        instance = MockService.return_value
+        instance.get_document_status = AsyncMock(return_value=None)
+
+        response = client.get(
+            f"/api/v1/documents/{doc_id}/status",
+            headers=make_auth_header(),
+        )
+
+    # Service should be called with tenant A's ID, not tenant B's
+    call_args = instance.get_document_status.call_args
+    if call_args:
+        assert call_args.kwargs.get("tenant_id", call_args.args[1] if len(call_args.args) > 1 else None) == MOCK_TENANT_ID
+
+
+# ── API Key Isolation ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_list_keys_scoped_to_tenant(client, mock_deps):
+    """List keys only returns keys for authenticated tenant."""
+    tenant_a_key = {
+        "_id": ObjectId(),
+        "tenant_id": MOCK_TENANT_ID,
+        "key_prefix": "mrag_abc",
+        "name": "Key A",
+        "permissions": ["chat"],
+        "is_revoked": False,
+        "last_used_at": None,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+    with patch("src.routers.keys.APIKeyService") as MockService:
+        instance = MockService.return_value
+        instance.list_keys = AsyncMock(return_value=[tenant_a_key])
+
+        response = client.get(
+            "/api/v1/keys",
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 200
+    # Service must have been called with tenant A's ID
+    instance.list_keys.assert_called_once_with(MOCK_TENANT_ID)
+
+
+@pytest.mark.unit
+def test_revoke_key_scoped_to_tenant(client, mock_deps):
+    """Revoke key only works for the authenticated tenant's keys."""
+    key_id = str(ObjectId())
+
+    with patch("src.routers.keys.APIKeyService") as MockService:
+        instance = MockService.return_value
+        instance.revoke_key = AsyncMock(return_value=True)
+
+        response = client.delete(
+            f"/api/v1/keys/{key_id}",
+            headers=make_auth_header(),
+        )
+
+    # Service must have been called with tenant A's ID
+    instance.revoke_key.assert_called_once_with(key_id, MOCK_TENANT_ID)
+
+
+# ── Search Isolation ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_semantic_search_filters_by_tenant():
+    """Semantic search pipeline includes tenant_id in $vectorSearch filter."""
+    from src.services.search import semantic_search
+
+    captured_pipelines = []
+    mock_collection = MagicMock()
+
+    async def capture_aggregate(pipeline):
+        captured_pipelines.append(pipeline)
+
+        class EmptyCursor:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        return EmptyCursor()
+
+    mock_collection.aggregate = capture_aggregate
+
+    deps = MagicMock()
+    deps.settings = MagicMock()
+    deps.settings.default_match_count = 10
+    deps.settings.max_match_count = 50
+    deps.settings.mongodb_vector_index = "vector_index"
+    deps.settings.mongodb_collection_documents = "documents"
+    deps.settings.mongodb_collection_chunks = "chunks"
+    deps.get_embedding = AsyncMock(return_value=[0.1] * 1536)
+    deps.db = MagicMock()
+    deps.db.__getitem__ = MagicMock(return_value=mock_collection)
+
+    # Search as Tenant A
+    await semantic_search(deps, "test query", tenant_id=MOCK_TENANT_ID)
+
+    pipeline = captured_pipelines[0]
+    vector_filter = pipeline[0]["$vectorSearch"]["filter"]
+    assert vector_filter == {"tenant_id": MOCK_TENANT_ID}
+    # Tenant B's ID must NOT appear
+    assert MOCK_TENANT_B_ID not in str(pipeline)
+
+
+@pytest.mark.unit
+async def test_text_search_filters_by_tenant():
+    """Text search pipeline includes tenant_id in $search compound filter."""
+    from src.services.search import text_search
+
+    captured_pipelines = []
+    mock_collection = MagicMock()
+
+    async def capture_aggregate(pipeline):
+        captured_pipelines.append(pipeline)
+
+        class EmptyCursor:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        return EmptyCursor()
+
+    mock_collection.aggregate = capture_aggregate
+
+    deps = MagicMock()
+    deps.settings = MagicMock()
+    deps.settings.default_match_count = 10
+    deps.settings.max_match_count = 50
+    deps.settings.mongodb_text_index = "text_index"
+    deps.settings.mongodb_collection_documents = "documents"
+    deps.settings.mongodb_collection_chunks = "chunks"
+    deps.db = MagicMock()
+    deps.db.__getitem__ = MagicMock(return_value=mock_collection)
+
+    await text_search(deps, "test query", tenant_id=MOCK_TENANT_ID)
+
+    pipeline = captured_pipelines[0]
+    search_stage = pipeline[0]["$search"]
+    filter_clause = search_stage["compound"]["filter"]
+    tenant_values = [
+        f["equals"]["value"]
+        for f in filter_clause
+        if "equals" in f and f["equals"].get("path") == "tenant_id"
+    ]
+    assert tenant_values == [MOCK_TENANT_ID]
+
+
+# ── Signup Email Uniqueness ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_signup_rejects_duplicate_email():
+    """Second signup with same email returns error."""
+    from pymongo.errors import DuplicateKeyError
+
+    from src.services.auth import AuthService
+
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    tenants_col.insert_one = AsyncMock()
+    tenants_col.delete_one = AsyncMock()
+    users_col.insert_one = AsyncMock(side_effect=DuplicateKeyError("duplicate email"))
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+
+    with pytest.raises(ValueError, match="Email is already registered"):
+        await service.signup("alice@example.com", "password123", "Org A")
+
+    # Orphaned tenant should be cleaned up
+    tenants_col.delete_one.assert_called_once()
+
+
+# ── Reset Token Tenant Scoping ──────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_reset_token_stores_tenant_id():
+    """Password reset token includes tenant_id from user document."""
+    from src.services.auth import AuthService
+
+    users_col = MagicMock()
+    tenants_col = MagicMock()
+    reset_tokens_col = MagicMock()
+
+    users_col.find_one = AsyncMock(return_value={
+        "_id": ObjectId(),
+        "email": "alice@example.com",
+        "tenant_id": MOCK_TENANT_ID,
+    })
+    reset_tokens_col.update_many = AsyncMock()
+    reset_tokens_col.insert_one = AsyncMock()
+
+    service = AuthService(users_col, tenants_col, reset_tokens_col)
+    await service.create_password_reset_token("alice@example.com")
+
+    inserted_doc = reset_tokens_col.insert_one.call_args[0][0]
+    assert inserted_doc["tenant_id"] == MOCK_TENANT_ID
+
+
+# ── WebSocket Isolation ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_websocket_rejects_without_token(client):
+    """WebSocket without token is rejected."""
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/v1/chat/ws"):
+            pass
+
+
+@pytest.mark.unit
+def test_websocket_rejects_forged_tenant_id(client):
+    """WebSocket cannot use raw tenant_id param (old vulnerable API)."""
+    # Old API used ?tenant_id=... — this should no longer work
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            f"/api/v1/chat/ws?tenant_id={MOCK_TENANT_B_ID}"
+        ):
+            pass
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd apps/api && uv run pytest tests/test_tenant_isolation.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd apps/api && uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```
+test: add cross-tenant isolation negative tests
+
+Verifies Tenant A cannot access Tenant B's data across chat,
+documents, API keys, search, WebSocket, signup, and reset tokens.
+
+Part of #9.
+```
+
+---
+
+### Task 6: Final Verification and Lint
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run linter**
+
+Run: `cd apps/api && uv run ruff check .`
+Expected: No errors
+
+- [ ] **Step 2: Run formatter check**
+
+Run: `cd apps/api && uv run ruff format --check .`
+Expected: No formatting issues (or fix them)
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd apps/api && uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: Fix any issues found, then commit fixes**
+
+If any issues: fix and commit with:
+```
+fix: resolve lint and formatting issues in tenant isolation
+```
+
+- [ ] **Step 5: Final commit if no issues**
+
+No action needed — all tasks already committed individually.
+
+---
+
+## Summary of Changes
+
+| Task | What | Key Files |
+|------|------|-----------|
+| 1 | Database indexes (unique email, tenant compounds, TTL) | `src/core/database.py`, `src/main.py` |
+| 2 | Password reset token tenant scoping | `src/models/user.py`, `src/services/auth.py` |
+| 3 | WebSocket JWT/API key authentication | `src/routers/chat.py`, `src/core/tenant.py` |
+| 4 | Tenant guard middleware | `src/core/middleware.py`, `src/core/tenant.py`, `src/main.py` |
+| 5 | Cross-tenant negative tests | `tests/test_tenant_isolation.py`, `tests/conftest.py` |
+| 6 | Lint and final verification | All files |

--- a/docs/superpowers/plans/2026-04-04-tenant-isolation.md
+++ b/docs/superpowers/plans/2026-04-04-tenant-isolation.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** FastAPI, Motor (async MongoDB), pytest + pytest-asyncio, python-jose (JWT)
 
+> **Post-implementation note (2026-04-04):** Task 3 (WebSocket auth) was revised during implementation after Codex adversarial review. The plan below describes `?token=<jwt>` but the actual implementation uses a one-time ticket system (`POST /api/v1/auth/ws-ticket` → `?ticket=`). See the design spec for the current approach. Additional fixes were also made: index failure is now fatal, reset tokens have backward compatibility for legacy docs, and the guard middleware only warns on successful responses.
+
 ---
 
 ## File Map

--- a/docs/superpowers/specs/2026-04-04-tenant-isolation-design.md
+++ b/docs/superpowers/specs/2026-04-04-tenant-isolation-design.md
@@ -30,7 +30,7 @@ The MongoRAG API already has good tenant isolation in most areas — chat, inges
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Email uniqueness | Global (one account per email) | Simplifies auth, natural for SaaS where signup creates one tenant per user |
-| WebSocket auth | JWT/API key in query param | Standard pattern — browsers can't send headers on WebSocket upgrade |
+| WebSocket auth | One-time ticket via REST, then `?ticket=` | Avoids leaking long-lived credentials in URLs (logs, browser history) |
 | Tenant enforcement | Explicit DI + guard middleware | Keep working explicit pattern, add safety net for future endpoints |
 | DB operations wrapper | Not needed | Codebase is small, explicit passing is clearer than magic abstraction |
 
@@ -59,21 +59,25 @@ Login queries `users` collection by email only (`find_one({"email": email})`). I
 `/chat/ws` accepts `tenant_id` as a raw query parameter. Anyone can connect and impersonate any tenant — complete isolation bypass.
 
 ### Solution
-- Client connects with `ws://host/api/v1/chat/ws?token=<jwt_or_api_key>`
+- Client first calls `POST /api/v1/auth/ws-ticket` with a Bearer token (JWT or API key) to obtain a short-lived, single-use ticket
+- Client connects with `ws://host/api/v1/chat/ws?ticket=<one_time_ticket>`
 - On connection, before `websocket.accept()`:
-  1. Extract `token` from query params
-  2. If token starts with `mrag_` → resolve via `_resolve_api_key()`
-  3. Otherwise → validate JWT via `_resolve_jwt()`
-  4. Extract `tenant_id` from result
-  5. If invalid/missing → `websocket.close(code=4001, reason="...")`
+  1. Extract `ticket` from query params
+  2. Validate and atomically consume the ticket via `WSTicketService.consume_ticket()`
+  3. Extract `tenant_id` from the consumed ticket document
+  4. If invalid/missing/expired → `websocket.close(code=4001, reason="...")`
 - Remove the `tenant_id` query parameter entirely
+- Tickets expire after 30 seconds and are single-use — long-lived credentials (JWTs, API keys) never appear in the URL
 
 ### Breaking Change
-Frontend/widget clients must send JWT or API key instead of raw `tenant_id`. This is necessary — the current behavior is a vulnerability.
+Frontend/widget clients must first obtain a ticket via REST, then connect with `?ticket=`. This avoids leaking long-lived credentials into URLs (logs, browser history, analytics).
 
 ### Files Modified
-- `src/routers/chat.py` — rewrite WebSocket handler auth logic
-- `src/core/tenant.py` — extract auth resolution functions for reuse (may already be importable)
+- `src/routers/chat.py` — rewrite WebSocket handler to use ticket-based auth
+- `src/routers/auth.py` — add `POST /api/v1/auth/ws-ticket` endpoint
+- `src/services/ws_ticket.py` — new ticket service (create/consume)
+- `src/core/settings.py` — add `ws_tickets` collection config
+- `src/core/dependencies.py` — add `ws_tickets_collection` accessor
 
 ---
 
@@ -186,8 +190,13 @@ Integration tests using `httpx.AsyncClient` with FastAPI's `TestClient`. Test Mo
 | `src/main.py` | Register `TenantGuardMiddleware` |
 | `src/models/user.py` | Add `tenant_id` to `PasswordResetTokenModel` |
 | `src/services/auth.py` | Handle `DuplicateKeyError` in signup, scope reset tokens |
-| `src/routers/chat.py` | Rewrite WebSocket auth (JWT/API key from query param) |
-| `tests/test_tenant_isolation.py` | New — 11 negative isolation test cases |
+| `src/routers/chat.py` | Rewrite WebSocket auth (ticket-based) |
+| `src/routers/auth.py` | Add `POST /api/v1/auth/ws-ticket` endpoint |
+| `src/services/ws_ticket.py` | New — ticket create/consume service |
+| `src/core/settings.py` | Add `ws_tickets` collection config |
+| `src/core/dependencies.py` | Add `ws_tickets_collection` accessor |
+| `tests/test_tenant_isolation.py` | New — 10 negative isolation test cases |
+| `tests/test_ws_ticket.py` | New — ticket service and endpoint tests |
 
 ## Out of Scope
 - Repository pattern / `TenantScopedCollection` abstraction — not needed at current scale

--- a/docs/superpowers/specs/2026-04-04-tenant-isolation-design.md
+++ b/docs/superpowers/specs/2026-04-04-tenant-isolation-design.md
@@ -1,0 +1,195 @@
+# Tenant Isolation Hardening — Design Spec
+
+**Issue:** #9 — Enforce tenant isolation across all API endpoints
+**Date:** 2026-04-04
+**Approach:** Surgical fixes + Tenant Guard Middleware (Approach B)
+
+## Context
+
+The MongoRAG API already has good tenant isolation in most areas — chat, ingest, keys, and all search endpoints properly filter by `tenant_id` via dependency injection. However, an audit revealed 4 critical gaps and several medium-priority improvements needed.
+
+### Current State
+
+**Already isolated:**
+- POST `/api/v1/chat` — `get_tenant_id()` dependency, passed to search/conversation services
+- POST `/api/v1/documents/ingest` — `get_tenant_id()` dependency, all queries filtered
+- GET `/api/v1/documents/{id}/status` — `get_tenant_id()` dependency
+- POST/GET/DELETE `/api/v1/keys` — `get_tenant_id_from_jwt()` dependency (JWT-only)
+- Semantic search — `$vectorSearch` filter includes `tenant_id`
+- Text search — `$search` compound filter includes `tenant_id`
+- Hybrid search — delegates to semantic + text, both filtered
+
+**Gaps identified:**
+1. WebSocket `/chat/ws` — accepts `tenant_id` as query param with zero auth
+2. Login — queries users by email only, no tenant disambiguation
+3. Forgot/reset password — email-only lookup, tokens not tenant-scoped
+4. No safety net for future endpoints that forget tenant context
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Email uniqueness | Global (one account per email) | Simplifies auth, natural for SaaS where signup creates one tenant per user |
+| WebSocket auth | JWT/API key in query param | Standard pattern — browsers can't send headers on WebSocket upgrade |
+| Tenant enforcement | Explicit DI + guard middleware | Keep working explicit pattern, add safety net for future endpoints |
+| DB operations wrapper | Not needed | Codebase is small, explicit passing is clearer than magic abstraction |
+
+---
+
+## Section 1: Global Email Uniqueness
+
+### Problem
+Login queries `users` collection by email only (`find_one({"email": email})`). If the same email exists in two tenants, MongoDB returns whichever it finds first — potential cross-tenant auth bypass.
+
+### Solution
+- Add a **unique index** on `users.email` at the database level
+- **Signup:** Catch `DuplicateKeyError` → return clear "email already registered" error (HTTP 409)
+- **Login:** `find_one({"email": email})` becomes safe — only one user per email exists, and the `tenant_id` on that document is authoritative
+- **Forgot/reset password:** Same — email lookup returns the correct (only) user
+
+### Files Modified
+- `src/core/database.py` — add unique index creation on startup
+- `src/services/auth.py` — handle `DuplicateKeyError` in signup
+
+---
+
+## Section 2: WebSocket Authentication
+
+### Problem
+`/chat/ws` accepts `tenant_id` as a raw query parameter. Anyone can connect and impersonate any tenant — complete isolation bypass.
+
+### Solution
+- Client connects with `ws://host/api/v1/chat/ws?token=<jwt_or_api_key>`
+- On connection, before `websocket.accept()`:
+  1. Extract `token` from query params
+  2. If token starts with `mrag_` → resolve via `_resolve_api_key()`
+  3. Otherwise → validate JWT via `_resolve_jwt()`
+  4. Extract `tenant_id` from result
+  5. If invalid/missing → `websocket.close(code=4001, reason="...")`
+- Remove the `tenant_id` query parameter entirely
+
+### Breaking Change
+Frontend/widget clients must send JWT or API key instead of raw `tenant_id`. This is necessary — the current behavior is a vulnerability.
+
+### Files Modified
+- `src/routers/chat.py` — rewrite WebSocket handler auth logic
+- `src/core/tenant.py` — extract auth resolution functions for reuse (may already be importable)
+
+---
+
+## Section 3: Password Reset Tenant Scoping
+
+### Problem
+`PasswordResetTokenModel` has no `tenant_id` field. Even with global email uniqueness making the email lookup safe, tokens should be scoped to tenants for defense in depth.
+
+### Solution
+- Add `tenant_id: str` field to `PasswordResetTokenModel`
+- **Forgot password flow:** After finding user by email, store `tenant_id` from user doc into the reset token document
+- **Reset password flow:** When validating token, verify `tenant_id` matches the user being updated
+- Add index on `reset_tokens.token_hash` for lookup performance
+
+### Files Modified
+- `src/models/user.py` — add `tenant_id` to `PasswordResetTokenModel`
+- `src/services/auth.py` — include `tenant_id` when creating/validating reset tokens
+
+---
+
+## Section 4: Tenant Guard Middleware
+
+### Purpose
+Safety net that catches future endpoints missing tenant context. Not primary enforcement — that remains the explicit `get_tenant_id()` dependency.
+
+### How It Works
+1. `get_tenant_id()` and `get_tenant_id_from_jwt()` accept `Request` parameter and set `request.state.tenant_id` after successful auth
+2. `TenantGuardMiddleware` runs on every response:
+   - Checks if route is under `/api/v1/` and NOT in exempt list
+   - Verifies `request.state.tenant_id` was set
+   - **Dev mode** (`DEBUG=true`): raises error
+   - **Prod mode**: logs warning with route path — never blocks user requests
+
+### Exempt Routes
+- `/api/v1/auth/*` — pre-authentication endpoints
+- `/health` — public health check
+
+### Files Modified
+- `src/core/tenant.py` — modify auth dependencies to set `request.state.tenant_id`
+- `src/core/middleware.py` — new file, `TenantGuardMiddleware` class (~30 lines)
+- `src/main.py` — register middleware
+
+---
+
+## Section 5: Negative Tests
+
+### Purpose
+Verify that Tenant A cannot access Tenant B's data. The most important deliverable for this issue.
+
+### Test File
+`tests/test_tenant_isolation.py`
+
+### Fixtures
+- Create Tenant A with user, documents, chunks, conversation, API key
+- Create Tenant B with user, documents, chunks, conversation, API key
+- Generate JWT tokens for both tenants
+
+### Test Cases
+
+| # | Test | Verifies |
+|---|------|----------|
+| 1 | Chat with Tenant A's token returns only Tenant A's search results | Chat isolation |
+| 2 | Document status with Tenant A's token returns 404 for Tenant B's document | Document isolation |
+| 3 | List keys with Tenant A's JWT shows only Tenant A's keys | API key isolation |
+| 4 | Revoke key with Tenant A's JWT fails for Tenant B's key ID | API key cross-tenant |
+| 5 | WebSocket with Tenant A's token only searches Tenant A's chunks | WebSocket isolation |
+| 6 | Semantic search returns only authenticated tenant's chunks | Search isolation |
+| 7 | Text search returns only authenticated tenant's chunks | Search isolation |
+| 8 | Hybrid search returns only authenticated tenant's chunks | Search isolation |
+| 9 | Signup with existing email returns 409 | Email uniqueness |
+| 10 | Reset token contains `tenant_id` matching the user | Reset token scoping |
+| 11 | Unprotected `/api/v1/` endpoint triggers tenant guard warning | Guard middleware |
+
+### Approach
+Integration tests using `httpx.AsyncClient` with FastAPI's `TestClient`. Test MongoDB database with isolated collections.
+
+---
+
+## Section 6: Database Indexes
+
+### New Indexes
+
+| Collection | Index | Type | Purpose |
+|---|---|---|---|
+| `users` | `{"email": 1}` | Unique | Global email uniqueness enforcement |
+| `documents` | `{"tenant_id": 1, "created_at": -1}` | Compound | Tenant-scoped document listing |
+| `chunks` | `{"tenant_id": 1, "document_id": 1}` | Compound | Tenant-scoped chunk lookups |
+| `conversations` | `{"tenant_id": 1, "created_at": -1}` | Compound | Tenant-scoped conversation queries |
+| `api_keys` | `{"tenant_id": 1}` | Regular | Tenant-scoped key listing |
+| `reset_tokens` | `{"token_hash": 1}` | Regular | Token lookup performance |
+| `reset_tokens` | `{"expires_at": 1}` | TTL (24h) | Auto-cleanup of expired tokens after 24 hours |
+
+### Implementation
+- Startup function in `src/core/database.py` using `create_index(background=True)`
+- `create_index()` is idempotent — safe to run on every app startup
+- Vector search and Atlas Search indexes remain managed via Atlas UI
+
+### Files Modified
+- `src/core/database.py` — add `ensure_indexes()` function, call from startup
+
+---
+
+## Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `src/core/database.py` | Add `ensure_indexes()` with all indexes, call on startup |
+| `src/core/tenant.py` | Set `request.state.tenant_id` in auth dependencies |
+| `src/core/middleware.py` | New — `TenantGuardMiddleware` |
+| `src/main.py` | Register `TenantGuardMiddleware` |
+| `src/models/user.py` | Add `tenant_id` to `PasswordResetTokenModel` |
+| `src/services/auth.py` | Handle `DuplicateKeyError` in signup, scope reset tokens |
+| `src/routers/chat.py` | Rewrite WebSocket auth (JWT/API key from query param) |
+| `tests/test_tenant_isolation.py` | New — 11 negative isolation test cases |
+
+## Out of Scope
+- Repository pattern / `TenantScopedCollection` abstraction — not needed at current scale
+- Row-level security at database level — MongoDB doesn't support this natively
+- Per-tenant database separation — overkill for current architecture


### PR DESCRIPTION
## Summary

- **WebSocket auth hardened** — Replaced raw `tenant_id` query param with one-time ticket system (`POST /api/v1/auth/ws-ticket` → `?ticket=`). Tickets expire in 30s and are single-use, so long-lived credentials never appear in URLs.
- **Password reset tokens scoped to tenants** — Added `tenant_id` field to `PasswordResetTokenModel` with defense-in-depth validation during reset. Backward compatible with legacy tokens.
- **Tenant guard middleware** — Safety net that logs warnings when protected `/api/v1/` routes complete without `tenant_id` in request state. Never blocks requests.
- **Database indexes** — Unique email index (global email uniqueness), tenant compound indexes, TTL indexes for reset tokens and WS tickets. Index creation is fatal on failure since isolation guarantees depend on them.
- **10 cross-tenant negative tests** — Verifies Tenant A cannot access Tenant B's data across chat, documents, API keys, search, WebSocket, signup, and reset tokens.

### Files changed (19 files, +1024/-20)

| Area | Files | What |
|------|-------|------|
| Core | `database.py`, `middleware.py`, `tenant.py`, `settings.py`, `dependencies.py` | Index management, guard middleware, auth state |
| Models | `user.py`, `api.py` | `tenant_id` on reset tokens, WS ticket response |
| Services | `auth.py`, `ws_ticket.py` | Reset token scoping, ticket service |
| Routers | `auth.py`, `chat.py` | WS ticket endpoint, ticket-based WebSocket |
| Startup | `main.py` | Middleware registration, fatal index bootstrap |
| Tests | 7 new/modified test files | 108 tests pass |

## Test plan

- [x] All 108 tests pass (1 pre-existing failure in `test_settings_requires_nextauth_secret` — unrelated)
- [x] Lint (`ruff check`) and format (`ruff format`) clean
- [x] Codex adversarial review — all 3 findings addressed
- [ ] Manual test: signup with duplicate email returns 409
- [ ] Manual test: WebSocket rejects without valid ticket
- [ ] Manual test: WS ticket expires after 30s

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)