### PR TITLE
feat(dashboard): layout, navigation, and overview page

### DIFF
--- a/apps/web/app/(dashboard)/_components/breadcrumbs.tsx
+++ b/apps/web/app/(dashboard)/_components/breadcrumbs.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Fragment } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+
+const LABEL_OVERRIDES: Record<string, string> = {
+  dashboard: "Overview",
+  "api-keys": "API Keys",
+};
+
+function humanize(slug: string): string {
+  if (LABEL_OVERRIDES[slug]) return LABEL_OVERRIDES[slug]!;
+  return slug
+    .split("-")
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+type Crumb = { href: string; label: string };
+
+function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0 || segments[0] !== "dashboard") return [];
+
+  const crumbs: Crumb[] = [];
+  let acc = "";
+  for (const seg of segments) {
+    acc += `/${seg}`;
+    crumbs.push({ href: acc, label: humanize(seg) });
+  }
+  return crumbs;
+}
+
+export function Breadcrumbs() {
+  const pathname = usePathname();
+  const crumbs = buildCrumbs(pathname);
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="hidden md:flex">
+      <ol className="flex items-center gap-1 text-[0.8rem] text-muted-foreground">
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1;
+          return (
+            <Fragment key={crumb.href}>
+              <li>
+                {isLast ? (
+                  <span
+                    aria-current="page"
+                    className="font-medium text-foreground"
+                  >
+                    {crumb.label}
+                  </span>
+                ) : (
+                  <Link
+                    href={crumb.href}
+                    className="rounded transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {crumb.label}
+                  </Link>
+                )}
+              </li>
+              {!isLast ? (
+                <li aria-hidden="true" className="text-muted-foreground/60">
+                  <ChevronRight className="size-3.5" />
+                </li>
+              ) : null}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/mobile-nav.tsx
+++ b/apps/web/app/(dashboard)/_components/mobile-nav.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { SidebarNav } from "./sidebar-nav";
+
+export function MobileNav({ tenantName }: { tenantName: string }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const [lastPathname, setLastPathname] = useState(pathname);
+
+  // Close drawer on route change without an effect.
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    if (open) setOpen(false);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open navigation"
+        aria-expanded={open}
+        aria-controls="mobile-nav-drawer"
+        className={cn(
+          "inline-flex size-8 items-center justify-center rounded-lg border border-border bg-background lg:hidden",
+          "transition-colors hover:bg-muted",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+      >
+        <Menu className="size-4" aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true">
+          <div
+            className="absolute inset-0 bg-foreground/40 backdrop-blur-[2px]"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div
+            id="mobile-nav-drawer"
+            className="absolute inset-y-0 left-0 flex w-[17rem] max-w-[85vw] flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
+          >
+            <div className="flex h-14 items-center justify-between border-b border-sidebar-border px-4">
+              <div className="flex items-center gap-2">
+                <div
+                  aria-hidden="true"
+                  className="grid size-7 place-items-center rounded-md bg-sidebar-foreground text-sidebar font-mono text-[0.7rem] font-semibold"
+                >
+                  MR
+                </div>
+                <span className="font-heading text-[0.95rem] font-semibold tracking-tight">
+                  MongoRAG
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close navigation"
+                className={cn(
+                  "inline-flex size-8 items-center justify-center rounded-lg",
+                  "transition-colors hover:bg-sidebar-accent",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+                )}
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              <SidebarNav onNavigate={() => setOpen(false)} />
+            </div>
+            <div className="border-t border-sidebar-border px-4 py-3">
+              <p className="text-[0.7rem] uppercase tracking-wide text-sidebar-foreground/50">
+                Workspace
+              </p>
+              <p className="mt-0.5 truncate text-[0.84rem] font-medium">
+                {tenantName}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/quick-action.tsx
+++ b/apps/web/app/(dashboard)/_components/quick-action.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function QuickAction({
+  href,
+  label,
+  description,
+  icon,
+}: {
+  href: string;
+  label: string;
+  description: string;
+  icon: ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "group flex items-start gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors",
+        "hover:border-foreground/30 hover:bg-muted/40",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="grid size-9 shrink-0 place-items-center rounded-lg bg-foreground text-background transition-transform group-hover:-rotate-3"
+      >
+        {icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-heading text-[0.95rem] font-medium tracking-tight text-foreground">
+          {label}
+        </div>
+        <p className="mt-0.5 text-[0.82rem] text-muted-foreground">
+          {description}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
+++ b/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Bot,
+  CreditCard,
+  FileText,
+  KeyRound,
+  LayoutDashboard,
+  Settings,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+const NAV_ITEMS: readonly NavItem[] = [
+  { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
+  { href: "/dashboard/bots", label: "Bots", icon: Bot },
+  { href: "/dashboard/documents", label: "Documents", icon: FileText },
+  { href: "/dashboard/api-keys", label: "API Keys", icon: KeyRound },
+  { href: "/dashboard/billing", label: "Billing", icon: CreditCard },
+  { href: "/dashboard/settings", label: "Settings", icon: Settings },
+] as const;
+
+export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Dashboard navigation" className="flex flex-col gap-0.5 p-3">
+      {NAV_ITEMS.map((item) => {
+        const Icon = item.icon;
+        const active =
+          item.href === "/dashboard"
+            ? pathname === "/dashboard"
+            : pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[0.84rem] font-medium text-sidebar-foreground/75 transition-colors",
+              "hover:bg-sidebar-accent hover:text-sidebar-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+              active &&
+                "bg-sidebar-accent text-sidebar-foreground ring-1 ring-sidebar-border",
+            )}
+          >
+            <Icon
+              className={cn(
+                "size-4 text-sidebar-foreground/55 transition-colors",
+                active && "text-sidebar-foreground",
+                "group-hover:text-sidebar-foreground",
+              )}
+              aria-hidden="true"
+            />
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/sidebar.tsx
+++ b/apps/web/app/(dashboard)/_components/sidebar.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import { SidebarNav } from "./sidebar-nav";
+
+export function Sidebar({ tenantName }: { tenantName: string }) {
+  return (
+    <aside
+      aria-label="Primary"
+      className="hidden lg:flex lg:w-60 lg:shrink-0 lg:flex-col lg:border-r lg:border-sidebar-border lg:bg-sidebar"
+    >
+      <div className="flex h-14 items-center gap-2 border-b border-sidebar-border px-4">
+        <Link
+          href="/dashboard"
+          className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring rounded-md"
+        >
+          <div
+            aria-hidden="true"
+            className="grid size-7 place-items-center rounded-md bg-sidebar-foreground text-sidebar font-mono text-[0.7rem] font-semibold tracking-tight"
+          >
+            MR
+          </div>
+          <span className="font-heading text-[0.95rem] font-semibold tracking-tight text-sidebar-foreground">
+            MongoRAG
+          </span>
+        </Link>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <SidebarNav />
+      </div>
+
+      <div className="border-t border-sidebar-border px-4 py-3">
+        <p className="text-[0.7rem] uppercase tracking-wide text-sidebar-foreground/50">
+          Workspace
+        </p>
+        <p className="mt-0.5 truncate text-[0.84rem] font-medium text-sidebar-foreground">
+          {tenantName}
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/stat-card.tsx
+++ b/apps/web/app/(dashboard)/_components/stat-card.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function StatCard({
+  label,
+  value,
+  hint,
+  icon,
+  className,
+}: {
+  label: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "group/stat relative flex flex-col gap-2 overflow-hidden rounded-xl border border-border bg-card p-4 text-card-foreground",
+        "before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-foreground/15 before:to-transparent",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[0.72rem] font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        {icon ? (
+          <span
+            aria-hidden="true"
+            className="grid size-7 place-items-center rounded-md bg-muted text-foreground/70"
+          >
+            {icon}
+          </span>
+        ) : null}
+      </div>
+      <div className="font-heading text-2xl font-semibold tracking-tight text-foreground tabular-nums">
+        {value}
+      </div>
+      {hint ? (
+        <div className="text-[0.78rem] text-muted-foreground">{hint}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/topbar.tsx
+++ b/apps/web/app/(dashboard)/_components/topbar.tsx
@@ -1,0 +1,34 @@
+import { Breadcrumbs } from "./breadcrumbs";
+import { MobileNav } from "./mobile-nav";
+import { UserMenu } from "./user-menu";
+
+export function Topbar({
+  tenantName,
+  email,
+  name,
+}: {
+  tenantName: string;
+  email: string;
+  name?: string | null;
+}) {
+  return (
+    <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background/85 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/70 sm:px-5">
+      <MobileNav tenantName={tenantName} />
+      <div className="flex items-center gap-2">
+        <span className="hidden text-[0.7rem] uppercase tracking-wide text-muted-foreground sm:inline">
+          Tenant
+        </span>
+        <span className="rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[0.8rem] font-medium text-foreground">
+          {tenantName}
+        </span>
+      </div>
+
+      <div className="ml-2 hidden h-5 w-px bg-border md:block" aria-hidden="true" />
+      <Breadcrumbs />
+
+      <div className="ml-auto flex items-center gap-2">
+        <UserMenu email={email} name={name} />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/usage-meter.tsx
+++ b/apps/web/app/(dashboard)/_components/usage-meter.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/lib/utils";
+
+export function UsageMeter({
+  used,
+  limit,
+}: {
+  used: number;
+  limit: number;
+}) {
+  const safeLimit = Math.max(limit, 1);
+  const pct = Math.min(100, Math.round((used / safeLimit) * 100));
+  const tone =
+    pct >= 90
+      ? "bg-destructive"
+      : pct >= 75
+        ? "bg-amber-500"
+        : "bg-foreground";
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Query usage"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={pct}
+      className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+    >
+      <div
+        className={cn("h-full rounded-full transition-[width]", tone)}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/_components/user-menu.tsx
+++ b/apps/web/app/(dashboard)/_components/user-menu.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { LogOut } from "lucide-react";
+import { signOut } from "next-auth/react";
+
+import { cn } from "@/lib/utils";
+
+function getInitials(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/[\s@.]+/).filter(Boolean);
+  if (parts.length === 0) return trimmed[0]!.toUpperCase();
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+}
+
+export function UserMenu({
+  email,
+  name,
+}: {
+  email: string;
+  name?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const initials = getInitials(name || email);
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+        onBlur={(e) => {
+          if (!e.currentTarget.parentElement?.contains(e.relatedTarget as Node)) {
+            setOpen(false);
+          }
+        }}
+        className={cn(
+          "flex items-center gap-2 rounded-lg border border-border bg-background px-1.5 py-1 text-sm",
+          "transition-colors hover:bg-muted",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="grid size-7 place-items-center rounded-md bg-foreground font-mono text-[0.7rem] font-semibold text-background"
+        >
+          {initials}
+        </span>
+        <span className="hidden max-w-[12rem] truncate pr-1 text-foreground/80 sm:inline">
+          {email}
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          aria-label="Account"
+          className={cn(
+            "absolute right-0 top-full z-50 mt-1.5 w-60 origin-top-right rounded-xl bg-popover p-1.5 text-popover-foreground shadow-lg ring-1 ring-foreground/10",
+          )}
+        >
+          <div className="px-2 py-1.5">
+            {name ? (
+              <p className="truncate text-sm font-medium text-foreground">
+                {name}
+              </p>
+            ) : null}
+            <p className="truncate text-[0.8rem] text-muted-foreground">
+              {email}
+            </p>
+          </div>
+          <div className="my-1 h-px bg-border" />
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              void signOut({ callbackUrl: "/login" });
+            }}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground",
+              "transition-colors hover:bg-muted",
+              "focus-visible:outline-none focus-visible:bg-muted",
+            )}
+          >
+            <LogOut className="size-4" aria-hidden="true" />
+            Sign out
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,19 +1,144 @@
+import { Bot, FileText, KeyRound, MessageSquareText, Upload, Zap } from "lucide-react";
+
 import { auth } from "@/lib/auth";
 
-export default async function DashboardPage() {
+import { QuickAction } from "../_components/quick-action";
+import { StatCard } from "../_components/stat-card";
+import { UsageMeter } from "../_components/usage-meter";
+
+type OverviewMetrics = {
+  plan: "free" | "starter" | "pro" | "enterprise";
+  queriesUsed: number;
+  queriesLimit: number;
+  documentCount: number;
+  activeBotCount: number;
+};
+
+const PLAN_LABELS: Record<OverviewMetrics["plan"], string> = {
+  free: "Free",
+  starter: "Starter",
+  pro: "Pro",
+  enterprise: "Enterprise",
+};
+
+async function loadOverview(tenantId: string): Promise<OverviewMetrics> {
+  // Placeholder data keyed by tenant — wired to Supabase + Mongo aggregation
+  // in a follow-up (subscriptions, documents, bots).
+  void tenantId;
+  return {
+    plan: "free",
+    queriesUsed: 0,
+    queriesLimit: 1000,
+    documentCount: 0,
+    activeBotCount: 0,
+  };
+}
+
+function formatNumber(n: number): string {
+  return new Intl.NumberFormat("en-US").format(n);
+}
+
+export default async function DashboardOverviewPage() {
   const session = await auth();
+  const email = session?.user?.email ?? "there";
+  const tenantId = session?.user?.tenant_id ?? "";
+
+  const metrics = await loadOverview(tenantId);
+  const usagePct = Math.round(
+    (metrics.queriesUsed / Math.max(metrics.queriesLimit, 1)) * 100,
+  );
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center flex flex-col gap-4">
-        <h1 className="text-3xl font-extralight tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground">
-          Welcome, {session?.user?.email}
+    <div className="flex flex-col gap-7">
+      <header className="flex flex-col gap-1">
+        <p className="text-[0.78rem] font-medium uppercase tracking-wide text-muted-foreground">
+          Overview
         </p>
+        <h1 className="font-heading text-2xl font-semibold tracking-tight text-foreground sm:text-[1.65rem]">
+          Welcome back, {email}
+        </h1>
         <p className="text-sm text-muted-foreground">
-          Tenant: {session?.user?.tenant_id}
+          A snapshot of your workspace usage and content.
         </p>
-      </div>
+      </header>
+
+      <section aria-labelledby="metrics-heading" className="flex flex-col gap-3">
+        <h2 id="metrics-heading" className="sr-only">
+          Key metrics
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label="Plan"
+            value={PLAN_LABELS[metrics.plan]}
+            hint={`${formatNumber(metrics.queriesLimit)} queries / month`}
+            icon={<Zap className="size-4" />}
+          />
+          <StatCard
+            label="Queries used"
+            value={
+              <span>
+                {formatNumber(metrics.queriesUsed)}
+                <span className="ml-1 text-base font-medium text-muted-foreground">
+                  / {formatNumber(metrics.queriesLimit)}
+                </span>
+              </span>
+            }
+            hint={
+              <div className="flex flex-col gap-1.5 pt-1">
+                <UsageMeter
+                  used={metrics.queriesUsed}
+                  limit={metrics.queriesLimit}
+                />
+                <span>{usagePct}% of monthly limit</span>
+              </div>
+            }
+            icon={<MessageSquareText className="size-4" />}
+          />
+          <StatCard
+            label="Documents"
+            value={formatNumber(metrics.documentCount)}
+            hint="Indexed sources"
+            icon={<FileText className="size-4" />}
+          />
+          <StatCard
+            label="Active bots"
+            value={formatNumber(metrics.activeBotCount)}
+            hint="Deployed assistants"
+            icon={<Bot className="size-4" />}
+          />
+        </div>
+      </section>
+
+      <section aria-labelledby="actions-heading" className="flex flex-col gap-3">
+        <div className="flex items-end justify-between gap-3">
+          <h2
+            id="actions-heading"
+            className="font-heading text-base font-medium tracking-tight text-foreground"
+          >
+            Quick actions
+          </h2>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <QuickAction
+            href="/dashboard/documents"
+            label="Upload document"
+            description="Ingest a PDF, Word or web page into your knowledge base."
+            icon={<Upload className="size-4" aria-hidden="true" />}
+          />
+          <QuickAction
+            href="/dashboard/bots"
+            label="Create a bot"
+            description="Configure a new assistant with custom prompts and tools."
+            icon={<Bot className="size-4" aria-hidden="true" />}
+          />
+          <QuickAction
+            href="/dashboard/api-keys"
+            label="Get script tag"
+            description="Generate keys and copy the snippet to embed your widget."
+            icon={<KeyRound className="size-4" aria-hidden="true" />}
+          />
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/error.tsx
+++ b/apps/web/app/(dashboard)/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[dashboard]", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-start gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-6">
+      <div className="grid size-9 place-items-center rounded-lg bg-destructive/10 text-destructive">
+        <AlertTriangle className="size-4" aria-hidden="true" />
+      </div>
+      <div>
+        <h2 className="font-heading text-lg font-medium text-foreground">
+          Something went wrong
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          We could not load this page. The team has been notified.
+        </p>
+      </div>
+      <Button variant="outline" onClick={reset}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -2,15 +2,38 @@ import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
 
+import { Sidebar } from "./_components/sidebar";
+import { Topbar } from "./_components/topbar";
+
 export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const session = await auth();
-  if (!session) {
+  if (!session?.user) {
     redirect("/login");
   }
 
-  return <div className="min-h-screen bg-background">{children}</div>;
+  const tenantName = session.user.tenant_id;
+
+  return (
+    <div className="flex min-h-screen w-full bg-background text-foreground">
+      <Sidebar tenantName={tenantName} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Topbar
+          tenantName={tenantName}
+          email={session.user.email}
+          name={session.user.name}
+        />
+        <main
+          id="main"
+          className="flex-1 px-4 py-6 sm:px-6 lg:px-8"
+          tabIndex={-1}
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/app/(dashboard)/loading.tsx
+++ b/apps/web/app/(dashboard)/loading.tsx
@@ -1,0 +1,19 @@
+export default function DashboardLoading() {
+  return (
+    <div className="flex flex-col gap-6" aria-busy="true" aria-live="polite">
+      <span className="sr-only">Loading dashboard…</span>
+      <div className="flex flex-col gap-2">
+        <div className="h-6 w-44 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-72 animate-pulse rounded-md bg-muted/70" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-28 animate-pulse rounded-xl bg-card ring-1 ring-foreground/10"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -336,5 +336,3 @@ export const Constants = {
     },
   },
 } as const
-A new version of Supabase CLI is available: v2.95.4 (currently installed v2.90.0)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli


### PR DESCRIPTION
## Summary
- Adds `(dashboard)` route group shell with server-rendered NextAuth guard, persistent sidebar (Overview / Bots / Documents / API Keys / Billing / Settings), top bar with tenant chip + breadcrumbs + user menu, and mobile drawer.
- Implements `/dashboard` overview page with stat cards (plan, queries used + usage meter, documents, active bots), quick actions, `loading.tsx`, and `error.tsx`. Real metrics will be wired through Supabase + Mongo aggregation in a follow-up.
- Strips a stray Supabase CLI "new version" banner accidentally appended to `apps/web/types/supabase.ts` in 86c9ad0 so the production build type-checks cleanly.

## Foundations for siblings
- Sidebar entries `/dashboard/documents` and `/dashboard/api-keys` are stable and ready for issues #13 (documents UI) and #14 (API keys UI) — siblings can drop pages under those segments without touching layout files.
- Layout passes `tenantName` from session; overview's `loadOverview(tenantId)` is the placeholder seam for live data.

## Anti-slop
- Geist Sans + Geist Mono pairing (already in root layout); no Inter-everywhere.
- Neutral oklch palette from `globals.css` (no purple→blue gradients, no AI emoji in CTAs).
- Custom card chrome (top-edge gradient hairline + ring border), not default shadcn glow.
- Motion is purposeful (focus-visible rings, mild quick-action icon rotate on hover); honours `prefers-reduced-motion` via Tailwind defaults.

## Test plan
- [ ] `pnpm lint` passes (verified locally — only pre-existing unrelated warnings).
- [ ] `pnpm build` passes (verified locally).
- [ ] Visit `/dashboard` while signed in: layout renders, sidebar links route, breadcrumbs reflect path, user menu signs out via `next-auth/react`.
- [ ] Resize to mobile (<lg): sidebar hides, hamburger opens drawer, Escape and route change close it.
- [ ] Visit while signed out: middleware redirects to `/login`.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)