### PR TITLE
feat(web): API key management UI

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/api-keys/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/actions.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  createApiKey as createApiKeyRequest,
+  revokeApiKey as revokeApiKeyRequest,
+  type CreatedApiKey,
+} from "@/lib/api-keys";
+import { createApiKeySchema } from "@/lib/validations/api-keys";
+
+export type CreateKeyResult =
+  | { ok: true; key: CreatedApiKey }
+  | { ok: false; error: string };
+
+export type RevokeKeyResult = { ok: true } | { ok: false; error: string };
+
+const PAGE_PATH = "/dashboard/api-keys";
+
+export async function createApiKeyAction(
+  input: unknown,
+): Promise<CreateKeyResult> {
+  const parsed = createApiKeySchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+
+  try {
+    const key = await createApiKeyRequest(parsed.data);
+    revalidatePath(PAGE_PATH);
+    return { ok: true, key };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      return { ok: false, error: err.message };
+    }
+    return { ok: false, error: "Failed to create API key" };
+  }
+}
+
+export async function revokeApiKeyAction(
+  keyId: string,
+): Promise<RevokeKeyResult> {
+  if (!keyId || typeof keyId !== "string") {
+    return { ok: false, error: "Missing key ID" };
+  }
+  try {
+    await revokeApiKeyRequest(keyId);
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      return { ok: false, error: err.message };
+    }
+    return { ok: false, error: "Failed to revoke API key" };
+  }
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/api-keys-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/api-keys-client.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import type { ApiKey, CreatedApiKey } from "@/lib/api-keys";
+
+import { CreateKeyDialog } from "./create-key-dialog";
+import { KeysTable } from "./keys-table";
+import { RevealKeyDialog } from "./reveal-key-dialog";
+import { RevokeKeyDialog } from "./revoke-key-dialog";
+import {
+  createApiKeyAction,
+  revokeApiKeyAction,
+} from "./actions";
+
+interface Props {
+  initialKeys: ApiKey[];
+  initialError: string | null;
+}
+
+export function ApiKeysClient({ initialKeys, initialError }: Props) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [revealKey, setRevealKey] = useState<CreatedApiKey | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleCreate(input: { name: string; permissions: ("chat" | "search")[] }) {
+    startTransition(async () => {
+      const result = await createApiKeyAction(input);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      setCreateOpen(false);
+      setRevealKey(result.key);
+    });
+  }
+
+  function handleRevoke() {
+    if (!revokeTarget) return;
+    const target = revokeTarget;
+    startTransition(async () => {
+      const result = await revokeApiKeyAction(target.id);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(`Revoked "${target.name}"`);
+      setRevokeTarget(null);
+    });
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {initialKeys.length === 0 && !initialError
+            ? "No keys yet."
+            : `${initialKeys.length} ${initialKeys.length === 1 ? "key" : "keys"}`}
+        </p>
+        <Button onClick={() => setCreateOpen(true)} disabled={isPending}>
+          <Plus />
+          New key
+        </Button>
+      </div>
+
+      {initialError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        >
+          {initialError}
+        </div>
+      ) : (
+        <KeysTable keys={initialKeys} onRevoke={setRevokeTarget} />
+      )}
+
+      <CreateKeyDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSubmit={handleCreate}
+        isPending={isPending}
+      />
+
+      <RevealKeyDialog
+        apiKey={revealKey}
+        onClose={() => setRevealKey(null)}
+      />
+
+      <RevokeKeyDialog
+        apiKey={revokeTarget}
+        onCancel={() => setRevokeTarget(null)}
+        onConfirm={handleRevoke}
+        isPending={isPending}
+      />
+    </section>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/create-key-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/create-key-dialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  apiKeyPermissions,
+  createApiKeySchema,
+  type CreateApiKeyFormData,
+} from "@/lib/validations/api-keys";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: CreateApiKeyFormData) => void;
+  isPending: boolean;
+}
+
+const PERMISSION_LABELS: Record<(typeof apiKeyPermissions)[number], string> = {
+  chat: "Chat — answer questions via the agent",
+  search: "Search — query documents directly",
+};
+
+export function CreateKeyDialog({ open, onOpenChange, onSubmit, isPending }: Props) {
+  const form = useForm<CreateApiKeyFormData>({
+    resolver: zodResolver(createApiKeySchema),
+    defaultValues: { name: "", permissions: ["chat", "search"] },
+  });
+
+  useEffect(() => {
+    if (!open) form.reset({ name: "", permissions: ["chat", "search"] });
+  }, [open, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create API key</DialogTitle>
+          <DialogDescription>
+            Give the key a recognisable name. The full secret is shown only once
+            after it is created — store it somewhere safe.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="grid gap-4"
+          onSubmit={form.handleSubmit(onSubmit)}
+          noValidate
+        >
+          <div className="grid gap-1.5">
+            <Label htmlFor="api-key-name">Name</Label>
+            <Input
+              id="api-key-name"
+              placeholder="Production widget"
+              autoComplete="off"
+              autoFocus
+              aria-invalid={!!form.formState.errors.name}
+              {...form.register("name")}
+            />
+            {form.formState.errors.name && (
+              <p
+                className="text-xs text-destructive"
+                role="alert"
+                id="api-key-name-error"
+              >
+                {form.formState.errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <Controller
+            control={form.control}
+            name="permissions"
+            render={({ field }) => (
+              <fieldset className="grid gap-2">
+                <legend className="text-sm font-medium">Permissions</legend>
+                {apiKeyPermissions.map((perm) => {
+                  const checked = field.value?.includes(perm) ?? false;
+                  return (
+                    <Label
+                      key={perm}
+                      htmlFor={`perm-${perm}`}
+                      className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border/60 bg-muted/20 px-3 py-2 transition-colors has-aria-checked:border-foreground/30 has-aria-checked:bg-muted/60"
+                    >
+                      <Checkbox
+                        id={`perm-${perm}`}
+                        checked={checked}
+                        onCheckedChange={(value) => {
+                          const next = new Set(field.value ?? []);
+                          if (value) next.add(perm);
+                          else next.delete(perm);
+                          field.onChange(Array.from(next));
+                        }}
+                      />
+                      <span className="grid gap-0.5 text-sm leading-tight">
+                        <span className="font-medium capitalize">{perm}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {PERMISSION_LABELS[perm]}
+                        </span>
+                      </span>
+                    </Label>
+                  );
+                })}
+                {form.formState.errors.permissions && (
+                  <p className="text-xs text-destructive" role="alert">
+                    {form.formState.errors.permissions.message as string}
+                  </p>
+                )}
+              </fieldset>
+            )}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Creating…" : "Create key"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/keys-table.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/keys-table.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { KeyRound, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { ApiKey } from "@/lib/api-keys";
+
+interface Props {
+  keys: ApiKey[];
+  onRevoke: (key: ApiKey) => void;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return dateFormatter.format(date);
+}
+
+function formatRelative(value: string | null): string {
+  if (!value) return "Never used";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  return dateFormatter.format(date);
+}
+
+export function KeysTable({ keys, onRevoke }: Props) {
+  if (keys.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border/70 bg-muted/30 px-8 py-14 text-center">
+        <div className="flex size-10 items-center justify-center rounded-full border border-foreground/10 bg-background text-muted-foreground">
+          <KeyRound className="size-4" />
+        </div>
+        <div className="space-y-1">
+          <h3 className="font-heading text-base font-medium">No keys yet</h3>
+          <p className="max-w-xs text-sm text-muted-foreground">
+            Create your first API key to embed the chat widget or call the
+            MongoRAG API from your own services.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border/60 bg-muted/40 text-left text-[0.7rem] tracking-wide text-muted-foreground uppercase">
+          <tr>
+            <th className="px-4 py-2.5 font-medium">Name</th>
+            <th className="px-4 py-2.5 font-medium">Key</th>
+            <th className="hidden px-4 py-2.5 font-medium md:table-cell">
+              Permissions
+            </th>
+            <th className="hidden px-4 py-2.5 font-medium md:table-cell">
+              Last used
+            </th>
+            <th className="hidden px-4 py-2.5 font-medium lg:table-cell">
+              Created
+            </th>
+            <th className="px-4 py-2.5 font-medium">Status</th>
+            <th className="px-4 py-2.5"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60">
+          {keys.map((key) => (
+            <tr
+              key={key.id}
+              className="transition-colors hover:bg-muted/30"
+              data-revoked={key.is_revoked || undefined}
+            >
+              <td className="px-4 py-3 font-medium">
+                <div className="flex items-center gap-2">
+                  <span className="truncate">{key.name}</span>
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <code className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[0.75rem] text-muted-foreground">
+                  mrag_{key.key_prefix}…
+                </code>
+              </td>
+              <td className="hidden px-4 py-3 md:table-cell">
+                <div className="flex flex-wrap gap-1">
+                  {key.permissions.map((perm) => (
+                    <Badge key={perm} variant="muted">
+                      {perm}
+                    </Badge>
+                  ))}
+                </div>
+              </td>
+              <td className="hidden px-4 py-3 text-muted-foreground md:table-cell">
+                {formatRelative(key.last_used_at)}
+              </td>
+              <td className="hidden px-4 py-3 text-muted-foreground lg:table-cell">
+                {formatDate(key.created_at)}
+              </td>
+              <td className="px-4 py-3">
+                {key.is_revoked ? (
+                  <Badge variant="destructive">Revoked</Badge>
+                ) : (
+                  <Badge variant="success">Active</Badge>
+                )}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {!key.is_revoked && (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Revoke ${key.name}`}
+                    onClick={() => onRevoke(key)}
+                  >
+                    <Trash2 />
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+
+import { ApiError } from "@/lib/api-client";
+import { listApiKeys } from "@/lib/api-keys";
+
+import { ApiKeysClient } from "./api-keys-client";
+
+export const metadata: Metadata = {
+  title: "API Keys — MongoRAG",
+  description: "Create, list, and revoke API keys for the chat widget and programmatic access.",
+};
+
+// JWT minted server-side per request, never cache.
+export const dynamic = "force-dynamic";
+
+export default async function ApiKeysPage() {
+  let initialError: string | null = null;
+  let keys: Awaited<ReturnType<typeof listApiKeys>> = [];
+  try {
+    keys = await listApiKeys();
+  } catch (err) {
+    initialError =
+      err instanceof ApiError
+        ? err.message
+        : "Could not reach the API. Try again in a moment.";
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-6 py-10">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+            Authentication
+          </p>
+          <h1 className="font-heading text-2xl leading-tight font-medium tracking-tight">
+            API keys
+          </h1>
+          <p className="max-w-xl text-sm text-muted-foreground">
+            Issue keys for the embed widget and any service that talks to your
+            MongoRAG tenant. Each key carries a tenant-scoped permission set
+            and can be revoked instantly.
+          </p>
+        </div>
+      </header>
+
+      <ApiKeysClient initialKeys={keys} initialError={initialError} />
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/reveal-key-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/reveal-key-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Check, Copy, ShieldAlert } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { CreatedApiKey } from "@/lib/api-keys";
+
+interface Props {
+  apiKey: CreatedApiKey | null;
+  onClose: () => void;
+}
+
+export function RevealKeyDialog({ apiKey, onClose }: Props) {
+  // Reset copied state whenever a new key is shown by keying state on the prefix.
+  const keyId = apiKey?.key_prefix ?? null;
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const copied = !!keyId && copiedKey === keyId;
+
+  async function handleCopy() {
+    if (!apiKey) return;
+    try {
+      await navigator.clipboard.writeText(apiKey.raw_key);
+      setCopiedKey(apiKey.key_prefix);
+      toast.success("Key copied to clipboard");
+    } catch {
+      toast.error("Could not copy — select the key and copy manually");
+    }
+  }
+
+  return (
+    <Dialog
+      open={!!apiKey}
+      onOpenChange={(value) => {
+        if (!value) onClose();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Save your API key</DialogTitle>
+          <DialogDescription>
+            This is the only time the full secret will be shown. Copy it now
+            and store it in your secrets manager.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-200"
+        >
+          <ShieldAlert className="mt-0.5 size-4 shrink-0" />
+          <span>
+            We only store a hash of this key. If you lose it, revoke it and
+            generate a new one.
+          </span>
+        </div>
+
+        {apiKey && (
+          <div className="grid gap-3">
+            <div className="flex items-stretch gap-2">
+              <code
+                className="grow truncate rounded-lg border border-border/60 bg-muted/40 px-3 py-2 font-mono text-xs"
+                aria-label="New API key"
+              >
+                {apiKey.raw_key}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCopy}
+                aria-label="Copy API key"
+              >
+                {copied ? <Check /> : <Copy />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <dt>Name</dt>
+              <dd className="text-foreground">{apiKey.name}</dd>
+              <dt>Permissions</dt>
+              <dd className="text-foreground">
+                {apiKey.permissions.join(", ")}
+              </dd>
+            </dl>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button onClick={onClose}>I&apos;ve stored it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/api-keys/revoke-key-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/api-keys/revoke-key-dialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { ApiKey } from "@/lib/api-keys";
+
+interface Props {
+  apiKey: ApiKey | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+export function RevokeKeyDialog({
+  apiKey,
+  onCancel,
+  onConfirm,
+  isPending,
+}: Props) {
+  return (
+    <Dialog
+      open={!!apiKey}
+      onOpenChange={(value) => {
+        if (!value) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke this API key?</DialogTitle>
+          <DialogDescription>
+            Any service or widget using this key will start failing
+            immediately. This cannot be undone — generate a new key if you
+            need access again.
+          </DialogDescription>
+        </DialogHeader>
+        {apiKey && (
+          <p className="rounded-lg border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+            <span className="font-medium">{apiKey.name}</span>{" "}
+            <code className="ml-1 font-mono text-xs text-muted-foreground">
+              mrag_{apiKey.key_prefix}…
+            </code>
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "Revoking…" : "Revoke key"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[5px] border border-input bg-background outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50 aria-checked:border-primary aria-checked:bg-primary aria-checked:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator>
+        <Check className="size-3" strokeWidth={3} />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Server-side API client for the FastAPI backend.
+ *
+ * The FastAPI backend authenticates dashboard requests with HS256 JWTs signed
+ * using `NEXTAUTH_SECRET` and a `tenant_id` claim (see apps/api/src/core/tenant.py).
+ *
+ * NextAuth's session cookie is encrypted (JWE) and cannot be forwarded directly,
+ * so we mint a short-lived signed token from the server-side session.
+ *
+ * IMPORTANT: never call this from a client component. Server actions / route
+ * handlers / RSC only — the secret must never reach the browser.
+ */
+
+import "server-only";
+
+import { SignJWT } from "jose";
+
+import { auth } from "@/lib/auth";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+const TOKEN_TTL_SECONDS = 60;
+
+function getSecret(): Uint8Array {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error("NEXTAUTH_SECRET is not configured");
+  }
+  return new TextEncoder().encode(secret);
+}
+
+async function mintBackendToken(params: {
+  sub: string;
+  tenantId: string;
+  role: string;
+}): Promise<string> {
+  return new SignJWT({ tenant_id: params.tenantId, role: params.role })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(params.sub)
+    .setIssuedAt()
+    .setExpirationTime(`${TOKEN_TTL_SECONDS}s`)
+    .sign(getSecret());
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+type RequestOptions = {
+  method?: "GET" | "POST" | "DELETE" | "PATCH";
+  body?: unknown;
+};
+
+/**
+ * Authenticated fetch against the FastAPI backend.
+ *
+ * Reads the current NextAuth session, mints a short-lived HS256 JWT, and
+ * sends it as a Bearer token. Returns the parsed JSON body. Throws ApiError
+ * on non-2xx responses.
+ */
+export async function apiFetch<T>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  const session = await auth();
+  if (!session?.user?.tenant_id) {
+    throw new ApiError(401, "Not authenticated");
+  }
+
+  const token = await mintBackendToken({
+    sub: session.user.id,
+    tenantId: session.user.tenant_id,
+    role: session.user.role,
+  });
+
+  const url = `${API_URL}${path}`;
+  const response = await fetch(url, {
+    method: options.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      if (data?.detail) message = data.detail;
+    } catch {
+      // ignore parse errors
+    }
+    throw new ApiError(response.status, message);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}

--- a/apps/web/lib/api-keys.ts
+++ b/apps/web/lib/api-keys.ts
@@ -1,0 +1,62 @@
+/**
+ * Typed client functions for the FastAPI /api/v1/keys endpoints.
+ *
+ * Server-only — these helpers mint a backend JWT, so they must never run in
+ * the browser. Use them from Server Components or Server Actions.
+ */
+
+import "server-only";
+
+import { apiFetch } from "@/lib/api-client";
+
+export type ApiKeyPermission = "chat" | "search";
+
+export interface ApiKey {
+  id: string;
+  key_prefix: string;
+  name: string;
+  permissions: ApiKeyPermission[];
+  is_revoked: boolean;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface ApiKeyListResponse {
+  keys: ApiKey[];
+}
+
+export interface CreatedApiKey {
+  raw_key: string;
+  key_prefix: string;
+  name: string;
+  permissions: ApiKeyPermission[];
+  created_at: string;
+}
+
+export interface CreateApiKeyInput {
+  name: string;
+  permissions?: ApiKeyPermission[];
+}
+
+export async function listApiKeys(): Promise<ApiKey[]> {
+  const data = await apiFetch<ApiKeyListResponse>("/api/v1/keys");
+  return data.keys;
+}
+
+export async function createApiKey(
+  input: CreateApiKeyInput,
+): Promise<CreatedApiKey> {
+  return apiFetch<CreatedApiKey>("/api/v1/keys", {
+    method: "POST",
+    body: {
+      name: input.name,
+      permissions: input.permissions ?? ["chat", "search"],
+    },
+  });
+}
+
+export async function revokeApiKey(keyId: string): Promise<void> {
+  await apiFetch<{ message: string }>(`/api/v1/keys/${keyId}`, {
+    method: "DELETE",
+  });
+}

--- a/apps/web/lib/validations/api-keys.ts
+++ b/apps/web/lib/validations/api-keys.ts
@@ -1,0 +1,16 @@
+import { z } from "zod/v3";
+
+export const apiKeyPermissions = ["chat", "search"] as const;
+
+export const createApiKeySchema = z.object({
+  name: z
+    .string()
+    .min(2, "Name must be at least 2 characters")
+    .max(100, "Name must be at most 100 characters")
+    .trim(),
+  permissions: z
+    .array(z.enum(apiKeyPermissions))
+    .min(1, "Select at least one permission"),
+});
+
+export type CreateApiKeyFormData = z.infer<typeof createApiKeySchema>;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.1",
+    "server-only": "^0.0.1",
     "shadcn": "^4.1.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.72.1
         version: 7.72.1(react@19.2.4)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       shadcn:
         specifier: ^4.1.1
         version: 4.1.1(@types/node@20.19.37)(typescript@5.9.3)
@@ -2904,6 +2907,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6307,6 +6313,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

Builds the `/dashboard/api-keys` page so tenants can create, list, and revoke API keys for the embed widget and programmatic access. Closes #14.

The FastAPI backend already exposes JWT-protected CRUD at `/api/v1/keys` (apps/api/src/routers/keys.py) — no backend changes were needed.

## Architecture

- **Server-only API client** (`apps/web/lib/api-client.ts`) — mints a short-lived (60s) HS256 JWT signed with `NEXTAUTH_SECRET` so the FastAPI backend (`apps/api/src/core/tenant.py`) validates dashboard requests via the same code path it uses today. NextAuth's session cookie is JWE-encrypted and cannot be forwarded directly.
- **Hard server boundary** — `import "server-only"` in `api-client.ts` makes any accidental import from a client component a build-time error. The secret never reaches the browser.
- **Server Actions** for create/revoke trigger `revalidatePath` so the list refreshes from the source of truth (no client-side cache to drift).

## UI

- Create dialog: React Hook Form + Zod, permission checkboxes, autofocus on name, inline error surfaces.
- Reveal dialog: full key shown exactly once with copy-to-clipboard, explicit "we only store a hash" warning, then state clears on close.
- Revoke dialog: destructive confirmation that surfaces the prefix being revoked.
- Table: prefix-only display (`mrag_<prefix>…`), permission badges, relative last-used, status badge, per-row revoke.
- Empty + error states; responsive (columns collapse on mobile); keyboard navigable.

## Coordination

- Sibling #12's sidebar already wires `/dashboard/api-keys` into the nav.
- Sibling #42 (Postgres migration) — kept the data layer behind typed helpers (`lib/api-keys.ts`) so swapping the underlying store is trivial.

## Drive-by fix

`apps/web/types/supabase.ts` had a Supabase-CLI banner leaked into the bottom of the file, breaking `pnpm build` on main. Truncated to the closing `} as const`.

## Test plan

- [ ] `pnpm build` (apps/web) — passes
- [ ] `pnpm lint` — passes (only pre-existing warnings)
- [ ] Browser: log into dashboard, navigate to `/dashboard/api-keys`, create a key, see plaintext shown once, copy, dismiss, list shows prefix only.
- [ ] Browser: revoke a key, confirm dialog, list shows status as Revoked.
- [ ] Tenant isolation: a second tenant cannot see or revoke keys created by the first.
- [ ] Errors surface as toasts (try invalid name, network failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)