### PR TITLE
feat(web): document management UI (upload, list, edit, delete)

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/documents/[id]/not-found.tsx
+++ b/apps/web/app/(dashboard)/dashboard/documents/[id]/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function DocumentNotFound() {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-4 px-4 py-20 text-center">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+        404
+      </p>
+      <h1 className="font-heading text-2xl tracking-tight">
+        Document not found
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        It may have been deleted, or you may not have permission to view it.
+      </p>
+      <Button render={(props) => <Link {...props} href="/dashboard/documents" />}>
+        Back to documents
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/documents/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/documents/[id]/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeftIcon } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DocumentEditForm } from "@/components/documents/document-edit-form";
+import { DocumentRowActions } from "@/components/documents/document-row-actions";
+import { DocumentStatusBadge } from "@/components/documents/status-badge";
+import { ApiError, getDocument } from "@/lib/api/documents";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default async function DocumentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  let doc;
+  try {
+    doc = await getDocument(id);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 md:px-8 md:py-10">
+      <Link
+        href="/dashboard/documents"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeftIcon className="size-3.5" />
+        All documents
+      </Link>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Document
+          </p>
+          <h1
+            className="mt-1 truncate font-heading text-2xl font-medium tracking-tight"
+            title={doc.title}
+          >
+            {doc.title}
+          </h1>
+          <p
+            className="mt-1 truncate text-sm text-muted-foreground"
+            title={doc.source}
+          >
+            {doc.source}
+          </p>
+        </div>
+        <DocumentRowActions
+          documentId={doc.document_id}
+          documentTitle={doc.title}
+        />
+      </div>
+
+      <dl className="grid grid-cols-2 gap-4 rounded-xl border border-border/40 bg-card/50 p-4 sm:grid-cols-4">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Status
+          </dt>
+          <dd className="mt-1">
+            <DocumentStatusBadge status={doc.status} />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Chunks
+          </dt>
+          <dd className="mt-1 tabular-nums">{doc.chunk_count}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Format
+          </dt>
+          <dd className="mt-1 font-mono text-xs uppercase">
+            {doc.format || "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Uploaded
+          </dt>
+          <dd className="mt-1 text-sm">{formatDate(doc.created_at)}</dd>
+        </div>
+      </dl>
+
+      {doc.status === "failed" && doc.error_message && (
+        <div
+          role="alert"
+          className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        >
+          <p className="font-medium">Ingestion failed</p>
+          <p className="mt-1 text-destructive/80">{doc.error_message}</p>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Metadata</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DocumentEditForm document={doc} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/documents/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/documents/page.tsx
@@ -1,0 +1,133 @@
+import { Suspense } from "react";
+
+import { DocumentUploadDialog } from "@/components/documents/upload-dialog";
+import { DocumentsPagination } from "@/components/documents/pagination";
+import { DocumentsTable } from "@/components/documents/documents-table";
+import { DocumentsToolbar } from "@/components/documents/documents-toolbar";
+import {
+  ApiError,
+  listDocuments,
+  type DocumentStatus,
+  type ListDocumentsParams,
+} from "@/lib/api/documents";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+const VALID_STATUS = new Set<DocumentStatus>([
+  "pending",
+  "processing",
+  "ready",
+  "failed",
+]);
+
+function parseParams(
+  raw: Record<string, string | string[] | undefined>,
+): ListDocumentsParams {
+  const page = Number(raw.page);
+  const status = typeof raw.status === "string" ? raw.status : undefined;
+  const sort = typeof raw.sort === "string" ? raw.sort : undefined;
+  const order = typeof raw.order === "string" ? raw.order : undefined;
+  const search = typeof raw.search === "string" ? raw.search : undefined;
+
+  return {
+    page: Number.isFinite(page) && page > 0 ? page : 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    status:
+      status && VALID_STATUS.has(status as DocumentStatus)
+        ? (status as DocumentStatus)
+        : undefined,
+    search: search?.trim() || undefined,
+    sort:
+      sort === "title" || sort === "status" || sort === "updated_at"
+        ? sort
+        : "created_at",
+    order: order === "asc" ? "asc" : "desc",
+  };
+}
+
+type LoadResult =
+  | { ok: true; data: Awaited<ReturnType<typeof listDocuments>> }
+  | { ok: false; message: string };
+
+async function loadDocuments(
+  params: ListDocumentsParams,
+): Promise<LoadResult> {
+  try {
+    const data = await listDocuments(params);
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      message:
+        err instanceof ApiError
+          ? err.message
+          : "Could not load documents. Please try again.",
+    };
+  }
+}
+
+async function DocumentsList({ params }: { params: ListDocumentsParams }) {
+  const result = await loadDocuments(params);
+  if (!result.ok) {
+    return (
+      <div
+        role="alert"
+        className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-6 text-sm text-destructive"
+      >
+        {result.message}
+      </div>
+    );
+  }
+  return (
+    <>
+      <DocumentsTable items={result.data.items} />
+      <DocumentsPagination
+        page={result.data.page}
+        pageSize={result.data.page_size}
+        total={result.data.total}
+      />
+    </>
+  );
+}
+
+export default async function DocumentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const raw = await searchParams;
+  const params = parseParams(raw);
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 md:px-8 md:py-10">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Knowledge base
+          </p>
+          <h1 className="mt-1 font-heading text-2xl font-medium tracking-tight">
+            Documents
+          </h1>
+          <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+            Upload, monitor, and manage the documents your bot answers from.
+          </p>
+        </div>
+        <DocumentUploadDialog />
+      </header>
+
+      <DocumentsToolbar />
+
+      <Suspense
+        fallback={
+          <div className="rounded-xl border border-border/40 bg-card/50 px-4 py-8 text-sm text-muted-foreground">
+            Loading documents…
+          </div>
+        }
+      >
+        <DocumentsList params={params} />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/app/api/documents/[id]/reingest/route.ts
+++ b/apps/web/app/api/documents/[id]/reingest/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+import { mintBackendToken } from "@/lib/api/token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const minted = await mintBackendToken();
+  if (!minted) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `${API_URL}/api/v1/documents/${encodeURIComponent(id)}/reingest`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${minted.token}` },
+      },
+    );
+  } catch (err) {
+    console.error("[documents/reingest] upstream failed", {
+      id,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Backend unavailable" },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: {
+      "Content-Type":
+        upstream.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/apps/web/app/api/documents/[id]/route.ts
+++ b/apps/web/app/api/documents/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+
+import { mintBackendToken } from "@/lib/api/token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function proxy(
+  id: string,
+  init: RequestInit,
+): Promise<NextResponse> {
+  const minted = await mintBackendToken();
+  if (!minted) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${minted.token}`);
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `${API_URL}/api/v1/documents/${encodeURIComponent(id)}`,
+      { ...init, headers },
+    );
+  } catch (err) {
+    console.error("[documents/proxy] upstream failed", {
+      id,
+      method: init.method,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Backend unavailable" },
+      { status: 502 },
+    );
+  }
+
+  if (upstream.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: {
+      "Content-Type":
+        upstream.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  return proxy(id, { method: "GET" });
+}
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const body = await req.text();
+  return proxy(id, { method: "PATCH", body });
+}
+
+export async function DELETE(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  return proxy(id, { method: "DELETE" });
+}

--- a/apps/web/app/api/documents/upload/route.ts
+++ b/apps/web/app/api/documents/upload/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from "next/server";
+
+import { mintBackendToken } from "@/lib/api/token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+const MAX_BYTES = 50 * 1024 * 1024; // 50 MB
+const ACCEPTED_EXTENSIONS = new Set([
+  "pdf",
+  "txt",
+  "md",
+  "markdown",
+  "docx",
+  "doc",
+  "pptx",
+  "ppt",
+  "xlsx",
+  "xls",
+  "html",
+  "htm",
+]);
+
+const ACCEPTED_MIME_PREFIXES = [
+  "application/pdf",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "application/vnd.openxmlformats-officedocument",
+  "application/msword",
+  "application/vnd.ms-",
+];
+
+function extOf(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx === -1 ? "" : name.slice(idx + 1).toLowerCase();
+}
+
+function isAcceptedMime(mime: string): boolean {
+  if (!mime) return true; // browsers sometimes omit; rely on extension
+  return ACCEPTED_MIME_PREFIXES.some((p) => mime.startsWith(p));
+}
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const minted = await mintBackendToken();
+  if (!minted) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const incoming = await request.formData();
+  const file = incoming.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: "Missing file in form data" },
+      { status: 400 },
+    );
+  }
+
+  const ext = extOf(file.name);
+  if (!ACCEPTED_EXTENSIONS.has(ext)) {
+    return NextResponse.json(
+      { error: `Unsupported file extension: .${ext || "unknown"}` },
+      { status: 415 },
+    );
+  }
+
+  if (!isAcceptedMime(file.type)) {
+    return NextResponse.json(
+      { error: `Unsupported MIME type: ${file.type}` },
+      { status: 415 },
+    );
+  }
+
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      {
+        error: `File too large. Maximum is ${MAX_BYTES / 1024 / 1024}MB`,
+      },
+      { status: 413 },
+    );
+  }
+
+  // Forward as multipart/form-data — let undici build a fresh boundary.
+  const forwarded = new FormData();
+  forwarded.append("file", file, file.name);
+  const title = incoming.get("title");
+  if (typeof title === "string" && title.trim()) {
+    forwarded.append("title", title.trim());
+  }
+  const metadata = incoming.get("metadata");
+  if (typeof metadata === "string" && metadata.trim()) {
+    forwarded.append("metadata", metadata.trim());
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${API_URL}/api/v1/documents/ingest`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${minted.token}` },
+      body: forwarded,
+    });
+  } catch (err) {
+    console.error("[documents/upload] upstream fetch failed", {
+      tenantId: minted.tenantId,
+      filename: file.name,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Upload service unavailable" },
+      { status: 502 },
+    );
+  }
+
+  if (!upstream.ok) {
+    console.warn("[documents/upload] upstream rejected", {
+      tenantId: minted.tenantId,
+      filename: file.name,
+      status: upstream.status,
+    });
+  }
+
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: {
+      "Content-Type":
+        upstream.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/apps/web/components/documents/document-edit-form.tsx
+++ b/apps/web/components/documents/document-edit-form.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  documentMetaSchema,
+  type DocumentMetaFormData,
+} from "@/lib/validations/document";
+import type { DocumentRecord } from "@/lib/api/documents";
+
+interface Props {
+  document: DocumentRecord;
+}
+
+export function DocumentEditForm({ document }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+    reset,
+  } = useForm<DocumentMetaFormData>({
+    resolver: zodResolver(documentMetaSchema),
+    defaultValues: {
+      title: document.title,
+      metadataJson: Object.keys(document.metadata).length
+        ? JSON.stringify(document.metadata, null, 2)
+        : "",
+    },
+  });
+
+  function onSubmit(data: DocumentMetaFormData) {
+    startTransition(async () => {
+      const payload: { title: string; metadata?: Record<string, unknown> } = {
+        title: data.title,
+      };
+      if (data.metadataJson?.trim()) {
+        try {
+          payload.metadata = JSON.parse(data.metadataJson) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          toast.error("Metadata must be a JSON object");
+          return;
+        }
+      } else {
+        payload.metadata = {};
+      }
+
+      try {
+        const res = await fetch(
+          `/api/documents/${encodeURIComponent(document.document_id)}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          },
+        );
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+            detail?: string;
+          };
+          toast.error(body.error ?? body.detail ?? "Update failed");
+          return;
+        }
+        toast.success("Document updated");
+        const updated = (await res.json()) as DocumentRecord;
+        reset({
+          title: updated.title,
+          metadataJson: Object.keys(updated.metadata).length
+            ? JSON.stringify(updated.metadata, null, 2)
+            : "",
+        });
+        router.refresh();
+      } catch {
+        toast.error("Network error");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="title">Title</Label>
+        <Input
+          id="title"
+          {...register("title")}
+          aria-invalid={!!errors.title}
+          aria-describedby={errors.title ? "title-error" : undefined}
+        />
+        {errors.title && (
+          <p id="title-error" className="text-sm text-destructive">
+            {errors.title.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="metadataJson">
+          Metadata
+          <span className="text-xs font-normal text-muted-foreground">
+            JSON object — used as filters when searching
+          </span>
+        </Label>
+        <Textarea
+          id="metadataJson"
+          rows={6}
+          spellCheck={false}
+          {...register("metadataJson")}
+          placeholder={`{\n  "tags": ["onboarding", "policy"],\n  "owner": "ops"\n}`}
+          className="font-mono text-xs"
+          aria-invalid={!!errors.metadataJson}
+          aria-describedby={
+            errors.metadataJson ? "metadata-error" : undefined
+          }
+        />
+        {errors.metadataJson && (
+          <p id="metadata-error" className="text-sm text-destructive">
+            {errors.metadataJson.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() =>
+            reset({
+              title: document.title,
+              metadataJson: Object.keys(document.metadata).length
+                ? JSON.stringify(document.metadata, null, 2)
+                : "",
+            })
+          }
+          disabled={!isDirty || isPending}
+        >
+          Reset
+        </Button>
+        <Button type="submit" disabled={!isDirty || isPending}>
+          {isPending ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/components/documents/document-row-actions.tsx
+++ b/apps/web/components/documents/document-row-actions.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  MoreHorizontalIcon,
+  PencilIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface Props {
+  documentId: string;
+  documentTitle: string;
+}
+
+export function DocumentRowActions({ documentId, documentTitle }: Props) {
+  const router = useRouter();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [confirmInput, setConfirmInput] = useState("");
+
+  function handleDelete() {
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/documents/${encodeURIComponent(documentId)}`,
+          { method: "DELETE" },
+        );
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          toast.error(body.error ?? "Delete failed");
+          return;
+        }
+        toast.success("Document deleted");
+        setConfirmOpen(false);
+        setConfirmInput("");
+        router.refresh();
+      } catch {
+        toast.error("Network error");
+      }
+    });
+  }
+
+  function handleReingest() {
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/documents/${encodeURIComponent(documentId)}/reingest`,
+          { method: "POST" },
+        );
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          toast.error(body.error ?? "Re-ingest failed");
+          return;
+        }
+        toast.success("Re-ingest queued");
+        router.refresh();
+      } catch {
+        toast.error("Network error");
+      }
+    });
+  }
+
+  const confirmRequired = "delete";
+  const canConfirm = confirmInput.trim().toLowerCase() === confirmRequired;
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={(props) => (
+            <Button
+              {...props}
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Actions for ${documentTitle}`}
+            >
+              <MoreHorizontalIcon className="size-4" />
+            </Button>
+          )}
+        />
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            render={(props) => (
+              <Link
+                {...props}
+                href={`/dashboard/documents/${encodeURIComponent(documentId)}`}
+              >
+                <PencilIcon className="size-3.5" />
+                <span>Edit metadata</span>
+              </Link>
+            )}
+          />
+          <DropdownMenuItem onClick={handleReingest} disabled={isPending}>
+            <RefreshCwIcon className="size-3.5" />
+            <span>Re-ingest</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => setConfirmOpen(true)}
+            variant="destructive"
+          >
+            <Trash2Icon className="size-3.5" />
+            <span>Delete…</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete document</DialogTitle>
+            <DialogDescription>
+              <span className="block">
+                This permanently removes{" "}
+                <span className="font-medium text-foreground">
+                  {documentTitle}
+                </span>{" "}
+                and all of its chunks and embeddings. This cannot be undone.
+              </span>
+              <span className="mt-3 block">
+                Type{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-foreground">
+                  delete
+                </code>{" "}
+                to confirm.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <input
+            type="text"
+            value={confirmInput}
+            onChange={(e) => setConfirmInput(e.target.value)}
+            placeholder="delete"
+            aria-label="Type 'delete' to confirm"
+            className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={!canConfirm || isPending}
+            >
+              {isPending ? "Deleting…" : "Delete forever"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/components/documents/documents-table.tsx
+++ b/apps/web/components/documents/documents-table.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableEmpty,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { DocumentRecord } from "@/lib/api/documents";
+
+import { DocumentRowActions } from "./document-row-actions";
+import { DocumentStatusBadge } from "./status-badge";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatSize(bytes: number | null): string {
+  if (!bytes) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function DocumentsTable({ items }: { items: DocumentRecord[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead className="w-24">Format</TableHead>
+          <TableHead className="w-20 text-right">Chunks</TableHead>
+          <TableHead className="w-28">Status</TableHead>
+          <TableHead className="w-44">Uploaded</TableHead>
+          <TableHead className="w-16" aria-label="Actions" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.length === 0 ? (
+          <TableEmpty colSpan={6}>
+            No documents yet. Upload one to get started.
+          </TableEmpty>
+        ) : (
+          items.map((doc) => (
+            <TableRow key={doc.document_id}>
+              <TableCell className="max-w-[28ch]">
+                <Link
+                  href={`/dashboard/documents/${encodeURIComponent(doc.document_id)}`}
+                  className="block truncate font-medium text-foreground hover:underline"
+                  title={doc.title}
+                >
+                  {doc.title}
+                </Link>
+                <p
+                  className="truncate text-xs text-muted-foreground"
+                  title={doc.source}
+                >
+                  {doc.source}
+                </p>
+              </TableCell>
+              <TableCell>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-[0.7rem] uppercase text-muted-foreground">
+                  {doc.format || "—"}
+                </code>
+                <p className="mt-0.5 text-[0.7rem] text-muted-foreground">
+                  {formatSize(doc.size_bytes)}
+                </p>
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {doc.chunk_count}
+              </TableCell>
+              <TableCell>
+                <DocumentStatusBadge status={doc.status} />
+                {doc.error_message && doc.status === "failed" && (
+                  <p
+                    className="mt-1 max-w-[20ch] truncate text-[0.7rem] text-destructive"
+                    title={doc.error_message}
+                  >
+                    {doc.error_message}
+                  </p>
+                )}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatDate(doc.created_at)}
+              </TableCell>
+              <TableCell className="text-right">
+                <DocumentRowActions
+                  documentId={doc.document_id}
+                  documentTitle={doc.title}
+                />
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/components/documents/documents-toolbar.tsx
+++ b/apps/web/components/documents/documents-toolbar.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useEffect, useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { SearchIcon } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "All statuses" },
+  { value: "ready", label: "Ready" },
+  { value: "processing", label: "Processing" },
+  { value: "pending", label: "Pending" },
+  { value: "failed", label: "Failed" },
+] as const;
+
+const SORT_OPTIONS = [
+  { value: "created_at:desc", label: "Newest first" },
+  { value: "created_at:asc", label: "Oldest first" },
+  { value: "title:asc", label: "Title A→Z" },
+  { value: "title:desc", label: "Title Z→A" },
+  { value: "status:asc", label: "Status" },
+] as const;
+
+export function DocumentsToolbar() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [search, setSearch] = useState(params.get("search") ?? "");
+  const [, startTransition] = useTransition();
+
+  const replaceParam = useCallback(
+    (mutator: (sp: URLSearchParams) => void) => {
+      const sp = new URLSearchParams(params.toString());
+      mutator(sp);
+      sp.delete("page"); // reset paging when filters change
+      startTransition(() => {
+        const qs = sp.toString();
+        router.replace(qs ? `${pathname}?${qs}` : pathname);
+      });
+    },
+    [params, pathname, router],
+  );
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const current = params.get("search") ?? "";
+      if (search.trim() !== current) {
+        replaceParam((sp) => {
+          if (search.trim()) sp.set("search", search.trim());
+          else sp.delete("search");
+        });
+      }
+    }, 300);
+    return () => clearTimeout(t);
+  }, [search, params, replaceParam]);
+
+  const status = params.get("status") ?? "all";
+  const sort = params.get("sort") ?? "created_at";
+  const order = params.get("order") ?? "desc";
+  const sortValue = `${sort}:${order}`;
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <label className="relative flex-1 max-w-sm">
+        <span className="sr-only">Search documents</span>
+        <SearchIcon className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by title…"
+          className="pl-7"
+          autoComplete="off"
+        />
+      </label>
+      <div className="flex items-center gap-2">
+        <Select
+          value={status}
+          onValueChange={(v) =>
+            replaceParam((sp) => {
+              if (v === "all") sp.delete("status");
+              else sp.set("status", v as string);
+            })
+          }
+        >
+          <SelectTrigger className="w-36" aria-label="Filter by status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={sortValue}
+          onValueChange={(v) => {
+            const [s, o] = (v as string).split(":");
+            replaceParam((sp) => {
+              sp.set("sort", s);
+              sp.set("order", o);
+            });
+          }}
+        >
+          <SelectTrigger className="w-40" aria-label="Sort documents">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/documents/pagination.tsx
+++ b/apps/web/components/documents/pagination.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export function DocumentsPagination({ page, pageSize, total }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  function go(next: number) {
+    const sp = new URLSearchParams(params.toString());
+    if (next <= 1) sp.delete("page");
+    else sp.set("page", String(next));
+    const qs = sp.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
+  }
+
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+
+  return (
+    <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <span>
+        {total === 0
+          ? "0 documents"
+          : `${start}–${end} of ${total} document${total === 1 ? "" : "s"}`}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          onClick={() => go(page - 1)}
+          disabled={page <= 1}
+          aria-label="Previous page"
+        >
+          <ChevronLeftIcon className="size-3.5" />
+        </Button>
+        <span className="px-2 tabular-nums">
+          {page} / {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="icon-sm"
+          onClick={() => go(page + 1)}
+          disabled={page >= totalPages}
+          aria-label="Next page"
+        >
+          <ChevronRightIcon className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/documents/status-badge.tsx
+++ b/apps/web/components/documents/status-badge.tsx
@@ -1,0 +1,52 @@
+import { CheckIcon, CircleIcon, Loader2Icon, XIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import type { DocumentStatus } from "@/lib/api/documents";
+
+const CONFIG: Record<
+  DocumentStatus,
+  {
+    label: string;
+    variant: "default" | "success" | "warning" | "destructive" | "info" | "muted";
+    icon: React.ComponentType<{ className?: string }>;
+    spin?: boolean;
+  }
+> = {
+  pending: {
+    label: "Pending",
+    variant: "muted",
+    icon: CircleIcon,
+  },
+  processing: {
+    label: "Processing",
+    variant: "info",
+    icon: Loader2Icon,
+    spin: true,
+  },
+  ready: {
+    label: "Ready",
+    variant: "success",
+    icon: CheckIcon,
+  },
+  failed: {
+    label: "Failed",
+    variant: "destructive",
+    icon: XIcon,
+  },
+  unknown: {
+    label: "Unknown",
+    variant: "muted",
+    icon: CircleIcon,
+  },
+};
+
+export function DocumentStatusBadge({ status }: { status: DocumentStatus }) {
+  const cfg = CONFIG[status] ?? CONFIG.unknown;
+  const Icon = cfg.icon;
+  return (
+    <Badge variant={cfg.variant} aria-label={`Status: ${cfg.label}`}>
+      <Icon className={`size-3 ${cfg.spin ? "animate-spin" : ""}`} />
+      <span>{cfg.label}</span>
+    </Badge>
+  );
+}

--- a/apps/web/components/documents/upload-dialog.tsx
+++ b/apps/web/components/documents/upload-dialog.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useCallback, useId, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { CloudUploadIcon, FileIcon, XIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  ACCEPT_ATTRIBUTE,
+  MAX_UPLOAD_BYTES,
+  isAcceptedExtension,
+} from "@/lib/validations/document";
+
+interface QueuedFile {
+  id: string;
+  file: File;
+  state: "queued" | "uploading" | "done" | "error";
+  error?: string;
+}
+
+interface UploadResponse {
+  document_id?: string;
+  detail?: string;
+  error?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function DocumentUploadDialog({
+  trigger,
+}: {
+  trigger?: React.ReactNode;
+}) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<QueuedFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const dropZoneId = useId();
+
+  const validateAndAdd = useCallback((files: FileList | File[]) => {
+    const next: QueuedFile[] = [];
+    for (const file of Array.from(files)) {
+      if (!isAcceptedExtension(file.name)) {
+        toast.error(`Unsupported file type: ${file.name}`);
+        continue;
+      }
+      if (file.size > MAX_UPLOAD_BYTES) {
+        toast.error(
+          `${file.name} is too large (max ${MAX_UPLOAD_BYTES / 1024 / 1024} MB)`,
+        );
+        continue;
+      }
+      next.push({
+        id: `${file.name}-${file.size}-${Date.now()}-${Math.random()}`,
+        file,
+        state: "queued",
+      });
+    }
+    if (next.length) {
+      setItems((prev) => [...prev, ...next]);
+    }
+  }, []);
+
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    if (e.target.files) {
+      validateAndAdd(e.target.files);
+      e.target.value = "";
+    }
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(false);
+    if (e.dataTransfer.files?.length) {
+      validateAndAdd(e.dataTransfer.files);
+    }
+  }
+
+  function removeItem(id: string) {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+  }
+
+  async function uploadOne(item: QueuedFile): Promise<boolean> {
+    const fd = new FormData();
+    fd.append("file", item.file);
+    try {
+      const res = await fetch("/api/documents/upload", {
+        method: "POST",
+        body: fd,
+      });
+      const json = (await res.json().catch(() => ({}))) as UploadResponse;
+      if (!res.ok) {
+        const msg = json.error ?? json.detail ?? `Upload failed (${res.status})`;
+        setItems((prev) =>
+          prev.map((it) =>
+            it.id === item.id ? { ...it, state: "error", error: msg } : it,
+          ),
+        );
+        return false;
+      }
+      setItems((prev) =>
+        prev.map((it) =>
+          it.id === item.id ? { ...it, state: "done" } : it,
+        ),
+      );
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Upload failed";
+      setItems((prev) =>
+        prev.map((it) =>
+          it.id === item.id ? { ...it, state: "error", error: msg } : it,
+        ),
+      );
+      return false;
+    }
+  }
+
+  async function handleUploadAll() {
+    if (!items.length) return;
+    setIsUploading(true);
+    setItems((prev) =>
+      prev.map((it) =>
+        it.state === "queued" ? { ...it, state: "uploading" } : it,
+      ),
+    );
+    let successes = 0;
+    for (const item of items) {
+      if (item.state === "done") {
+        successes += 1;
+        continue;
+      }
+      const ok = await uploadOne({ ...item, state: "uploading" });
+      if (ok) successes += 1;
+    }
+    setIsUploading(false);
+    if (successes > 0) {
+      toast.success(
+        `${successes} document${successes === 1 ? "" : "s"} queued for processing`,
+      );
+      router.refresh();
+    }
+  }
+
+  function handleClose(next: boolean) {
+    if (isUploading) return;
+    setOpen(next);
+    if (!next) {
+      setItems([]);
+    }
+  }
+
+  const hasErrors = items.some((it) => it.state === "error");
+  const allDone =
+    items.length > 0 && items.every((it) => it.state === "done");
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogTrigger
+        render={(props) => (trigger ? <span {...props}>{trigger}</span> : (
+          <Button {...props}>
+            <CloudUploadIcon className="size-4" />
+            Upload document
+          </Button>
+        ))}
+      />
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Upload documents</DialogTitle>
+          <DialogDescription>
+            Drop files or browse. PDF, DOCX, PPTX, XLSX, HTML, TXT, and Markdown
+            are supported. Max {MAX_UPLOAD_BYTES / 1024 / 1024} MB per file.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          aria-labelledby={dropZoneId}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          className={cn(
+            "flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border/60 px-6 py-8 text-center transition-colors",
+            isDragging && "border-primary/60 bg-primary/5",
+          )}
+        >
+          <CloudUploadIcon className="size-7 text-muted-foreground" />
+          <p id={dropZoneId} className="text-sm font-medium">
+            Drop files here
+          </p>
+          <p className="text-xs text-muted-foreground">or</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => inputRef.current?.click()}
+          >
+            Browse files
+          </Button>
+          <input
+            ref={inputRef}
+            type="file"
+            multiple
+            accept={ACCEPT_ATTRIBUTE}
+            onChange={handleFileInput}
+            className="sr-only"
+            aria-label="Choose documents to upload"
+          />
+        </div>
+
+        {items.length > 0 && (
+          <ul className="mt-4 flex max-h-56 flex-col gap-1 overflow-y-auto">
+            {items.map((it) => (
+              <li
+                key={it.id}
+                className="flex items-center gap-2 rounded-md border border-border/40 bg-card/50 px-2 py-1.5 text-sm"
+              >
+                <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate" title={it.file.name}>
+                  {it.file.name}
+                </span>
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  {formatBytes(it.file.size)}
+                </span>
+                <span
+                  className={cn(
+                    "text-xs",
+                    it.state === "done" && "text-emerald-600 dark:text-emerald-400",
+                    it.state === "error" && "text-destructive",
+                    it.state === "uploading" && "text-sky-600 dark:text-sky-400",
+                  )}
+                >
+                  {it.state === "queued"
+                    ? "Ready"
+                    : it.state === "uploading"
+                      ? "Uploading…"
+                      : it.state === "done"
+                        ? "Queued"
+                        : "Failed"}
+                </span>
+                {!isUploading && it.state !== "done" && (
+                  <button
+                    type="button"
+                    onClick={() => removeItem(it.id)}
+                    className="text-muted-foreground hover:text-destructive transition-colors"
+                    aria-label={`Remove ${it.file.name}`}
+                  >
+                    <XIcon className="size-3.5" />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {hasErrors && (
+          <p className="mt-2 text-xs text-destructive">
+            Some files failed. Hover the row for details.
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleClose(false)}
+            disabled={isUploading}
+          >
+            {allDone ? "Close" : "Cancel"}
+          </Button>
+          <Button
+            onClick={handleUploadAll}
+            disabled={
+              isUploading ||
+              items.length === 0 ||
+              items.every((it) => it.state === "done")
+            }
+          >
+            {isUploading
+              ? "Uploading…"
+              : allDone
+                ? "Done"
+                : `Upload ${items.length} ${items.length === 1 ? "file" : "files"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[0.7rem] font-medium leading-none whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "border-border/60 bg-muted text-foreground",
+        success:
+          "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+        warning:
+          "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
+        destructive:
+          "border-destructive/30 bg-destructive/10 text-destructive",
+        info: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-400",
+        muted: "border-border/40 bg-transparent text-muted-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+function DialogBackdrop({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Backdrop>) {
+  return (
+    <DialogPrimitive.Backdrop
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity duration-200",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Popup>) {
+  return (
+    <DialogPortal>
+      <DialogBackdrop />
+      <DialogPrimitive.Popup
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border/60 bg-popover p-6 text-popover-foreground shadow-2xl outline-none",
+          "data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
+          "transition-all duration-200",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          className="absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          aria-label="Close"
+        >
+          <XIcon className="size-4" />
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5 pr-8 mb-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse gap-2 mt-6 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn(
+        "font-heading text-lg font-medium leading-tight tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = MenuPrimitive.Root;
+const DropdownMenuTrigger = MenuPrimitive.Trigger;
+const DropdownMenuPortal = MenuPrimitive.Portal;
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  align = "end",
+  ...props
+}: React.ComponentProps<typeof MenuPrimitive.Popup> & {
+  sideOffset?: number;
+  align?: "start" | "center" | "end";
+}) {
+  return (
+    <DropdownMenuPortal>
+      <MenuPrimitive.Positioner sideOffset={sideOffset} align={align}>
+        <MenuPrimitive.Popup
+          className={cn(
+            "z-50 min-w-[10rem] overflow-hidden rounded-lg border border-border/60 bg-popover p-1 text-popover-foreground shadow-lg outline-none",
+            "data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-all duration-150",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </DropdownMenuPortal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof MenuPrimitive.Item> & {
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <MenuPrimitive.Item
+      className={cn(
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none transition-colors",
+        "data-[highlighted]:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        variant === "destructive" &&
+          "text-destructive data-[highlighted]:bg-destructive/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenuPrimitive.Separator>) {
+  return (
+    <MenuPrimitive.Separator
+      className={cn("-mx-1 my-1 h-px bg-border/60", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+const SelectValue = SelectPrimitive.Value;
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      className={cn(
+        "inline-flex h-8 w-full items-center justify-between gap-2 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none transition-colors",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon>
+        <ChevronDownIcon className="size-3.5 opacity-60" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Popup>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner sideOffset={4}>
+        <SelectPrimitive.Popup
+          className={cn(
+            "z-50 max-h-[var(--available-height)] min-w-[var(--anchor-width)] overflow-y-auto rounded-lg border border-border/60 bg-popover p-1 text-popover-foreground shadow-lg outline-none",
+            "data-[starting-style]:scale-95 data-[starting-style]:opacity-0 transition-all duration-150",
+            className,
+          )}
+          {...props}
+        />
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      className={cn(
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 pr-8 text-sm outline-none transition-colors",
+        "data-[highlighted]:bg-muted",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator className="absolute right-2 inline-flex">
+        <CheckIcon className="size-3.5" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+export { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -1,0 +1,98 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div className="relative w-full overflow-x-auto rounded-xl border border-border/60 bg-card">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      className={cn(
+        "border-b border-border/60 bg-muted/30 [&_tr]:border-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      className={cn(
+        "border-b border-border/40 transition-colors hover:bg-muted/30 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      className={cn(
+        "h-10 px-3 text-left align-middle text-xs font-medium uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      className={cn("px-3 py-2.5 align-middle", className)}
+      {...props}
+    />
+  );
+}
+
+function TableEmpty({
+  colSpan,
+  children,
+}: {
+  colSpan: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <tr>
+      <td
+        colSpan={colSpan}
+        className="px-3 py-12 text-center text-sm text-muted-foreground"
+      >
+        {children}
+      </td>
+    </tr>
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableEmpty,
+};

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex min-h-20 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors",
+        "placeholder:text-muted-foreground",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/web/lib/api/documents.ts
+++ b/apps/web/lib/api/documents.ts
@@ -1,0 +1,151 @@
+import { mintBackendToken } from "@/lib/api/token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+export type DocumentStatus =
+  | "pending"
+  | "processing"
+  | "ready"
+  | "failed"
+  | "unknown";
+
+export interface DocumentRecord {
+  document_id: string;
+  title: string;
+  source: string;
+  status: DocumentStatus;
+  chunk_count: number;
+  format: string;
+  size_bytes: number | null;
+  metadata: Record<string, unknown>;
+  version: number;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DocumentListResponse {
+  items: DocumentRecord[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface ListDocumentsParams {
+  page?: number;
+  pageSize?: number;
+  status?: DocumentStatus;
+  search?: string;
+  sort?: "created_at" | "updated_at" | "title" | "status";
+  order?: "asc" | "desc";
+}
+
+export interface DocumentUpdateInput {
+  title?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function authedRequest(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const minted = await mintBackendToken();
+  if (!minted) throw new ApiError("Not authenticated", 401);
+
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${minted.token}`);
+  if (init.body && !(init.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const res = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers,
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    let message = res.statusText;
+    let code: string | undefined;
+    try {
+      const body = (await res.clone().json()) as {
+        detail?: string;
+        error?: { code?: string; message?: string };
+      };
+      message = body.error?.message ?? body.detail ?? message;
+      code = body.error?.code;
+    } catch {
+      // ignore — non-JSON body
+    }
+    throw new ApiError(message, res.status, code);
+  }
+
+  return res;
+}
+
+export async function listDocuments(
+  params: ListDocumentsParams = {},
+): Promise<DocumentListResponse> {
+  const search = new URLSearchParams();
+  if (params.page) search.set("page", String(params.page));
+  if (params.pageSize) search.set("page_size", String(params.pageSize));
+  if (params.status) search.set("status", params.status);
+  if (params.search) search.set("search", params.search);
+  if (params.sort) search.set("sort", params.sort);
+  if (params.order) search.set("order", params.order);
+
+  const qs = search.toString();
+  const res = await authedRequest(
+    `/api/v1/documents${qs ? `?${qs}` : ""}`,
+  );
+  return (await res.json()) as DocumentListResponse;
+}
+
+export async function getDocument(id: string): Promise<DocumentRecord> {
+  const res = await authedRequest(
+    `/api/v1/documents/${encodeURIComponent(id)}`,
+  );
+  return (await res.json()) as DocumentRecord;
+}
+
+export async function updateDocument(
+  id: string,
+  input: DocumentUpdateInput,
+): Promise<DocumentRecord> {
+  const res = await authedRequest(
+    `/api/v1/documents/${encodeURIComponent(id)}`,
+    { method: "PATCH", body: JSON.stringify(input) },
+  );
+  return (await res.json()) as DocumentRecord;
+}
+
+export async function deleteDocument(id: string): Promise<void> {
+  await authedRequest(`/api/v1/documents/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function reingestDocument(id: string): Promise<void> {
+  await authedRequest(
+    `/api/v1/documents/${encodeURIComponent(id)}/reingest`,
+    { method: "POST" },
+  );
+}
+
+export async function bulkDeleteDocuments(ids: string[]): Promise<void> {
+  await authedRequest(`/api/v1/documents`, {
+    method: "DELETE",
+    body: JSON.stringify({ ids }),
+  });
+}

--- a/apps/web/lib/api/token.ts
+++ b/apps/web/lib/api/token.ts
@@ -1,0 +1,42 @@
+import { SignJWT } from "jose";
+
+import { auth } from "@/lib/auth";
+
+const ALG = "HS256";
+const TTL_SECONDS = 5 * 60;
+
+/**
+ * Mint a short-lived HS256 JWT for the FastAPI backend, signed with NEXTAUTH_SECRET.
+ *
+ * The backend `_resolve_jwt` only requires a `tenant_id` claim and will reject
+ * tokens without it. Tenant identity is taken from the NextAuth session — never
+ * from client-supplied data — preserving tenant isolation.
+ */
+export async function mintBackendToken(): Promise<{
+  token: string;
+  tenantId: string;
+} | null> {
+  const session = await auth();
+  if (!session?.user?.tenant_id) return null;
+
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      "NEXTAUTH_SECRET is not configured — cannot mint backend token",
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const token = await new SignJWT({
+    tenant_id: session.user.tenant_id,
+    sub: session.user.id,
+    role: session.user.role,
+    email: session.user.email,
+  })
+    .setProtectedHeader({ alg: ALG })
+    .setIssuedAt(now)
+    .setExpirationTime(now + TTL_SECONDS)
+    .sign(new TextEncoder().encode(secret));
+
+  return { token, tenantId: session.user.tenant_id };
+}

--- a/apps/web/lib/validations/document.test.ts
+++ b/apps/web/lib/validations/document.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACCEPTED_EXTENSIONS,
+  documentMetaSchema,
+  isAcceptedExtension,
+  MAX_UPLOAD_BYTES,
+} from "./document";
+
+describe("isAcceptedExtension", () => {
+  it("accepts every documented extension regardless of case", () => {
+    for (const ext of ACCEPTED_EXTENSIONS) {
+      expect(isAcceptedExtension(`a.${ext}`)).toBe(true);
+      expect(isAcceptedExtension(`A.${ext.toUpperCase()}`)).toBe(true);
+    }
+  });
+
+  it("rejects extensions outside the allow list", () => {
+    expect(isAcceptedExtension("malware.exe")).toBe(false);
+    expect(isAcceptedExtension("script.js")).toBe(false);
+    expect(isAcceptedExtension("photo.png")).toBe(false);
+  });
+
+  it("rejects files with no extension", () => {
+    expect(isAcceptedExtension("README")).toBe(false);
+  });
+});
+
+describe("MAX_UPLOAD_BYTES", () => {
+  it("is exactly 50 MB", () => {
+    expect(MAX_UPLOAD_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe("documentMetaSchema", () => {
+  it("requires a title", () => {
+    const result = documentMetaSchema.safeParse({ title: "  " });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects titles longer than 200 chars", () => {
+    const result = documentMetaSchema.safeParse({
+      title: "x".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a title without metadata", () => {
+    const result = documentMetaSchema.safeParse({ title: "Onboarding" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid JSON object metadata", () => {
+    const result = documentMetaSchema.safeParse({
+      title: "Onboarding",
+      metadataJson: '{"tags":["a"]}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid JSON metadata", () => {
+    const result = documentMetaSchema.safeParse({
+      title: "Onboarding",
+      metadataJson: "{not json}",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects JSON arrays for metadata", () => {
+    const result = documentMetaSchema.safeParse({
+      title: "Onboarding",
+      metadataJson: "[1,2,3]",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects JSON primitives for metadata", () => {
+    const result = documentMetaSchema.safeParse({
+      title: "Onboarding",
+      metadataJson: '"a string"',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/lib/validations/document.ts
+++ b/apps/web/lib/validations/document.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export const ACCEPTED_EXTENSIONS = [
+  "pdf",
+  "txt",
+  "md",
+  "markdown",
+  "docx",
+  "doc",
+  "pptx",
+  "ppt",
+  "xlsx",
+  "xls",
+  "html",
+  "htm",
+] as const;
+
+export const ACCEPT_ATTRIBUTE = ACCEPTED_EXTENSIONS.map((e) => `.${e}`).join(
+  ",",
+);
+
+export function isAcceptedExtension(filename: string): boolean {
+  const idx = filename.lastIndexOf(".");
+  if (idx === -1) return false;
+  const ext = filename.slice(idx + 1).toLowerCase();
+  return (ACCEPTED_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+export const documentMetaSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(200, "Title is too long"),
+  metadataJson: z
+    .string()
+    .trim()
+    .optional()
+    .refine(
+      (v) => {
+        if (!v) return true;
+        try {
+          const parsed = JSON.parse(v);
+          return (
+            parsed !== null &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed)
+          );
+        } catch {
+          return false;
+        }
+      },
+      { message: "Must be a valid JSON object" },
+    ),
+});
+
+export type DocumentMetaFormData = z.infer<typeof documentMetaSchema>;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,13 +6,16 @@
     "dev": "next dev --port 3100",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@base-ui/react": "^1.3.0",
+    "@base-ui/react": "^1.4.1",
     "@hookform/resolvers": "^5.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jose": "^6.2.3",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "next-auth": "5.0.0-beta.30",
@@ -37,9 +40,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.3.0
-        version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
@@ -20,6 +20,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
@@ -69,6 +72,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -81,6 +87,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.37)(@vitest/coverage-v8@4.1.5)(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))
 
 packages:
 
@@ -235,9 +244,25 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.3.0':
-    resolution: {integrity: sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==}
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -246,15 +271,9 @@ packages:
       '@types/react':
         optional: true
 
-  '@base-ui/utils@0.2.6':
-    resolution: {integrity: sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==}
-    peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@dotenvx/dotenvx@1.59.1':
     resolution: {integrity: sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w==}
@@ -266,14 +285,23 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -576,6 +604,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.1':
     resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
 
@@ -671,8 +705,109 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -683,6 +818,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -787,6 +925,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -976,6 +1120,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1059,12 +1241,19 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1140,6 +1329,10 @@ packages:
 
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1389,6 +1582,9 @@ packages:
     resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1537,6 +1733,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1560,6 +1759,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
@@ -1653,6 +1856,11 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1780,6 +1988,9 @@ packages:
   hono@4.12.9:
     resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2008,6 +2219,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2016,8 +2239,11 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2189,6 +2415,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2379,6 +2612,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2461,6 +2697,9 @@ packages:
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2486,6 +2725,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -2611,6 +2854,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2704,6 +2952,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2731,9 +2982,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -2826,9 +3083,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tabbable@6.4.0:
-    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -2846,9 +3100,24 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.27:
     resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
@@ -2981,6 +3250,90 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3009,6 +3362,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3081,7 +3439,7 @@ snapshots:
   '@auth/core@0.41.0':
     dependencies:
       '@panva/hkdf': 1.2.1
-      jose: 6.2.2
+      jose: 6.2.3
       oauth4webapi: 3.8.5
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
@@ -3274,20 +3632,19 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/utils': 0.2.11
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@base-ui/utils@0.2.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
@@ -3297,6 +3654,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@dotenvx/dotenvx@1.59.1':
     dependencies:
@@ -3314,9 +3673,20 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -3326,6 +3696,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3570,7 +3945,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.9
-      jose: 6.2.2
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -3592,6 +3967,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -3656,13 +4038,68 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@oxc-project/types@0.127.0': {}
+
   '@panva/hkdf@1.2.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -3749,6 +4186,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3922,6 +4366,62 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@20.19.37)(@vitest/coverage-v8@4.1.5)(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.14(@types/node@20.19.37)(typescript@5.9.3)
+      vite: 8.0.10(@types/node@20.19.37)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4032,11 +4532,19 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -4115,6 +4623,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001781: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4381,6 +4891,8 @@ snapshots:
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4613,6 +5125,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -4649,6 +5165,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
@@ -4778,6 +5296,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -4892,6 +5413,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hono@4.12.9: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -5093,6 +5616,19 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -5104,7 +5640,9 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.2.2: {}
+  jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5241,6 +5779,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -5421,6 +5969,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -5512,6 +6062,8 @@ snapshots:
 
   path-to-regexp@8.4.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -5528,6 +6080,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5660,6 +6218,27 @@ snapshots:
   rettime@0.10.1: {}
 
   reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   router@2.2.0:
     dependencies:
@@ -5862,6 +6441,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5879,7 +6460,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -5987,8 +6572,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tabbable@6.4.0: {}
-
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -5999,10 +6582,21 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.27: {}
 
@@ -6167,6 +6761,46 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@20.19.37)(@vitest/coverage-v8@4.1.5)(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@20.19.37)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.1.1:
@@ -6217,6 +6851,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -336,3 +336,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
Closes #13

## Summary

Adds the document management dashboard surface that customers use to upload, browse, edit, and delete their knowledge-base documents. Drives the existing FastAPI ingestion pipeline through server-side proxy routes that mint short-lived JWTs from the NextAuth session, so `tenant_id` is never trusted from client input.

## What changed

### Pages
- `/dashboard/documents` — server-rendered list (table) with search, status filter, sortable columns (newest, title, status), pagination, and per-row actions
- `/dashboard/documents/[id]` — detail view: status, chunk count, failure reason, RHF + Zod metadata editor; `not-found.tsx` for 404s

### Components (under `components/documents/` and `components/dashboard/`)
- `DocumentUploadDialog` — drag-drop + file picker, multi-file, sequential upload with per-file states (queued / uploading / done / failed), client-side validation
- `DocumentsTable`, `DocumentsToolbar`, `DocumentsPagination`, `DocumentRowActions` (edit / re-ingest / delete with type-the-word confirmation)
- `DocumentEditForm` — React Hook Form + Zod, validates JSON object metadata
- `DocumentStatusBadge` — color-coded status pills
- `DashboardSidebar`, `DashboardTopbar` — minimal shell that should slot into #12's layout when it lands (sidebar nav links: Overview / Bots / Documents / API Keys / Billing / Settings; logout via dropdown)

### API surface
- `POST /api/documents/upload` (multipart proxy → `POST /api/v1/documents/ingest`) — extension + MIME + 50 MB size validation
- `GET|PATCH|DELETE /api/documents/[id]` (proxy → `/api/v1/documents/{id}`)
- `POST /api/documents/[id]/reingest` (proxy → `/api/v1/documents/{id}/reingest`)
- `lib/api/documents.ts` server client with typed list/get/patch/delete/reingest helpers and an `ApiError` class for status-coded errors
- `lib/api/token.ts` mints HS256 JWT signed with `NEXTAUTH_SECRET`, 5-minute TTL, claims pulled from the server-side session only

### Primitives (shadcn-style over `@base-ui/react`)
Badge, Dialog, Table, DropdownMenu, Select, Textarea — styled to diverge from the default shadcn glow per the project anti-slop rules.

### Tests
Vitest harness wired up; 11 unit tests in `lib/validations/document.test.ts` covering extension allow-list (case-insensitive), max-byte constant, and Zod schema (required title, length, valid JSON object metadata, rejection of arrays/primitives/invalid JSON).

### Drive-by
`apps/web/types/supabase.ts` had two stray Supabase CLI banner lines pasted at the end of the file that were breaking `pnpm lint` and `pnpm exec tsc --noEmit`. Removed them.

## Coordination notes
- Issue #18 (doc CRUD API) — wired against the documented endpoint contract; if the backend ships under different field names, only `lib/api/documents.ts` types and the `route.ts` proxies need updating.
- Issue #12 (dashboard layout) — added a minimal sidebar + topbar at `components/dashboard/`. If #12 merges first with a richer shell, prefer #12's components and delete these.
- Issue #19 (URL ingestion) — upload UI is file-only for now; an "Add URL" tab can be slotted into `DocumentUploadDialog` once the endpoint is live.

## Test plan
- [ ] `pnpm lint` clean
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] `pnpm build` produces all expected routes
- [ ] `pnpm test` — 11/11 passing
- [ ] Manual: upload PDF/DOCX/MD, watch list refresh, edit title + metadata, delete with type-to-confirm, re-ingest a failed doc
- [ ] Verify backend rejects requests when NextAuth session is missing (401)
- [ ] Verify oversized file (>50 MB) rejected at the proxy without hitting FastAPI