### PR TITLE
feat(widget): build embeddable chat widget

### DIFF
--- a/packages/widget/.gitignore
+++ b/packages/widget/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/packages/widget/demo/index.html
+++ b/packages/widget/demo/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MongoRAG Widget — Demo Host</title>
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        background: #f1f5f9;
+        color: #0f172a;
+      }
+      main { max-width: 720px; margin: 0 auto; padding: 64px 24px; }
+      h1 { font-size: 28px; letter-spacing: -0.02em; }
+      p { color: #475569; line-height: 1.6; }
+      code {
+        background: #e2e8f0;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>MongoRAG Widget Demo</h1>
+      <p>
+        This page exists only to manually verify the widget. Set
+        <code>data-api-key</code> and <code>data-api-url</code> to point at a
+        running MongoRAG API and you should see the chat launcher in the
+        bottom-right corner.
+      </p>
+      <p>
+        Test plan: open the widget, send a message, confirm tokens stream in
+        and the conversation_id persists across page reloads.
+      </p>
+    </main>
+
+    <!-- Replace with a real key + URL when manually testing. -->
+    <script
+      src="../dist/widget.js"
+      data-api-key="mrag_demoreplaceme"
+      data-api-url="http://localhost:8100"
+      data-bot-name="DemoBot"
+      data-primary-color="#0f172a"
+      data-position="bottom-right"
+    ></script>
+  </body>
+</html>

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -4,11 +4,17 @@
   "description": "Embeddable chat widget for MongoRAG",
   "main": "dist/widget.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --minify --outfile=dist/widget.js --format=iife --target=es2020",
-    "dev": "esbuild src/index.ts --bundle --outfile=dist/widget.js --format=iife --target=es2020 --watch"
+    "build": "esbuild src/index.ts --bundle --minify --outfile=dist/widget.js --format=iife --target=es2020 --legal-comments=none",
+    "dev": "esbuild src/index.ts --bundle --outfile=dist/widget.js --format=iife --target=es2020 --watch --servedir=demo",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^22.10.0",
     "esbuild": "^0.24.0",
-    "typescript": "^5.7.0"
+    "happy-dom": "^15.11.7",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/widget/pnpm-lock.yaml
+++ b/packages/widget/pnpm-lock.yaml
@@ -8,14 +8,29 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)
 
 packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -23,10 +38,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.24.2':
     resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.24.2':
@@ -35,16 +62,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.24.2':
     resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.24.2':
     resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.24.2':
@@ -53,10 +98,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.24.2':
     resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.24.2':
@@ -65,10 +122,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.24.2':
     resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.24.2':
@@ -77,10 +146,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.24.2':
     resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.24.2':
@@ -89,10 +170,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.24.2':
     resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.24.2':
@@ -101,16 +194,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.24.2':
     resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.24.2':
     resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.24.2':
@@ -125,6 +236,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.24.2':
     resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
     engines: {node: '>=18'}
@@ -137,11 +254,23 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.24.2':
     resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.24.2':
     resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
@@ -149,10 +278,22 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.24.2':
     resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.24.2':
@@ -161,70 +302,501 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.24.2':
     resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.24.2':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.24.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.24.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.24.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.24.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.24.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.24.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.24.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.24.2':
@@ -233,26 +805,217 @@ snapshots:
   '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.24.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/openbsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
     optional: true
 
   '@esbuild/sunos-x64@0.24.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
   '@esbuild/win32-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
     optional: true
 
   '@esbuild/win32-ia32@0.24.2':
     optional: true
 
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
   '@esbuild/win32-x64@0.24.2':
     optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  entities@4.5.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.24.2:
     optionalDependencies:
@@ -282,4 +1045,164 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
   typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.12
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/packages/widget/src/api.ts
+++ b/packages/widget/src/api.ts
@@ -1,0 +1,138 @@
+/**
+ * Backend client for the chat widget.
+ *
+ * Uses fetch + ReadableStream to consume the FastAPI Server-Sent-Events
+ * endpoint at POST /api/v1/chat (Accept: text/event-stream).
+ *
+ * Auth: `Authorization: Bearer <apiKey>` per src/core/tenant.py.
+ */
+
+import type { SSEEvent } from "./types.js";
+
+export interface ChatRequestBody {
+  message: string;
+  conversation_id?: string;
+  search_type?: "hybrid" | "semantic" | "text";
+}
+
+export function buildAuthHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+  };
+}
+
+export interface StreamOptions {
+  apiUrl: string;
+  apiKey: string;
+  body: ChatRequestBody;
+  signal?: AbortSignal;
+}
+
+export interface StreamResult {
+  ok: boolean;
+  status: number;
+  events: AsyncIterable<SSEEvent>;
+}
+
+export async function startChatStream(opts: StreamOptions): Promise<StreamResult> {
+  const url = `${opts.apiUrl}/api/v1/chat`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: buildAuthHeaders(opts.apiKey),
+    body: JSON.stringify(opts.body),
+    credentials: "omit",
+    mode: "cors",
+    ...(opts.signal ? { signal: opts.signal } : {}),
+  });
+
+  if (!response.ok || !response.body) {
+    return {
+      ok: false,
+      status: response.status,
+      events: emptyAsyncIterable(),
+    };
+  }
+
+  return {
+    ok: true,
+    status: response.status,
+    events: parseSSE(response.body),
+  };
+}
+
+async function* emptyAsyncIterable(): AsyncIterable<SSEEvent> {
+  // Empty generator.
+}
+
+/**
+ * Parse a Server-Sent-Events stream into typed events.
+ *
+ * Handles UTF-8 decoding, multi-line messages, and partial chunks.
+ * Only supports `data:` lines; other SSE fields are ignored.
+ */
+export async function* parseSSE(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SSEEvent, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep: number;
+      // Events are separated by a blank line (\n\n).
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const rawEvent = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        const data = extractData(rawEvent);
+        if (data === null) continue;
+        const parsed = tryParseJson(data);
+        if (parsed) yield parsed;
+      }
+    }
+    // Drain any final event without trailing blank line.
+    const tail = buffer.trim();
+    if (tail) {
+      const data = extractData(tail);
+      if (data !== null) {
+        const parsed = tryParseJson(data);
+        if (parsed) yield parsed;
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function extractData(rawEvent: string): string | null {
+  const lines = rawEvent.split("\n");
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).replace(/^ /, ""));
+    }
+  }
+  if (dataLines.length === 0) return null;
+  return dataLines.join("\n");
+}
+
+function tryParseJson(text: string): SSEEvent | null {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && typeof parsed.type === "string") {
+      return parsed as SSEEvent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/widget/src/config.ts
+++ b/packages/widget/src/config.ts
@@ -1,0 +1,132 @@
+/**
+ * Configuration parsing for the embeddable widget.
+ *
+ * Sources, in priority order:
+ *   1. window.MongoRAG  (explicit JS config)
+ *   2. data-* attributes on the loading <script> tag
+ *
+ * Validation:
+ *   - apiKey must be present and start with "mrag_"
+ *   - apiUrl must be http(s); defaults to https://api.mongorag.com
+ *   - position is whitelisted to prevent CSS injection
+ *   - primaryColor is whitelisted to a safe regex (#hex or rgb(a))
+ */
+
+import type { Position, WidgetConfig } from "./types.js";
+
+const DEFAULT_API_URL = "https://api.mongorag.com";
+const DEFAULT_PRIMARY_COLOR = "#0f172a";
+const SAFE_COLOR = /^(#[0-9a-fA-F]{3,8}|rgb\([\d,\s]+\)|rgba\([\d,.\s]+\))$/;
+const ALLOWED_POSITIONS: ReadonlySet<Position> = new Set(["bottom-right", "bottom-left"]);
+// Strip C0 controls (0x00-0x1F) and DEL (0x7F).
+const CONTROL_CHARS = /[\x00-\x1F\x7F]/g;
+
+export interface RawConfigInput {
+  apiKey?: string;
+  apiUrl?: string;
+  botId?: string;
+  primaryColor?: string;
+  botName?: string;
+  welcomeMessage?: string;
+  position?: string;
+  showBranding?: boolean | string;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+export function parseScriptDataset(script: HTMLScriptElement): RawConfigInput {
+  const ds = script.dataset;
+  const out: RawConfigInput = {
+    apiKey: ds.apiKey,
+    apiUrl: ds.apiUrl,
+    botId: ds.botId,
+    primaryColor: ds.primaryColor,
+    botName: ds.botName,
+    welcomeMessage: ds.welcomeMessage,
+    position: ds.position,
+  };
+  if (ds.showBranding !== undefined) out.showBranding = ds.showBranding;
+  return out;
+}
+
+export function mergeConfig(
+  primary: RawConfigInput | undefined,
+  fallback: RawConfigInput | undefined,
+): RawConfigInput {
+  return { ...(fallback ?? {}), ...(primary ?? {}) };
+}
+
+function validateUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ConfigError(`apiUrl is not a valid URL: ${url}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ConfigError(`apiUrl must be http or https: ${url}`);
+  }
+  // Strip trailing slash for predictable concatenation.
+  return url.replace(/\/+$/, "");
+}
+
+function safeColor(input: string | undefined, fallback: string): string {
+  if (!input) return fallback;
+  if (!SAFE_COLOR.test(input)) return fallback;
+  return input;
+}
+
+function safePosition(input: string | undefined): Position {
+  if (input && ALLOWED_POSITIONS.has(input as Position)) {
+    return input as Position;
+  }
+  return "bottom-right";
+}
+
+function safeText(input: string | undefined, fallback: string, max = 200): string {
+  if (!input) return fallback;
+  return input.replace(CONTROL_CHARS, "").slice(0, max) || fallback;
+}
+
+function safeBool(input: boolean | string | undefined, fallback: boolean): boolean {
+  if (typeof input === "boolean") return input;
+  if (typeof input === "string") {
+    if (input === "true") return true;
+    if (input === "false") return false;
+  }
+  return fallback;
+}
+
+export function buildConfig(raw: RawConfigInput): WidgetConfig {
+  const apiKey = (raw.apiKey ?? "").trim();
+  if (!apiKey) {
+    throw new ConfigError("Missing required apiKey (data-api-key)");
+  }
+  if (!apiKey.startsWith("mrag_")) {
+    throw new ConfigError("apiKey must start with 'mrag_'");
+  }
+
+  const apiUrl = validateUrl(raw.apiUrl?.trim() || DEFAULT_API_URL);
+
+  const result: WidgetConfig = {
+    apiKey,
+    apiUrl,
+    primaryColor: safeColor(raw.primaryColor?.trim(), DEFAULT_PRIMARY_COLOR),
+    botName: safeText(raw.botName?.trim(), "Assistant", 60),
+    welcomeMessage: safeText(
+      raw.welcomeMessage?.trim(),
+      "Hi! Ask me anything about this site.",
+      400,
+    ),
+    position: safePosition(raw.position?.trim()),
+    showBranding: safeBool(raw.showBranding, true),
+  };
+  const botId = raw.botId?.trim();
+  if (botId) result.botId = botId;
+  return result;
+}

--- a/packages/widget/src/escape.ts
+++ b/packages/widget/src/escape.ts
@@ -1,0 +1,39 @@
+/**
+ * HTML and URL escaping helpers.
+ *
+ * The widget never renders untrusted input via innerHTML — it always uses
+ * textContent. These helpers exist for audit-friendly defense-in-depth and
+ * for any future feature (e.g. clickable source links) that needs to vet
+ * a URL before using it as an href.
+ */
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+  "/": "&#x2F;",
+};
+
+export function escapeHtml(input: string): string {
+  return input.replace(/[&<>"'/]/g, (ch) => HTML_ESCAPES[ch] ?? ch);
+}
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+/**
+ * Returns the canonical absolute URL if the input uses an allowlisted scheme,
+ * or null otherwise. Relative URLs are rejected because we cannot determine
+ * their effective origin in a generic embed context.
+ */
+export function safeUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) return null;
+  return parsed.toString();
+}

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -1,35 +1,70 @@
 /**
- * MongoRAG Embeddable Chat Widget
+ * MongoRAG Embeddable Chat Widget — entrypoint.
  *
  * Usage:
  *   <script src="https://cdn.mongorag.com/widget.js"
- *           data-api-key="mrag_..." />
+ *           data-api-key="mrag_..."
+ *           data-bot-id="..."
+ *           data-primary-color="#4f46e5"
+ *           data-position="bottom-right"></script>
+ *
+ * Or programmatic:
+ *   <script>
+ *     window.MongoRAG = { apiKey: "mrag_...", apiUrl: "https://api.mongorag.com" };
+ *   </script>
+ *   <script src="https://cdn.mongorag.com/widget.js"></script>
  */
 
-interface MongoRAGConfig {
-  apiKey: string;
-  apiUrl?: string;
+import { ConfigError, buildConfig, mergeConfig, parseScriptDataset, type RawConfigInput } from "./config.js";
+import { mountWidget } from "./widget.js";
+import type { WidgetConfig } from "./types.js";
+
+declare global {
+  interface Window {
+    MongoRAG?: RawConfigInput & {
+      mount?: (cfg: RawConfigInput) => void;
+    };
+  }
+}
+
+let mounted = false;
+
+function logWarning(message: string): void {
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn(`[MongoRAG] ${message}`);
+  }
 }
 
 function init(): void {
+  if (mounted) return;
+
   const script = document.currentScript as HTMLScriptElement | null;
-  if (!script) return;
+  const datasetCfg = script ? parseScriptDataset(script) : undefined;
+  const windowCfgRaw = (window.MongoRAG ?? undefined) as RawConfigInput | undefined;
 
-  const config: MongoRAGConfig = {
-    apiKey: script.dataset.apiKey || "",
-    apiUrl: script.dataset.apiUrl || "",
-  };
+  const merged = mergeConfig(windowCfgRaw, datasetCfg);
 
-  if (!config.apiKey) {
-    console.warn("[MongoRAG] Missing data-api-key attribute");
+  let config: WidgetConfig;
+  try {
+    config = buildConfig(merged);
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      logWarning(err.message);
+    } else {
+      logWarning("Failed to initialize widget");
+    }
     return;
   }
 
-  console.log("[MongoRAG] Widget initialized", { apiUrl: config.apiUrl });
+  mounted = true;
+  // Defer mount until DOM is interactive so document.body exists.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => mountWidget(config), { once: true });
+  } else {
+    mountWidget(config);
+  }
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", init);
-} else {
+if (typeof window !== "undefined") {
   init();
 }

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -1,0 +1,282 @@
+/**
+ * Scoped CSS for the widget. Returned as a string and inserted via a single
+ * <style> element inside the Shadow DOM, so it cannot leak into the host page.
+ *
+ * Design notes (anti-AI-slop):
+ *   - System font stack — never Inter
+ *   - Single-tone surface, no purple→blue gradient
+ *   - Custom borders (1px solid rgba) instead of default shadcn glow
+ *   - Motion respects prefers-reduced-motion
+ */
+
+export interface StyleVars {
+  primaryColor: string;
+}
+
+export function buildStyles(vars: StyleVars): string {
+  // CSS variables let us interpolate the customer's primary color exactly once,
+  // safely (we already validated against SAFE_COLOR upstream).
+  return `
+:host {
+  --mrag-primary: ${vars.primaryColor};
+  --mrag-bg: #ffffff;
+  --mrag-fg: #0f172a;
+  --mrag-muted: #64748b;
+  --mrag-border: rgba(15, 23, 42, 0.08);
+  --mrag-surface: #f8fafc;
+  --mrag-radius: 14px;
+  all: initial;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: var(--mrag-fg);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.mrag-launcher {
+  position: fixed;
+  bottom: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: var(--mrag-primary);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  z-index: 2147483646;
+  transition: transform 160ms ease;
+}
+.mrag-launcher:hover { transform: translateY(-1px); }
+.mrag-launcher:focus-visible {
+  outline: 2px solid var(--mrag-primary);
+  outline-offset: 3px;
+}
+.mrag-launcher svg { width: 24px; height: 24px; }
+
+.mrag-pos-right { right: 20px; }
+.mrag-pos-left  { left: 20px; }
+
+.mrag-panel {
+  position: fixed;
+  bottom: 90px;
+  width: 380px;
+  max-width: calc(100vw - 24px);
+  height: 560px;
+  max-height: calc(100vh - 110px);
+  background: var(--mrag-bg);
+  border: 1px solid var(--mrag-border);
+  border-radius: var(--mrag-radius);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.16);
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2147483647;
+}
+.mrag-panel[data-open="true"] { display: flex; }
+
+.mrag-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--mrag-border);
+  background: var(--mrag-primary);
+  color: #fff;
+}
+.mrag-header h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.mrag-close {
+  background: transparent;
+  border: 0;
+  color: #fff;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  line-height: 0;
+}
+.mrag-close:hover { background: rgba(255, 255, 255, 0.15); }
+.mrag-close:focus-visible { outline: 2px solid #fff; outline-offset: 1px; }
+
+.mrag-messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--mrag-surface);
+}
+
+.mrag-msg {
+  max-width: 85%;
+  padding: 9px 12px;
+  border-radius: 12px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  font-size: 14px;
+}
+.mrag-msg-user {
+  align-self: flex-end;
+  background: var(--mrag-primary);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+.mrag-msg-assistant {
+  align-self: flex-start;
+  background: #fff;
+  border: 1px solid var(--mrag-border);
+  border-bottom-left-radius: 4px;
+}
+.mrag-msg-system {
+  align-self: center;
+  background: transparent;
+  color: var(--mrag-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.mrag-typing {
+  display: inline-flex;
+  gap: 4px;
+  padding: 6px 0;
+}
+.mrag-typing span {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--mrag-muted);
+  animation: mrag-bounce 1.2s infinite ease-in-out;
+}
+.mrag-typing span:nth-child(2) { animation-delay: 0.15s; }
+.mrag-typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes mrag-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+  30% { transform: translateY(-4px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mrag-launcher { transition: none; }
+  .mrag-typing span { animation: none; opacity: 0.7; }
+}
+
+.mrag-sources {
+  margin-top: 6px;
+  font-size: 12px;
+}
+.mrag-sources summary {
+  cursor: pointer;
+  color: var(--mrag-muted);
+  user-select: none;
+}
+.mrag-sources summary:hover { color: var(--mrag-fg); }
+.mrag-sources ul {
+  list-style: none;
+  margin: 6px 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.mrag-sources li {
+  background: var(--mrag-surface);
+  border: 1px solid var(--mrag-border);
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+.mrag-sources .mrag-src-title {
+  font-weight: 600;
+  font-size: 12px;
+}
+.mrag-sources .mrag-src-snippet {
+  color: var(--mrag-muted);
+  font-size: 11px;
+  margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.mrag-form {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid var(--mrag-border);
+  background: var(--mrag-bg);
+}
+.mrag-input {
+  flex: 1;
+  padding: 9px 12px;
+  font: inherit;
+  color: inherit;
+  background: var(--mrag-surface);
+  border: 1px solid var(--mrag-border);
+  border-radius: 10px;
+  outline: none;
+  resize: none;
+  max-height: 120px;
+  min-height: 38px;
+}
+.mrag-input:focus {
+  border-color: var(--mrag-primary);
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.06);
+}
+.mrag-send {
+  background: var(--mrag-primary);
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  padding: 0 14px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
+.mrag-send:disabled { opacity: 0.5; cursor: not-allowed; }
+.mrag-send:focus-visible { outline: 2px solid var(--mrag-primary); outline-offset: 2px; }
+
+.mrag-footer {
+  text-align: center;
+  font-size: 11px;
+  color: var(--mrag-muted);
+  padding: 6px 0 8px 0;
+  border-top: 1px solid var(--mrag-border);
+  background: var(--mrag-bg);
+}
+.mrag-footer a {
+  color: var(--mrag-muted);
+  text-decoration: none;
+}
+.mrag-footer a:hover { text-decoration: underline; }
+
+.mrag-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  margin: 8px 14px;
+}
+
+@media (max-width: 480px) {
+  .mrag-panel {
+    width: calc(100vw - 16px);
+    height: calc(100vh - 100px);
+    bottom: 80px;
+  }
+  .mrag-pos-right { right: 8px; }
+  .mrag-pos-left  { left: 8px; }
+}
+`;
+}

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared widget types.
+ */
+
+export type Position = "bottom-right" | "bottom-left";
+
+export interface WidgetConfig {
+  apiKey: string;
+  apiUrl: string;
+  botId?: string;
+  primaryColor: string;
+  botName: string;
+  welcomeMessage: string;
+  position: Position;
+  showBranding: boolean;
+}
+
+export interface ChatSource {
+  document_title: string;
+  heading_path: string[];
+  snippet: string;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+  sources?: ChatSource[];
+  pending?: boolean;
+}
+
+export interface SSEEvent {
+  type: string;
+  content?: string;
+  message?: string;
+  sources?: ChatSource[];
+  conversation_id?: string;
+  [key: string]: unknown;
+}

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -1,0 +1,383 @@
+/**
+ * Widget mount + interaction loop.
+ *
+ * - Renders into a closed-shadow-DOM container so host CSS cannot leak in
+ *   and we cannot accidentally style the host page.
+ * - All untrusted text (assistant tokens, source titles, snippets, error
+ *   messages) is set via textContent, never innerHTML. Static SVG icons are
+ *   built with createElementNS to avoid any innerHTML usage at all.
+ * - conversation_id persists per-tenant in localStorage so sessions survive
+ *   page navigations.
+ */
+
+import { startChatStream, type ChatRequestBody } from "./api.js";
+import { buildStyles } from "./styles.js";
+import type { ChatMessage, ChatSource, SSEEvent, WidgetConfig } from "./types.js";
+
+const STORAGE_KEY_PREFIX = "mongorag.conversation_id:";
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+interface WidgetHandle {
+  destroy: () => void;
+}
+
+export function mountWidget(config: WidgetConfig): WidgetHandle {
+  const host = document.createElement("div");
+  host.setAttribute("data-mongorag-widget", "");
+  host.style.cssText = "all: initial;";
+  document.body.appendChild(host);
+
+  const root = host.attachShadow({ mode: "closed" });
+
+  const style = document.createElement("style");
+  style.textContent = buildStyles({ primaryColor: config.primaryColor });
+  root.appendChild(style);
+
+  const launcher = createLauncher(config);
+  const panel = createPanel(config);
+  root.appendChild(launcher);
+  root.appendChild(panel.element);
+
+  const state = {
+    open: false,
+    sending: false,
+    messages: [] as ChatMessage[],
+    abort: null as AbortController | null,
+    conversationId: loadConversationId(config.apiKey),
+  };
+
+  function setOpen(open: boolean): void {
+    state.open = open;
+    panel.element.dataset.open = String(open);
+    launcher.setAttribute("aria-expanded", String(open));
+    if (open) {
+      if (state.messages.length === 0) {
+        state.messages.push({ role: "assistant", content: config.welcomeMessage });
+        renderMessages();
+      }
+      requestAnimationFrame(() => panel.input.focus());
+    }
+  }
+
+  function renderMessages(): void {
+    panel.messages.textContent = "";
+    for (const msg of state.messages) {
+      panel.messages.appendChild(renderMessage(msg));
+    }
+    panel.messages.scrollTop = panel.messages.scrollHeight;
+  }
+
+  async function send(rawText: string): Promise<void> {
+    const text = rawText.trim();
+    if (!text || state.sending) return;
+
+    state.sending = true;
+    panel.send.disabled = true;
+    panel.input.disabled = true;
+
+    state.messages.push({ role: "user", content: text });
+    const assistantMsg: ChatMessage = { role: "assistant", content: "", pending: true };
+    state.messages.push(assistantMsg);
+    renderMessages();
+
+    const body: ChatRequestBody = { message: text };
+    if (state.conversationId) body.conversation_id = state.conversationId;
+
+    const abort = new AbortController();
+    state.abort = abort;
+
+    try {
+      const result = await startChatStream({
+        apiUrl: config.apiUrl,
+        apiKey: config.apiKey,
+        body,
+        signal: abort.signal,
+      });
+
+      if (!result.ok) {
+        assistantMsg.pending = false;
+        assistantMsg.content = errorMessageForStatus(result.status);
+        renderMessages();
+        return;
+      }
+
+      let receivedToken = false;
+      for await (const event of result.events) {
+        applyEvent(event, assistantMsg, (id) => {
+          state.conversationId = id;
+          saveConversationId(config.apiKey, id);
+        });
+        if (event.type === "token") receivedToken = true;
+        renderMessages();
+      }
+      if (!receivedToken && !assistantMsg.content) {
+        assistantMsg.pending = false;
+        assistantMsg.content = "No response received. Please try again.";
+        renderMessages();
+      }
+    } catch (err) {
+      assistantMsg.pending = false;
+      assistantMsg.content =
+        err instanceof DOMException && err.name === "AbortError"
+          ? "Cancelled."
+          : "Couldn't reach the server. Check your connection and try again.";
+      renderMessages();
+    } finally {
+      state.sending = false;
+      state.abort = null;
+      panel.send.disabled = false;
+      panel.input.disabled = false;
+      panel.input.focus();
+    }
+  }
+
+  launcher.addEventListener("click", () => setOpen(!state.open));
+  panel.close.addEventListener("click", () => setOpen(false));
+
+  panel.form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const value = panel.input.value;
+    panel.input.value = "";
+    autoresize(panel.input);
+    void send(value);
+  });
+
+  panel.input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      panel.form.requestSubmit();
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+      launcher.focus();
+    }
+  });
+
+  panel.input.addEventListener("input", () => autoresize(panel.input));
+
+  return {
+    destroy() {
+      state.abort?.abort();
+      host.remove();
+    },
+  };
+}
+
+function svgIcon(paths: Array<{ tag: "path" | "line"; attrs: Record<string, string> }>): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  for (const p of paths) {
+    const child = document.createElementNS(SVG_NS, p.tag);
+    for (const [k, v] of Object.entries(p.attrs)) child.setAttribute(k, v);
+    svg.appendChild(child);
+  }
+  return svg;
+}
+
+function createLauncher(config: WidgetConfig): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = `mrag-launcher mrag-pos-${config.position === "bottom-left" ? "left" : "right"}`;
+  btn.setAttribute("aria-label", `Open chat with ${config.botName}`);
+  btn.setAttribute("aria-haspopup", "dialog");
+  btn.setAttribute("aria-expanded", "false");
+  btn.appendChild(
+    svgIcon([
+      { tag: "path", attrs: { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" } },
+    ]),
+  );
+  return btn;
+}
+
+interface PanelRefs {
+  element: HTMLDivElement;
+  messages: HTMLDivElement;
+  form: HTMLFormElement;
+  input: HTMLTextAreaElement;
+  send: HTMLButtonElement;
+  close: HTMLButtonElement;
+}
+
+function createPanel(config: WidgetConfig): PanelRefs {
+  const el = document.createElement("div");
+  el.className = `mrag-panel mrag-pos-${config.position === "bottom-left" ? "left" : "right"}`;
+  el.setAttribute("role", "dialog");
+  el.setAttribute("aria-label", `${config.botName} chat`);
+  el.setAttribute("aria-modal", "false");
+
+  const header = document.createElement("div");
+  header.className = "mrag-header";
+  const title = document.createElement("h2");
+  title.textContent = config.botName;
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "mrag-close";
+  close.setAttribute("aria-label", "Close chat");
+  close.appendChild(
+    svgIcon([
+      { tag: "line", attrs: { x1: "18", y1: "6", x2: "6", y2: "18" } },
+      { tag: "line", attrs: { x1: "6", y1: "6", x2: "18", y2: "18" } },
+    ]),
+  );
+  header.append(title, close);
+
+  const messages = document.createElement("div");
+  messages.className = "mrag-messages";
+  messages.setAttribute("role", "log");
+  messages.setAttribute("aria-live", "polite");
+  messages.setAttribute("aria-relevant", "additions");
+
+  const form = document.createElement("form");
+  form.className = "mrag-form";
+  form.setAttribute("aria-label", "Send message");
+
+  const input = document.createElement("textarea");
+  input.className = "mrag-input";
+  input.placeholder = "Type your message…";
+  input.setAttribute("aria-label", "Message");
+  input.rows = 1;
+  input.maxLength = 2000;
+
+  const send = document.createElement("button");
+  send.type = "submit";
+  send.className = "mrag-send";
+  send.textContent = "Send";
+
+  form.append(input, send);
+  el.append(header, messages, form);
+
+  if (config.showBranding) {
+    const footer = document.createElement("div");
+    footer.className = "mrag-footer";
+    const link = document.createElement("a");
+    link.href = "https://mongorag.com";
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = "Powered by MongoRAG";
+    footer.appendChild(link);
+    el.appendChild(footer);
+  }
+
+  return { element: el, messages, form, input, send, close };
+}
+
+function renderMessage(msg: ChatMessage): HTMLDivElement {
+  const wrap = document.createElement("div");
+  wrap.className = `mrag-msg mrag-msg-${msg.role}`;
+  if (msg.pending && !msg.content) {
+    const t = document.createElement("div");
+    t.className = "mrag-typing";
+    t.setAttribute("aria-label", "Assistant is typing");
+    for (let i = 0; i < 3; i++) t.appendChild(document.createElement("span"));
+    wrap.appendChild(t);
+    return wrap;
+  }
+  const body = document.createElement("div");
+  body.textContent = msg.content;
+  wrap.appendChild(body);
+
+  if (msg.role === "assistant" && msg.sources && msg.sources.length > 0) {
+    wrap.appendChild(renderSources(msg.sources));
+  }
+  return wrap;
+}
+
+function renderSources(sources: ChatSource[]): HTMLDetailsElement {
+  const details = document.createElement("details");
+  details.className = "mrag-sources";
+  const summary = document.createElement("summary");
+  summary.textContent = `${sources.length} source${sources.length === 1 ? "" : "s"}`;
+  details.appendChild(summary);
+
+  const ul = document.createElement("ul");
+  for (const src of sources.slice(0, 8)) {
+    const li = document.createElement("li");
+    const t = document.createElement("div");
+    t.className = "mrag-src-title";
+    const headingPath = Array.isArray(src.heading_path) ? src.heading_path.join(" › ") : "";
+    const title = src.document_title || "Source";
+    t.textContent = headingPath ? `${title} — ${headingPath}` : title;
+    li.appendChild(t);
+
+    if (src.snippet) {
+      const s = document.createElement("div");
+      s.className = "mrag-src-snippet";
+      s.textContent = src.snippet;
+      li.appendChild(s);
+    }
+    ul.appendChild(li);
+  }
+  details.appendChild(ul);
+  return details;
+}
+
+export function applyEvent(
+  event: SSEEvent,
+  assistantMsg: ChatMessage,
+  onConversationId: (id: string) => void,
+): void {
+  switch (event.type) {
+    case "token":
+      if (typeof event.content === "string") {
+        assistantMsg.content += event.content;
+        assistantMsg.pending = true;
+      }
+      break;
+    case "sources":
+      if (Array.isArray(event.sources)) {
+        assistantMsg.sources = event.sources;
+      }
+      break;
+    case "done":
+      assistantMsg.pending = false;
+      if (typeof event.conversation_id === "string" && event.conversation_id) {
+        onConversationId(event.conversation_id);
+      }
+      break;
+    case "error":
+      assistantMsg.pending = false;
+      assistantMsg.content =
+        typeof event.message === "string" && event.message
+          ? event.message
+          : "Something went wrong.";
+      break;
+  }
+}
+
+function errorMessageForStatus(status: number): string {
+  if (status === 401 || status === 403) return "Authentication failed. Check your API key.";
+  if (status === 429) return "Rate limit reached. Please try again in a moment.";
+  if (status === 503 || status === 502) return "The service is temporarily unavailable.";
+  if (status >= 500) return "Server error. Please try again.";
+  return "Something went wrong. Please try again.";
+}
+
+function loadConversationId(apiKey: string): string | undefined {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY_PREFIX + apiKey);
+    return v || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function saveConversationId(apiKey: string, id: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY_PREFIX + apiKey, id);
+  } catch {
+    // ignore storage errors (private mode, etc.)
+  }
+}
+
+function autoresize(el: HTMLTextAreaElement): void {
+  el.style.height = "auto";
+  const max = 120;
+  el.style.height = Math.min(el.scrollHeight, max) + "px";
+}
+

--- a/packages/widget/tests/api.test.ts
+++ b/packages/widget/tests/api.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthHeaders, parseSSE } from "../src/api.js";
+
+describe("buildAuthHeaders", () => {
+  it("formats the bearer token and SSE accept", () => {
+    const headers = buildAuthHeaders("mrag_xyz");
+    expect(headers["Authorization"]).toBe("Bearer mrag_xyz");
+    expect(headers["Accept"]).toBe("text/event-stream");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i]!));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+describe("parseSSE", () => {
+  it("parses a single complete event", async () => {
+    const stream = streamFromChunks([
+      'data: {"type":"token","content":"hi"}\n\n',
+    ]);
+    const events = [];
+    for await (const e of parseSSE(stream)) events.push(e);
+    expect(events).toEqual([{ type: "token", content: "hi" }]);
+  });
+
+  it("handles events split across chunks", async () => {
+    const stream = streamFromChunks([
+      'data: {"type":"to',
+      'ken","content":"a"}\n\ndata: {"type":"token","content":"b"}\n\n',
+    ]);
+    const events = [];
+    for await (const e of parseSSE(stream)) events.push(e);
+    expect(events.length).toBe(2);
+    expect(events[0]).toEqual({ type: "token", content: "a" });
+    expect(events[1]).toEqual({ type: "token", content: "b" });
+  });
+
+  it("ignores non-data lines and malformed JSON", async () => {
+    const stream = streamFromChunks([
+      "event: ping\n\n",
+      "data: not-json\n\n",
+      'data: {"type":"done","conversation_id":"c1"}\n\n',
+    ]);
+    const events = [];
+    for await (const e of parseSSE(stream)) events.push(e);
+    expect(events).toEqual([{ type: "done", conversation_id: "c1" }]);
+  });
+
+  it("rejects events without a string type", async () => {
+    const stream = streamFromChunks(['data: {"foo":"bar"}\n\n']);
+    const events = [];
+    for await (const e of parseSSE(stream)) events.push(e);
+    expect(events).toEqual([]);
+  });
+
+  it("emits a final event without trailing blank line", async () => {
+    const stream = streamFromChunks(['data: {"type":"done"}']);
+    const events = [];
+    for await (const e of parseSSE(stream)) events.push(e);
+    expect(events).toEqual([{ type: "done" }]);
+  });
+});

--- a/packages/widget/tests/config.test.ts
+++ b/packages/widget/tests/config.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { ConfigError, buildConfig, mergeConfig } from "../src/config.js";
+
+describe("buildConfig", () => {
+  it("returns defaults for a minimal valid input", () => {
+    const cfg = buildConfig({ apiKey: "mrag_abc" });
+    expect(cfg.apiKey).toBe("mrag_abc");
+    expect(cfg.apiUrl).toBe("https://api.mongorag.com");
+    expect(cfg.position).toBe("bottom-right");
+    expect(cfg.primaryColor).toBe("#0f172a");
+    expect(cfg.botName).toBe("Assistant");
+    expect(cfg.showBranding).toBe(true);
+  });
+
+  it("throws when apiKey is missing", () => {
+    expect(() => buildConfig({})).toThrow(ConfigError);
+  });
+
+  it("rejects an apiKey without the mrag_ prefix", () => {
+    expect(() => buildConfig({ apiKey: "sk-abc" })).toThrow(/mrag_/);
+  });
+
+  it("rejects javascript: schemes for apiUrl", () => {
+    expect(() => buildConfig({ apiKey: "mrag_x", apiUrl: "javascript:alert(1)" })).toThrow(
+      ConfigError,
+    );
+  });
+
+  it("rejects file: schemes for apiUrl", () => {
+    expect(() => buildConfig({ apiKey: "mrag_x", apiUrl: "file:///etc/passwd" })).toThrow(
+      ConfigError,
+    );
+  });
+
+  it("strips trailing slashes from apiUrl", () => {
+    const cfg = buildConfig({ apiKey: "mrag_x", apiUrl: "https://api.example.com//" });
+    expect(cfg.apiUrl).toBe("https://api.example.com");
+  });
+
+  it("falls back to safe color when given an unsafe value", () => {
+    const cfg = buildConfig({
+      apiKey: "mrag_x",
+      primaryColor: "url(javascript:alert(1))",
+    });
+    expect(cfg.primaryColor).toBe("#0f172a");
+  });
+
+  it("accepts a valid hex color", () => {
+    const cfg = buildConfig({ apiKey: "mrag_x", primaryColor: "#ff5500" });
+    expect(cfg.primaryColor).toBe("#ff5500");
+  });
+
+  it("falls back to bottom-right for an unknown position", () => {
+    const cfg = buildConfig({ apiKey: "mrag_x", position: "top-center" });
+    expect(cfg.position).toBe("bottom-right");
+  });
+
+  it("strips C0 control characters from text fields", () => {
+    const malicious = "Bot" + String.fromCharCode(0x07) + "Name" + String.fromCharCode(0x1b);
+    const cfg = buildConfig({ apiKey: "mrag_x", botName: malicious });
+    expect(cfg.botName).toBe("BotName");
+  });
+
+  it("truncates excessively long text", () => {
+    const long = "x".repeat(1000);
+    const cfg = buildConfig({ apiKey: "mrag_x", welcomeMessage: long });
+    expect(cfg.welcomeMessage.length).toBeLessThanOrEqual(400);
+  });
+
+  it("respects showBranding=false from string input", () => {
+    const cfg = buildConfig({ apiKey: "mrag_x", showBranding: "false" });
+    expect(cfg.showBranding).toBe(false);
+  });
+});
+
+describe("mergeConfig", () => {
+  it("primary overrides fallback", () => {
+    const merged = mergeConfig(
+      { apiKey: "mrag_a" },
+      { apiKey: "mrag_b", apiUrl: "https://x.test" },
+    );
+    expect(merged.apiKey).toBe("mrag_a");
+    expect(merged.apiUrl).toBe("https://x.test");
+  });
+
+  it("handles undefined inputs", () => {
+    expect(mergeConfig(undefined, undefined)).toEqual({});
+  });
+});

--- a/packages/widget/tests/escape.test.ts
+++ b/packages/widget/tests/escape.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml, safeUrl } from "../src/escape.js";
+
+describe("escapeHtml", () => {
+  it("escapes the standard HTML metacharacters", () => {
+    expect(escapeHtml('<script>alert("x")</script>')).toBe(
+      "&lt;script&gt;alert(&quot;x&quot;)&lt;&#x2F;script&gt;",
+    );
+  });
+
+  it("escapes ampersands first to avoid double-encoding", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes single quotes", () => {
+    expect(escapeHtml("it's")).toBe("it&#39;s");
+  });
+});
+
+describe("safeUrl", () => {
+  it("accepts https URLs", () => {
+    expect(safeUrl("https://example.com")).toBe("https://example.com/");
+  });
+
+  it("accepts http URLs", () => {
+    expect(safeUrl("http://example.com/page")).toBe("http://example.com/page");
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(safeUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects data: URLs", () => {
+    expect(safeUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  it("rejects relative paths (no scheme)", () => {
+    expect(safeUrl("/foo/bar")).toBeNull();
+  });
+});

--- a/packages/widget/tests/widget.test.ts
+++ b/packages/widget/tests/widget.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { applyEvent } from "../src/widget.js";
+import type { ChatMessage, SSEEvent } from "../src/types.js";
+
+function makeMsg(): ChatMessage {
+  return { role: "assistant", content: "", pending: true };
+}
+
+describe("applyEvent", () => {
+  it("appends content for token events", () => {
+    const msg = makeMsg();
+    applyEvent({ type: "token", content: "Hello " } as SSEEvent, msg, () => {});
+    applyEvent({ type: "token", content: "world" } as SSEEvent, msg, () => {});
+    expect(msg.content).toBe("Hello world");
+    expect(msg.pending).toBe(true);
+  });
+
+  it("attaches sources from a sources event", () => {
+    const msg = makeMsg();
+    applyEvent(
+      {
+        type: "sources",
+        sources: [{ document_title: "Doc", heading_path: ["A"], snippet: "s" }],
+      } as SSEEvent,
+      msg,
+      () => {},
+    );
+    expect(msg.sources).toHaveLength(1);
+    expect(msg.sources?.[0]?.document_title).toBe("Doc");
+  });
+
+  it("clears pending and reports conversation_id on done", () => {
+    const msg = makeMsg();
+    let captured = "";
+    applyEvent(
+      { type: "done", conversation_id: "abc" } as SSEEvent,
+      msg,
+      (id) => (captured = id),
+    );
+    expect(msg.pending).toBe(false);
+    expect(captured).toBe("abc");
+  });
+
+  it("uses error message when present", () => {
+    const msg = makeMsg();
+    applyEvent({ type: "error", message: "Boom" } as SSEEvent, msg, () => {});
+    expect(msg.content).toBe("Boom");
+    expect(msg.pending).toBe(false);
+  });
+
+  it("ignores token content that is not a string", () => {
+    const msg = makeMsg();
+    applyEvent({ type: "token", content: 42 } as unknown as SSEEvent, msg, () => {});
+    expect(msg.content).toBe("");
+  });
+
+  it("safely ignores unknown event types", () => {
+    const msg = makeMsg();
+    applyEvent({ type: "weird" } as SSEEvent, msg, () => {});
+    expect(msg.content).toBe("");
+    expect(msg.pending).toBe(true);
+  });
+});

--- a/packages/widget/tsconfig.json
+++ b/packages/widget/tsconfig.json
@@ -3,13 +3,15 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true
+    "declaration": false,
+    "types": ["vitest/globals"]
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/widget/vitest.config.ts
+++ b/packages/widget/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements the embeddable chat widget customers install via a single `<script>` tag (issue #16, Phase 6).

- Vanilla TypeScript bundled with esbuild — **15.1 KB minified, ~5 KB gzipped** (target was <50 KB)
- Closed Shadow DOM mount — host CSS cannot leak in, widget CSS cannot leak out
- Floating launcher + chat panel with typing indicator + collapsible source citations
- Streams responses via SSE from `POST /api/v1/chat` with `Authorization: Bearer mrag_*`
- `conversation_id` persisted per-API-key in `localStorage`
- Customization via `data-*` attributes or `window.MongoRAG` (apiKey, apiUrl, botName, welcomeMessage, primaryColor, position, showBranding)
- Accessibility: ARIA dialog + log + aria-live, focus management, Escape closes, `prefers-reduced-motion` respected
- Mobile responsive (full-width panel <= 480px)
- XSS hardening: every untrusted string via `textContent`, SVG via `createElementNS`, whitelisted color/position/URL-scheme validation
- 34 vitest unit tests covering config validation, SSE parser (chunked + malformed JSON + missing trailing newline), auth header builder, event reducer, HTML/URL escaping
- `demo/index.html` for manual verification against a local API

## Test plan

- [x] `pnpm typecheck` passes (strict + `noUncheckedIndexedAccess`)
- [x] `pnpm test` — 34/34 pass
- [x] `pnpm build` — 15.1 KB output
- [ ] Manual: open `demo/index.html` against a running API on `localhost:8100` with a real `mrag_*` key, confirm tokens stream and conversation_id persists across reloads
- [ ] Manual: verify on a third-party host (WordPress/Shopify) that Shadow DOM prevents CSS conflicts

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)