### PR TITLE
feat(web): billing and plan management UI

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/billing/_components/checkout-status-banner.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/checkout-status-banner.tsx
@@ -1,0 +1,37 @@
+import { CheckCircle2, XCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export function CheckoutStatusBanner({ status }: { status: "success" | "cancelled" }) {
+  const success = status === "success";
+  const Icon = success ? CheckCircle2 : XCircle;
+  const title = success ? "Payment received" : "Checkout cancelled";
+  const message = success
+    ? "Thanks — your subscription is being activated. It can take a moment to reflect here while we sync with Stripe."
+    : "No charge was made. You can pick a different plan or model tier whenever you're ready.";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-3 rounded-md border px-3 py-2.5 text-[0.82rem]",
+        success
+          ? "border-foreground/20 bg-foreground/5 text-foreground"
+          : "border-border bg-muted/40 text-muted-foreground",
+      )}
+    >
+      <Icon
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          success ? "text-foreground" : "text-muted-foreground",
+        )}
+        aria-hidden="true"
+      />
+      <div className="flex flex-col gap-0.5">
+        <span className="font-medium text-foreground">{title}</span>
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/_components/current-plan-card.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/current-plan-card.tsx
@@ -1,0 +1,113 @@
+import { CalendarClock, ShieldCheck } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { PlanTier, UsageResponse } from "@/lib/billing";
+
+const PLAN_LABELS: Record<PlanTier, string> = {
+  free: "Free",
+  starter: "Starter",
+  pro: "Pro",
+  enterprise: "Enterprise",
+};
+
+function formatDate(value: string): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function CurrentPlanCard({
+  usage,
+  loadError,
+}: {
+  usage: UsageResponse | null;
+  loadError: string | null;
+}) {
+  const plan = usage?.plan ?? "free";
+  const label = PLAN_LABELS[plan];
+  const renewal = usage ? formatDate(usage.period_end) : null;
+
+  return (
+    <section
+      aria-labelledby="current-plan-heading"
+      className={cn(
+        "relative flex flex-col gap-4 overflow-hidden rounded-xl border border-border bg-card p-5 text-card-foreground",
+        "before:absolute before:inset-x-5 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-foreground/15 before:to-transparent",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <p
+            id="current-plan-heading"
+            className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase"
+          >
+            Current plan
+          </p>
+          <h2 className="font-heading text-2xl font-semibold tracking-tight text-foreground">
+            {label}
+          </h2>
+        </div>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[0.72rem] font-medium",
+            plan === "free"
+              ? "border-border bg-muted text-muted-foreground"
+              : "border-foreground/15 bg-foreground/5 text-foreground",
+          )}
+        >
+          <ShieldCheck className="size-3" aria-hidden="true" />
+          {plan === "free" ? "No card on file" : "Active"}
+        </span>
+      </div>
+
+      {loadError ? (
+        <p
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[0.78rem] text-destructive"
+        >
+          {loadError}
+        </p>
+      ) : (
+        <dl className="grid gap-3 sm:grid-cols-2">
+          <div className="flex flex-col gap-0.5">
+            <dt className="text-[0.72rem] font-medium uppercase tracking-wide text-muted-foreground">
+              Renewal
+            </dt>
+            <dd className="flex items-center gap-1.5 text-[0.85rem] text-foreground">
+              <CalendarClock
+                className="size-3.5 text-muted-foreground"
+                aria-hidden="true"
+              />
+              {renewal ? (
+                <>
+                  {renewal}
+                  {plan === "free" ? (
+                    <span className="text-muted-foreground">
+                      &nbsp;· no charge
+                    </span>
+                  ) : null}
+                </>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <dt className="text-[0.72rem] font-medium uppercase tracking-wide text-muted-foreground">
+              Rate limit
+            </dt>
+            <dd className="text-[0.85rem] text-foreground tabular-nums">
+              {usage ? `${usage.rate_limit_per_minute} req / min` : "—"}
+            </dd>
+          </div>
+        </dl>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/_components/plan-card.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/plan-card.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ModelTier, PlanInfo, PlanTier } from "@/lib/billing";
+
+import { UpgradeButton } from "./upgrade-button";
+
+type PriceMap = Partial<Record<ModelTier, number>>;
+
+type Props = {
+  plan: PlanInfo;
+  prices: PriceMap;
+  modelTiers: ModelTier[];
+  modelLabels: Record<ModelTier, string>;
+  current: boolean;
+  highlight?: boolean;
+  description: string;
+};
+
+const numberFmt = new Intl.NumberFormat("en-US");
+
+const PLAN_LABELS: Record<PlanTier, string> = {
+  free: "Free",
+  starter: "Starter",
+  pro: "Pro",
+  enterprise: "Enterprise",
+};
+
+function formatPrice(cents: number | undefined): string {
+  if (typeof cents !== "number") return "—";
+  const dollars = cents / 100;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: dollars % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 2,
+  }).format(dollars);
+}
+
+export function PlanCard({
+  plan,
+  prices,
+  modelTiers,
+  modelLabels,
+  current,
+  highlight = false,
+  description,
+}: Props) {
+  const tiersWithPrice = modelTiers.filter((t) => typeof prices[t] === "number");
+  const initial = tiersWithPrice[0] ?? "standard";
+  const [selectedTier, setSelectedTier] = useState<ModelTier>(initial);
+
+  const purchaseable = plan.plan === "pro" || plan.plan === "enterprise";
+  const price = prices[selectedTier];
+
+  return (
+    <article
+      className={cn(
+        "relative flex h-full flex-col gap-4 rounded-xl border bg-card p-5 text-card-foreground",
+        highlight
+          ? "border-foreground/40 ring-1 ring-foreground/15"
+          : "border-border",
+      )}
+    >
+      {highlight ? (
+        <span className="absolute -top-2 right-4 rounded-full bg-foreground px-2 py-0.5 font-mono text-[0.65rem] uppercase tracking-[0.18em] text-background">
+          Recommended
+        </span>
+      ) : null}
+
+      <header className="flex flex-col gap-1">
+        <h3 className="font-heading text-lg font-semibold tracking-tight">
+          {PLAN_LABELS[plan.plan]}
+        </h3>
+        <p className="text-[0.78rem] text-muted-foreground">{description}</p>
+      </header>
+
+      <div className="flex items-baseline gap-1">
+        <span className="font-heading text-3xl font-semibold tabular-nums">
+          {purchaseable ? formatPrice(price) : "Free"}
+        </span>
+        {purchaseable ? (
+          <span className="text-[0.78rem] text-muted-foreground">/ month</span>
+        ) : null}
+      </div>
+
+      {purchaseable && tiersWithPrice.length > 0 ? (
+        <fieldset className="flex flex-col gap-1.5">
+          <legend className="text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
+            Model tier
+          </legend>
+          <div
+            role="radiogroup"
+            aria-label="Model tier"
+            className="grid grid-cols-2 gap-1.5"
+          >
+            {tiersWithPrice.map((tier) => {
+              const active = selectedTier === tier;
+              return (
+                <button
+                  key={tier}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => setSelectedTier(tier)}
+                  className={cn(
+                    "rounded-md border px-2.5 py-1.5 text-left text-[0.78rem] transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    active
+                      ? "border-foreground/40 bg-foreground/5 text-foreground"
+                      : "border-border bg-background text-muted-foreground hover:border-foreground/20 hover:text-foreground",
+                  )}
+                >
+                  <span className="block font-medium capitalize">
+                    {modelLabels[tier] ?? tier}
+                  </span>
+                  <span className="block font-mono text-[0.7rem] tabular-nums text-muted-foreground">
+                    {formatPrice(prices[tier])}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+      ) : null}
+
+      <ul className="flex flex-col gap-1.5 border-t border-border pt-4 text-[0.82rem]">
+        <Feature text={`${numberFmt.format(plan.limits.queries_per_month)} queries / month`} />
+        <Feature text={`${numberFmt.format(plan.limits.documents)} documents`} />
+        <Feature text={`${numberFmt.format(plan.limits.bots)} bots`} />
+      </ul>
+
+      <div className="mt-auto pt-2">
+        {current ? (
+          <span className="block w-full rounded-md border border-border bg-muted/40 px-3 py-2 text-center text-[0.8rem] font-medium text-muted-foreground">
+            Current plan
+          </span>
+        ) : purchaseable ? (
+          <UpgradeButton
+            plan={plan.plan}
+            modelTier={selectedTier}
+            label={`Upgrade to ${PLAN_LABELS[plan.plan]}`}
+            variant={highlight ? "default" : "outline"}
+            className="w-full"
+          />
+        ) : (
+          <span className="block w-full rounded-md border border-border bg-muted/40 px-3 py-2 text-center text-[0.8rem] font-medium text-muted-foreground">
+            Default tier
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function Feature({ text }: { text: string }) {
+  return (
+    <li className="flex items-start gap-2 text-foreground">
+      <Check
+        className="mt-0.5 size-3.5 text-foreground/70"
+        aria-hidden="true"
+      />
+      <span>{text}</span>
+    </li>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/_components/upgrade-button.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/upgrade-button.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+import { startCheckoutAction } from "../actions";
+import type { ModelTier, PlanTier } from "@/lib/billing";
+
+type Props = {
+  plan: PlanTier;
+  modelTier: ModelTier;
+  label: string;
+  variant?: "default" | "outline" | "secondary";
+  disabled?: boolean;
+  className?: string;
+};
+
+export function UpgradeButton({
+  plan,
+  modelTier,
+  label,
+  variant = "default",
+  disabled = false,
+  className,
+}: Props) {
+  const [pending, startTransition] = useTransition();
+  const [submitted, setSubmitted] = useState(false);
+
+  function onClick() {
+    if (pending || submitted) return;
+    setSubmitted(true);
+    startTransition(async () => {
+      const result = await startCheckoutAction({ plan, model_tier: modelTier });
+      if (!result.ok) {
+        setSubmitted(false);
+        toast.error(result.error);
+        return;
+      }
+      // Full-page navigation to Stripe-hosted checkout.
+      window.location.assign(result.checkout_url);
+    });
+  }
+
+  const busy = pending || submitted;
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      onClick={onClick}
+      disabled={disabled || busy}
+      aria-busy={busy}
+      className={className}
+    >
+      {busy ? (
+        <>
+          <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+          Redirecting…
+        </>
+      ) : (
+        label
+      )}
+    </Button>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/_components/usage-panel.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/usage-panel.tsx
@@ -1,0 +1,72 @@
+import type { UsageResponse } from "@/lib/billing";
+
+import { UsageRow } from "./usage-row";
+
+export function UsagePanel({
+  usage,
+  loadError,
+}: {
+  usage: UsageResponse | null;
+  loadError: string | null;
+}) {
+  return (
+    <section
+      aria-labelledby="usage-heading"
+      className="flex flex-col gap-4 rounded-xl border border-border bg-card p-5 text-card-foreground"
+    >
+      <header className="flex flex-col gap-1">
+        <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+          This period
+        </p>
+        <h2
+          id="usage-heading"
+          className="font-heading text-base font-medium tracking-tight"
+        >
+          Usage vs. plan limits
+        </h2>
+      </header>
+
+      {loadError || !usage ? (
+        <p
+          role="status"
+          className="rounded-md border border-border bg-muted/40 px-3 py-2 text-[0.78rem] text-muted-foreground"
+        >
+          {loadError ?? "Usage data is not available right now."}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <UsageRow
+            label="Queries"
+            used={usage.queries.used}
+            limit={usage.queries.limit}
+            warning={usage.queries.warning}
+            blocked={usage.queries.blocked}
+            unit="this month"
+          />
+          <UsageRow
+            label="Documents"
+            used={usage.documents.used}
+            limit={usage.documents.limit}
+            warning={usage.documents.warning}
+            blocked={usage.documents.blocked}
+          />
+          <UsageRow
+            label="Chunks"
+            used={usage.chunks.used}
+            limit={usage.chunks.limit}
+            warning={usage.chunks.warning}
+            blocked={usage.chunks.blocked}
+          />
+          <UsageRow
+            label="Embedding tokens"
+            used={usage.embedding_tokens.used}
+            limit={usage.embedding_tokens.limit}
+            warning={usage.embedding_tokens.warning}
+            blocked={usage.embedding_tokens.blocked}
+            unit="this month"
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/_components/usage-row.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/_components/usage-row.tsx
@@ -1,0 +1,79 @@
+import { cn } from "@/lib/utils";
+
+const numberFmt = new Intl.NumberFormat("en-US");
+
+function formatPercent(percent: number): string {
+  return `${Math.min(100, Math.round(percent * 100))}%`;
+}
+
+export function UsageRow({
+  label,
+  used,
+  limit,
+  warning,
+  blocked,
+  unit,
+}: {
+  label: string;
+  used: number;
+  limit: number;
+  warning: boolean;
+  blocked: boolean;
+  unit?: string;
+}) {
+  const safeLimit = Math.max(limit, 1);
+  const pct = Math.min(100, Math.round((used / safeLimit) * 100));
+  const tone = blocked
+    ? "bg-destructive"
+    : warning
+      ? "bg-amber-500"
+      : "bg-foreground";
+
+  const status = blocked
+    ? "Limit reached"
+    : warning
+      ? "Approaching limit"
+      : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-[0.85rem] font-medium text-foreground">
+          {label}
+        </span>
+        <span className="font-mono text-[0.78rem] tabular-nums text-muted-foreground">
+          {numberFmt.format(used)}
+          <span className="px-1 text-muted-foreground/60">/</span>
+          {numberFmt.format(limit)}
+          {unit ? <span className="ml-1 text-muted-foreground/70">{unit}</span> : null}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={`${label} usage`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+      >
+        <div
+          className={cn("h-full rounded-full transition-[width]", tone)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between text-[0.72rem] text-muted-foreground">
+        <span className="tabular-nums">{formatPercent(used / safeLimit)}</span>
+        {status ? (
+          <span
+            className={cn(
+              "font-medium",
+              blocked ? "text-destructive" : "text-amber-600 dark:text-amber-500",
+            )}
+          >
+            {status}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/billing/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { ApiError } from "@/lib/api-client";
+import { createCheckoutSession } from "@/lib/billing";
+import { checkoutInputSchema } from "@/lib/validations/billing";
+
+export type StartCheckoutResult =
+  | { ok: true; checkout_url: string }
+  | { ok: false; error: string };
+
+/**
+ * Build redirect URLs from the server-controlled NEXTAUTH_URL so a malicious
+ * client cannot make Stripe redirect to an attacker-controlled domain.
+ */
+function buildRedirectUrls(): { success_url: string; cancel_url: string } {
+  const origin = process.env.NEXTAUTH_URL;
+  if (!origin) {
+    throw new Error("NEXTAUTH_URL is not configured");
+  }
+  // Trim trailing slashes for predictable concatenation.
+  const base = origin.replace(/\/+$/, "");
+  return {
+    success_url: `${base}/dashboard/billing?status=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${base}/dashboard/billing?status=cancelled`,
+  };
+}
+
+export async function startCheckoutAction(
+  input: unknown,
+): Promise<StartCheckoutResult> {
+  const parsed = checkoutInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+
+  let urls: { success_url: string; cancel_url: string };
+  try {
+    urls = buildRedirectUrls();
+  } catch {
+    return {
+      ok: false,
+      error: "Checkout is not configured. Please contact support.",
+    };
+  }
+
+  try {
+    const session = await createCheckoutSession({
+      plan: parsed.data.plan,
+      model_tier: parsed.data.model_tier,
+      success_url: urls.success_url,
+      cancel_url: urls.cancel_url,
+    });
+    return { ok: true, checkout_url: session.checkout_url };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      // 503 = Stripe not configured. Surface a friendlier message.
+      if (err.status === 503) {
+        return {
+          ok: false,
+          error: "Billing is temporarily unavailable. Please try again later.",
+        };
+      }
+      return { ok: false, error: err.message };
+    }
+    return { ok: false, error: "Could not start checkout. Please try again." };
+  }
+}

--- a/apps/web/app/(dashboard)/dashboard/billing/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/billing/page.tsx
@@ -1,0 +1,214 @@
+import type { Metadata } from "next";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  getPlans,
+  getUsage,
+  type ModelTier,
+  type PlanInfo,
+  type PlansResponse,
+  type UsageResponse,
+} from "@/lib/billing";
+
+import { CheckoutStatusBanner } from "./_components/checkout-status-banner";
+import { CurrentPlanCard } from "./_components/current-plan-card";
+import { PlanCard } from "./_components/plan-card";
+import { UsagePanel } from "./_components/usage-panel";
+
+export const metadata: Metadata = {
+  title: "Billing — MongoRAG",
+  description:
+    "View your current plan, monthly usage, and upgrade your MongoRAG subscription.",
+};
+
+// JWT minted server-side per request, never cache.
+export const dynamic = "force-dynamic";
+
+const MODEL_TIER_ORDER: ModelTier[] = ["starter", "standard", "premium", "ultra"];
+const MODEL_TIER_LABELS: Record<ModelTier, string> = {
+  starter: "Starter",
+  standard: "Standard",
+  premium: "Premium",
+  ultra: "Ultra",
+};
+
+type LoadResult = {
+  plans: PlansResponse | null;
+  usage: UsageResponse | null;
+  plansError: string | null;
+  usageError: string | null;
+};
+
+async function loadBillingData(): Promise<LoadResult> {
+  const [plansResult, usageResult] = await Promise.allSettled([
+    getPlans(),
+    getUsage(),
+  ]);
+  const plans = plansResult.status === "fulfilled" ? plansResult.value : null;
+  const usage = usageResult.status === "fulfilled" ? usageResult.value : null;
+
+  const plansError =
+    plansResult.status === "rejected"
+      ? plansResult.reason instanceof ApiError
+        ? plansResult.reason.message
+        : "Could not load pricing right now."
+      : null;
+  const usageError =
+    usageResult.status === "rejected"
+      ? usageResult.reason instanceof ApiError
+        ? usageResult.reason.message
+        : "Could not load usage data right now."
+      : null;
+
+  return { plans, usage, plansError, usageError };
+}
+
+function buildPriceMap(
+  modelTiers: PlansResponse["model_tiers"],
+  plan: "pro" | "enterprise",
+): Partial<Record<ModelTier, number>> {
+  const map: Partial<Record<ModelTier, number>> = {};
+  for (const t of modelTiers) {
+    const cents = plan === "pro" ? t.pro_price_cents : t.enterprise_price_cents;
+    if (typeof cents === "number") {
+      map[t.tier] = cents;
+    }
+  }
+  return map;
+}
+
+function findPlan(plans: PlanInfo[], target: PlanInfo["plan"]): PlanInfo | undefined {
+  return plans.find((p) => p.plan === target);
+}
+
+export default async function BillingPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const rawStatus = Array.isArray(params.status) ? params.status[0] : params.status;
+  const checkoutStatus =
+    rawStatus === "success" || rawStatus === "cancelled" ? rawStatus : null;
+
+  const { plans, usage, plansError, usageError } = await loadBillingData();
+  const currentPlan = usage?.plan ?? "free";
+
+  const free = plans ? findPlan(plans.plans, "free") : undefined;
+  const pro = plans ? findPlan(plans.plans, "pro") : undefined;
+  const enterprise = plans ? findPlan(plans.plans, "enterprise") : undefined;
+
+  const proPrices = plans ? buildPriceMap(plans.model_tiers, "pro") : {};
+  const enterprisePrices = plans
+    ? buildPriceMap(plans.model_tiers, "enterprise")
+    : {};
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-2 py-2">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+            Plans &amp; usage
+          </p>
+          <h1 className="font-heading text-2xl leading-tight font-medium tracking-tight">
+            Billing
+          </h1>
+          <p className="max-w-xl text-sm text-muted-foreground">
+            Track your monthly usage against plan limits and upgrade when you
+            need more headroom. Payments and cancellations are handled by
+            Stripe.
+          </p>
+        </div>
+      </header>
+
+      {checkoutStatus ? <CheckoutStatusBanner status={checkoutStatus} /> : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <CurrentPlanCard usage={usage} loadError={usageError} />
+        <UsagePanel usage={usage} loadError={usageError} />
+      </div>
+
+      <section
+        aria-labelledby="plans-heading"
+        className="flex flex-col gap-4"
+      >
+        <div className="flex flex-col gap-1">
+          <h2
+            id="plans-heading"
+            className="font-heading text-base font-medium tracking-tight"
+          >
+            Compare plans
+          </h2>
+          <p className="text-[0.82rem] text-muted-foreground">
+            Pick the plan and model tier that fits your workload. You can
+            change tiers any time from this page.
+          </p>
+        </div>
+
+        {plansError ? (
+          <p
+            role="alert"
+            className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[0.82rem] text-destructive"
+          >
+            {plansError}
+          </p>
+        ) : plans && free && pro && enterprise ? (
+          <div className="grid gap-4 md:grid-cols-3">
+            <PlanCard
+              plan={free}
+              prices={{}}
+              modelTiers={MODEL_TIER_ORDER}
+              modelLabels={MODEL_TIER_LABELS}
+              current={currentPlan === "free"}
+              description="Try MongoRAG with light usage and a single bot."
+            />
+            <PlanCard
+              plan={pro}
+              prices={proPrices}
+              modelTiers={MODEL_TIER_ORDER}
+              modelLabels={MODEL_TIER_LABELS}
+              current={currentPlan === "pro"}
+              highlight
+              description="For growing teams shipping production assistants."
+            />
+            <PlanCard
+              plan={enterprise}
+              prices={enterprisePrices}
+              modelTiers={MODEL_TIER_ORDER}
+              modelLabels={MODEL_TIER_LABELS}
+              current={currentPlan === "enterprise"}
+              description="High volume, premium models, and white-glove support."
+            />
+          </div>
+        ) : (
+          <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-[0.82rem] text-muted-foreground">
+            Pricing is unavailable right now.
+          </p>
+        )}
+      </section>
+
+      <section
+        aria-labelledby="billing-mgmt-heading"
+        className="flex flex-col gap-2 rounded-xl border border-dashed border-border bg-muted/20 p-5"
+      >
+        <h2
+          id="billing-mgmt-heading"
+          className="font-heading text-base font-medium tracking-tight"
+        >
+          Manage billing
+        </h2>
+        <p className="text-[0.82rem] text-muted-foreground">
+          To update your payment method, download invoices, or cancel your
+          subscription, contact{" "}
+          <a
+            href="mailto:billing@mongorag.com"
+            className="text-foreground underline-offset-4 hover:underline"
+          >
+            billing@mongorag.com
+          </a>
+          . Self-service customer portal is coming soon.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -1,0 +1,88 @@
+/**
+ * Typed client for the FastAPI /api/v1/billing and /api/v1/usage endpoints.
+ *
+ * Server-only — apiFetch mints a backend JWT, so these helpers must never
+ * run in the browser. Use them from Server Components or Server Actions.
+ */
+
+import "server-only";
+
+import { apiFetch } from "@/lib/api-client";
+
+export type PlanTier = "free" | "starter" | "pro" | "enterprise";
+export type ModelTier = "starter" | "standard" | "premium" | "ultra";
+
+export interface ModelInfo {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+export interface ModelTierInfo {
+  tier: ModelTier;
+  pro_price_cents: number | null;
+  enterprise_price_cents: number | null;
+  models: ModelInfo[];
+}
+
+export interface PlanLimitsInfo {
+  queries_per_month: number;
+  documents: number;
+  bots: number;
+}
+
+export interface PlanInfo {
+  plan: PlanTier;
+  limits: PlanLimitsInfo;
+}
+
+export interface PlansResponse {
+  plans: PlanInfo[];
+  model_tiers: ModelTierInfo[];
+}
+
+export interface UsageMetric {
+  used: number;
+  limit: number;
+  percent: number;
+  warning: boolean;
+  blocked: boolean;
+}
+
+export interface UsageResponse {
+  tenant_id: string;
+  plan: PlanTier;
+  period_key: string;
+  period_start: string;
+  period_end: string;
+  queries: UsageMetric;
+  documents: UsageMetric;
+  chunks: UsageMetric;
+  embedding_tokens: UsageMetric;
+  rate_limit_per_minute: number;
+}
+
+export interface CheckoutSession {
+  checkout_url: string;
+  session_id: string;
+}
+
+export async function getPlans(): Promise<PlansResponse> {
+  return apiFetch<PlansResponse>("/api/v1/billing/plans");
+}
+
+export async function getUsage(): Promise<UsageResponse> {
+  return apiFetch<UsageResponse>("/api/v1/usage");
+}
+
+export async function createCheckoutSession(input: {
+  plan: PlanTier;
+  model_tier: ModelTier;
+  success_url: string;
+  cancel_url: string;
+}): Promise<CheckoutSession> {
+  return apiFetch<CheckoutSession>("/api/v1/billing/checkout", {
+    method: "POST",
+    body: input,
+  });
+}

--- a/apps/web/lib/validations/billing.test.ts
+++ b/apps/web/lib/validations/billing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { CHECKOUT_PLAN_TIERS, checkoutInputSchema } from "./billing";
+
+describe("checkoutInputSchema", () => {
+  it("accepts pro + standard", () => {
+    const result = checkoutInputSchema.safeParse({
+      plan: "pro",
+      model_tier: "standard",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts enterprise + ultra", () => {
+    const result = checkoutInputSchema.safeParse({
+      plan: "enterprise",
+      model_tier: "ultra",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects free as a checkout plan", () => {
+    const result = checkoutInputSchema.safeParse({
+      plan: "free",
+      model_tier: "starter",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects starter as a checkout plan", () => {
+    // starter is a tenant plan but not purchaseable via Checkout.
+    const result = checkoutInputSchema.safeParse({
+      plan: "starter",
+      model_tier: "standard",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown model tiers", () => {
+    const result = checkoutInputSchema.safeParse({
+      plan: "pro",
+      model_tier: "infinite",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("only purchaseable plans appear in CHECKOUT_PLAN_TIERS", () => {
+    expect(CHECKOUT_PLAN_TIERS).toEqual(["pro", "enterprise"]);
+  });
+});

--- a/apps/web/lib/validations/billing.ts
+++ b/apps/web/lib/validations/billing.ts
@@ -1,0 +1,17 @@
+import { z } from "zod/v3";
+
+export const PLAN_TIERS = ["free", "starter", "pro", "enterprise"] as const;
+export const MODEL_TIERS = ["starter", "standard", "premium", "ultra"] as const;
+
+export const CHECKOUT_PLAN_TIERS = ["pro", "enterprise"] as const;
+
+export const checkoutInputSchema = z.object({
+  plan: z.enum(CHECKOUT_PLAN_TIERS, {
+    errorMap: () => ({ message: "Plan must be 'pro' or 'enterprise'" }),
+  }),
+  model_tier: z.enum(MODEL_TIERS, {
+    errorMap: () => ({ message: "Invalid model tier" }),
+  }),
+});
+
+export type CheckoutInput = z.infer<typeof checkoutInputSchema>;


### PR DESCRIPTION
Closes #15

## Summary

Adds the dashboard billing page so tenants can see their current plan, monthly usage vs. limits, and upgrade via Stripe Checkout.

- `/dashboard/billing` server component fetches `/api/v1/usage` and `/api/v1/billing/plans` in parallel
- Three plan cards (Free / Pro / Enterprise) with per-card model-tier picker (Starter / Standard / Premium / Ultra) and live prices from the public catalog
- Server action `startCheckoutAction` validates input with Zod, derives success/cancel URLs from `NEXTAUTH_URL` server-side, then calls `POST /api/v1/billing/checkout`
- Usage panel renders queries/documents/chunks/embedding-tokens with warning + blocked tones from the metering service
- `?status=success` and `?status=cancelled` query params surface a return-from-Stripe banner
- Manage-billing card points to support email until the customer portal endpoint lands (#43-adjacent work)

## Security notes

- Stripe secrets stay server-side. The browser only ever sees the catalog and is redirected to a Stripe-hosted Checkout URL.
- Success/cancel URLs are built from `NEXTAUTH_URL` on the server, not from user-supplied input — closes the open-redirect vector even though the API also validates.
- All API access uses the existing `api-client` `apiFetch` helper (short-lived HS256 JWT, `tenant_id` from session — never trusted from client).
- `dynamic = "force-dynamic"` keeps the page from caching tenant data.

## Test plan

- [x] `pnpm test` (vitest) — Zod schema unit tests pass (17 tests)
- [x] `pnpm lint` clean
- [x] `pnpm build` clean (Next.js 16 / Turbopack, Route appears in build manifest)
- [ ] Manual: visit `/dashboard/billing`, see current plan + usage; click Upgrade → land on Stripe Checkout (test mode)
- [ ] Manual: cancel from Stripe → returns to `/dashboard/billing?status=cancelled` and shows banner
- [ ] Manual: complete checkout → returns to `?status=success` banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)