### PR TITLE
feat(ingestion): URL-based document ingestion with SSRF defense

### DIFF
--- a/.obsidian/_search/index.json
+++ b/.obsidian/_search/index.json
@@ -1,5 +1,5 @@
 {
-  "built": "2026-04-29T19:44:46.567Z",
+  "built": "2026-04-29T20:13:33.887Z",
   "docs": [
     {
       "file": "decision-pydantic-ai-over-langchain.md",

--- a/.obsidian/_search/lean-index.json
+++ b/.obsidian/_search/lean-index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-29T19:44:46.570Z",
+  "generated": "2026-04-29T20:13:33.889Z",
   "docs": [
     {
       "file": "decision-pydantic-ai-over-langchain.md",

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "resend>=2.0.0",
     "stripe>=11.0.0",
+    "httpx>=0.27.0",
 ]
 
 [build-system]

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -136,6 +136,30 @@ class Settings(BaseSettings):
         default="/tmp/mongorag-uploads", description="Temporary directory for uploaded files"
     )
 
+    # URL Ingestion Configuration
+    url_fetch_timeout_seconds: float = Field(
+        default=30.0,
+        description="Total timeout for fetching a remote URL (connect + read)",
+    )
+
+    url_fetch_max_redirects: int = Field(
+        default=3,
+        description="Maximum redirects to follow when fetching a URL",
+    )
+
+    url_fetch_max_size_mb: int = Field(
+        default=25,
+        description="Maximum response size in MB for URL ingestion",
+    )
+
+    url_fetch_allow_private_ips: bool = Field(
+        default=False,
+        description=(
+            "Allow URL fetcher to connect to private/loopback/link-local IP ranges. "
+            "MUST stay false in production — only flip on for tests against localhost."
+        ),
+    )
+
     # Auth Configuration
     nextauth_secret: str = Field(
         ..., description="Shared secret for JWT signing (same as NEXTAUTH_SECRET in frontend)"

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -16,6 +16,39 @@ class IngestResponse(BaseModel):
     task_id: str = Field(..., description="Celery task ID for tracking")
 
 
+class IngestURLRequest(BaseModel):
+    """Request body for URL-based document ingestion."""
+
+    url: str = Field(
+        ...,
+        min_length=1,
+        max_length=2048,
+        description="HTTP(S) URL to fetch and ingest",
+    )
+    title: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Override document title (defaults to <title> or hostname/path)",
+    )
+    metadata: Optional[dict] = Field(
+        default=None,
+        description="Optional caller-supplied metadata (merged onto extracted metadata)",
+    )
+
+    @field_validator("url")
+    @classmethod
+    def validate_url_scheme(cls, v: str) -> str:
+        """Surface scheme errors as Pydantic validation errors (422)."""
+        from urllib.parse import urlparse
+
+        parsed = urlparse(v.strip())
+        if parsed.scheme.lower() not in {"http", "https"}:
+            raise ValueError("URL must use http or https scheme")
+        if not parsed.hostname:
+            raise ValueError("URL must include a hostname")
+        return v.strip()
+
+
 class DocumentStatusResponse(BaseModel):
     """Response from document status endpoint."""
 

--- a/apps/api/src/routers/ingest.py
+++ b/apps/api/src/routers/ingest.py
@@ -15,11 +15,12 @@ from src.core.deps import get_deps
 from src.core.rate_limit_dep import enforce_rate_limit
 from src.core.settings import Settings, load_settings
 from src.core.tenant import get_tenant_id
-from src.models.api import DocumentStatusResponse, IngestResponse
+from src.models.api import DocumentStatusResponse, IngestResponse, IngestURLRequest
 from src.models.usage import QuotaExceededError
 from src.services.ingestion.service import IngestionService
+from src.services.ingestion.url_loader import URLValidationError, validate_url
 from src.services.usage import UsageService
-from src.worker import ingest_document
+from src.worker import ingest_document, ingest_url
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +175,81 @@ async def ingest_document_endpoint(
 
     logger.info(
         "Ingestion dispatched: doc=%s, tenant=%s, task=%s",
+        document_id,
+        tenant_id,
+        task.id,
+    )
+
+    return IngestResponse(
+        document_id=str(document_id),
+        status="pending",
+        task_id=task.id,
+    )
+
+
+@router.post("/ingest-url", response_model=IngestResponse, status_code=202)
+async def ingest_url_endpoint(
+    payload: IngestURLRequest,
+    tenant_id: str = Depends(enforce_rate_limit),
+    settings: Settings = Depends(_get_settings),
+    deps: AgentDependencies = Depends(get_deps),
+) -> IngestResponse:
+    """Fetch a remote URL and ingest its contents.
+
+    The URL is validated synchronously (scheme, hostname, DNS resolution to a
+    public IP, no metadata endpoints) before a Celery task is dispatched.
+    Returns 202 Accepted with the document_id and task_id.
+    """
+    # Pre-flight SSRF check at request time so callers see a meaningful 422
+    # before we create a database row or enqueue a job.
+    try:
+        normalized = validate_url(payload.url, allow_private=settings.url_fetch_allow_private_ips)
+    except URLValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    usage_service = UsageService(deps.usage_collection, deps.subscriptions_collection)
+    current_doc_count = await deps.documents_collection.count_documents({"tenant_id": tenant_id})
+    try:
+        await usage_service.check_document_quota(tenant_id, current_doc_count)
+    except QuotaExceededError as e:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Document quota exceeded ({e.used}/{e.limit})",
+            headers={"Retry-After": "3600", "X-Quota-Limit": str(e.limit)},
+        )
+
+    service = IngestionService(
+        documents_collection=deps.documents_collection,
+        chunks_collection=deps.chunks_collection,
+    )
+
+    metadata = dict(payload.metadata or {})
+    metadata["source_url"] = normalized
+
+    document_id = await service.create_pending_document(
+        tenant_id=tenant_id,
+        title=payload.title or normalized,
+        source=normalized,
+        metadata=metadata,
+    )
+
+    try:
+        task = ingest_url.delay(
+            url=normalized,
+            document_id=str(document_id),
+            tenant_id=tenant_id,
+            title=payload.title,
+            metadata=metadata,
+        )
+    except Exception:
+        await service.update_status(
+            str(document_id), tenant_id, "failed", error_message="Task queue unavailable"
+        )
+        logger.exception("Failed to dispatch URL ingestion task for doc=%s", document_id)
+        raise HTTPException(status_code=503, detail="Task queue unavailable")
+
+    logger.info(
+        "URL ingestion dispatched: doc=%s tenant=%s task=%s",
         document_id,
         tenant_id,
         task.id,

--- a/apps/api/src/services/ingestion/url_loader.py
+++ b/apps/api/src/services/ingestion/url_loader.py
@@ -1,0 +1,344 @@
+"""Async URL fetcher with SSRF defense for document ingestion.
+
+Performs strict validation of remote URLs before fetching:
+- Scheme must be http/https
+- Hostname is resolved at validation time AND on every redirect; resolved IPs
+  must not be private, loopback, link-local, multicast, reserved, or the
+  cloud-metadata range (169.254.169.254, fd00:ec2::254, etc.)
+- Response Content-Type must be on the allowlist (missing types rejected)
+- Response size capped via streaming with a hard byte limit
+- Redirects manually followed with re-validation each hop (prevents
+  open-redirect → internal-IP and DNS-rebinding-on-redirect attacks)
+
+Residual risks:
+- DNS rebinding TOCTOU: between validate_url() and the actual connect, a
+  malicious DNS server with low TTL could swap to a private IP. The kernel
+  resolver caches this in practice; deployments that need stronger isolation
+  should run the worker in a network namespace that blocks RFC1918 egress.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from src.core.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# MIME prefixes Docling can convert (we strip parameters before matching).
+ALLOWED_MIME_TYPES = frozenset(
+    {
+        "text/html",
+        "application/xhtml+xml",
+        "text/plain",
+        "text/markdown",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    }
+)
+
+# Cloud / orchestrator metadata endpoints. urllib's `is_private` already covers
+# 169.254.0.0/16 (link-local) which contains AWS/GCP/Azure IMDS, but we keep an
+# explicit list here for defense-in-depth and clearer error logging.
+BLOCKED_METADATA_HOSTS = frozenset(
+    {
+        "169.254.169.254",  # AWS / GCP / Azure / DigitalOcean / Alibaba
+        "fd00:ec2::254",  # AWS IMDSv6
+        "100.100.100.200",  # Alibaba
+        "metadata.google.internal",
+        "metadata.goog",
+    }
+)
+
+DEFAULT_USER_AGENT = "MongoRAG-URLIngester/1.0 (+https://mongorag.com)"
+
+
+class URLValidationError(ValueError):
+    """Raised when a URL fails security validation (SSRF, scheme, etc.)."""
+
+
+class URLFetchError(RuntimeError):
+    """Raised when a URL cannot be fetched (network, size, MIME, status)."""
+
+
+@dataclass(frozen=True)
+class FetchedURL:
+    """Result of a successful URL fetch."""
+
+    url: str  # Originally requested URL
+    final_url: str  # Final URL after redirects
+    content: bytes
+    content_type: str  # Bare media type, e.g. "text/html"
+    charset: Optional[str]
+    title: Optional[str] = None
+
+
+def _normalize_mime(content_type: str) -> tuple[str, Optional[str]]:
+    """Split a Content-Type header into (media_type, charset)."""
+    if not content_type:
+        return ("", None)
+    parts = [p.strip() for p in content_type.split(";")]
+    media = parts[0].lower()
+    charset: Optional[str] = None
+    for p in parts[1:]:
+        if p.lower().startswith("charset="):
+            charset = p.split("=", 1)[1].strip().strip("\"'") or None
+    return (media, charset)
+
+
+def _is_blocked_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Block private, loopback, link-local, multicast, reserved, unspecified."""
+    return bool(
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_and_check_host(host: str, *, allow_private: bool) -> list[str]:
+    """Resolve a hostname and ensure NO resolved IP is in a blocked range.
+
+    Returns the list of resolved IP strings on success.
+    Raises URLValidationError if any IP is blocked or resolution fails.
+
+    Note: All resolved addresses are checked. This thwarts DNS-rebinding-style
+    tricks where a hostname resolves to one public + one private address.
+    """
+    if host in BLOCKED_METADATA_HOSTS:
+        raise URLValidationError(f"Host '{host}' is blocked (metadata endpoint)")
+
+    # Reject literal IPs that are blocked (skipping the DNS round-trip).
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if not allow_private and _is_blocked_ip(literal):
+            raise URLValidationError(
+                f"IP address '{host}' is in a blocked range (private/loopback/link-local)"
+            )
+        return [str(literal)]
+
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise URLValidationError(f"DNS lookup failed for '{host}'") from e
+
+    resolved: list[str] = []
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if not allow_private and _is_blocked_ip(ip):
+            raise URLValidationError(f"Host '{host}' resolved to blocked IP '{ip_str}'")
+        resolved.append(ip_str)
+
+    if not resolved:
+        raise URLValidationError(f"DNS resolution returned no usable addresses for '{host}'")
+    return resolved
+
+
+def validate_url(url: str, *, allow_private: bool = False) -> str:
+    """Validate a URL is safe to fetch.
+
+    Args:
+        url: User-supplied URL.
+        allow_private: If True, skip private-IP checks (test-only).
+
+    Returns:
+        The normalized URL string.
+
+    Raises:
+        URLValidationError: If the URL fails any safety check.
+    """
+    if not url or not isinstance(url, str):
+        raise URLValidationError("URL is required")
+
+    if len(url) > 2048:
+        raise URLValidationError("URL is too long (max 2048 chars)")
+
+    try:
+        parsed = urlparse(url.strip())
+    except (ValueError, TypeError) as e:
+        raise URLValidationError("Malformed URL") from e
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise URLValidationError(
+            f"Unsupported URL scheme '{parsed.scheme}'. Only http and https are allowed."
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise URLValidationError("URL is missing a hostname")
+
+    # Defence: refuse credentials in URL (avoid leaking via logs / proxies).
+    if parsed.username or parsed.password:
+        raise URLValidationError("URLs with embedded credentials are not allowed")
+
+    _resolve_and_check_host(host, allow_private=allow_private)
+    return urlunparse(parsed)
+
+
+async def _read_capped(response: httpx.Response, max_bytes: int) -> bytes:
+    """Stream a response, aborting if it exceeds max_bytes."""
+    buf = bytearray()
+    async for chunk in response.aiter_bytes():
+        buf.extend(chunk)
+        if len(buf) > max_bytes:
+            raise URLFetchError(f"Response exceeds maximum size of {max_bytes} bytes")
+    return bytes(buf)
+
+
+async def fetch_url(
+    url: str,
+    settings: Settings,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+) -> FetchedURL:
+    """Fetch a URL with SSRF protection, size cap, and MIME allowlist.
+
+    Manually follows up to ``settings.url_fetch_max_redirects`` redirects,
+    re-validating each Location to defeat redirect-based SSRF.
+
+    Args:
+        url: URL to fetch.
+        settings: App settings.
+        client: Optional pre-built httpx.AsyncClient (used in tests).
+
+    Returns:
+        FetchedURL with raw bytes and detected content type.
+
+    Raises:
+        URLValidationError: If URL or any redirect target fails safety checks.
+        URLFetchError: For network/HTTP/size errors.
+    """
+    allow_private = settings.url_fetch_allow_private_ips
+    max_bytes = settings.url_fetch_max_size_mb * 1024 * 1024
+    max_redirects = max(0, int(settings.url_fetch_max_redirects))
+    timeout = httpx.Timeout(settings.url_fetch_timeout_seconds, connect=10.0)
+
+    current = validate_url(url, allow_private=allow_private)
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=False,
+            headers={"User-Agent": DEFAULT_USER_AGENT, "Accept": "*/*"},
+            max_redirects=0,
+        )
+
+    try:
+        for hop in range(max_redirects + 1):
+            try:
+                async with client.stream("GET", current) as response:
+                    # Redirect handling — re-validate target.
+                    if response.is_redirect:
+                        if hop >= max_redirects:
+                            raise URLFetchError(f"Too many redirects (max {max_redirects})")
+                        location = response.headers.get("location")
+                        if not location:
+                            raise URLFetchError("Redirect without Location header")
+                        # Resolve relative locations against the current URL.
+                        next_url = str(httpx.URL(current).join(location))
+                        current = validate_url(next_url, allow_private=allow_private)
+                        # Drain & continue to next hop.
+                        await response.aclose()
+                        continue
+
+                    if response.status_code >= 400:
+                        raise URLFetchError(f"Upstream returned HTTP {response.status_code}")
+
+                    # Cheap pre-flight using Content-Length when available.
+                    declared_len = response.headers.get("content-length")
+                    if declared_len and declared_len.isdigit() and int(declared_len) > max_bytes:
+                        raise URLFetchError(f"Response exceeds maximum size of {max_bytes} bytes")
+
+                    media_type, charset = _normalize_mime(response.headers.get("content-type", ""))
+                    # Reject responses with no Content-Type or a type not on
+                    # the allowlist. An unset header is suspicious and lets a
+                    # server smuggle binary/executable content past us.
+                    if not media_type or media_type not in ALLOWED_MIME_TYPES:
+                        raise URLFetchError(f"Unsupported or missing content type '{media_type}'")
+
+                    body = await _read_capped(response, max_bytes)
+                    if not body:
+                        raise URLFetchError("Empty response body")
+
+                    return FetchedURL(
+                        url=url,
+                        final_url=current,
+                        content=body,
+                        content_type=media_type or "application/octet-stream",
+                        charset=charset,
+                    )
+            except httpx.TimeoutException as e:
+                raise URLFetchError("Request timed out") from e
+            except httpx.RequestError as e:
+                # Network-level error (connect refused, TLS, etc.). Surface a
+                # generic message — don't leak internal infrastructure details.
+                logger.warning("URL fetch network error for %s: %s", current, e)
+                raise URLFetchError("Network error fetching URL") from e
+
+        raise URLFetchError(f"Too many redirects (max {max_redirects})")
+    finally:
+        if owns_client and client is not None:
+            await client.aclose()
+
+
+def html_to_markdown(content: bytes, charset: Optional[str] = None) -> str:
+    """Best-effort HTML→markdown fallback used when Docling cannot convert.
+
+    Strips scripts/styles, drops tags, collapses whitespace. Output is plain
+    text wrapped in a minimal structure that preserves line breaks; it is fed
+    through the same chunker pipeline.
+    """
+    import html
+    import re
+
+    if not content:
+        return ""
+
+    encoding = charset or "utf-8"
+    try:
+        text = content.decode(encoding, errors="replace")
+    except (LookupError, TypeError):
+        text = content.decode("utf-8", errors="replace")
+
+    # Strip script/style/noscript blocks first (case-insensitive, multiline).
+    text = re.sub(
+        r"<(script|style|noscript|template)\b[^>]*>.*?</\1>",
+        " ",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    # Convert paragraph/line-break tags to explicit newlines.
+    text = re.sub(r"</(p|div|section|article|li|h[1-6]|tr|br)>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    # Drop remaining tags.
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Decode entities.
+    text = html.unescape(text)
+    # Collapse runs of whitespace per line, then trim blank lines.
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.splitlines()]
+    cleaned = "\n".join(line for line in lines if line)
+    return cleaned

--- a/apps/api/src/worker.py
+++ b/apps/api/src/worker.py
@@ -220,3 +220,243 @@ def ingest_document(
                 task_logger.info("Cleaned up temp dir: %s", temp_dir)
 
     return asyncio.run(_run())
+
+
+@celery_app.task(
+    bind=True,
+    name="mongorag.ingest_url",
+    max_retries=2,
+    autoretry_for=(ConnectionError,),
+    retry_backoff=15,
+    retry_backoff_max=120,
+)
+def ingest_url(
+    self,
+    url: str,
+    document_id: str,
+    tenant_id: str,
+    title: str | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    """Fetch a URL, convert it to markdown, and run the full ingestion pipeline.
+
+    SSRF defense and size/MIME limits live in
+    :mod:`src.services.ingestion.url_loader`. This task is the same
+    chunk → embed → persist flow as :func:`ingest_document`, but the source is
+    the fetched response body written to a temp file so Docling sees a real
+    path with the right extension.
+
+    Args:
+        url: User-supplied URL to fetch.
+        document_id: Pre-created document ID.
+        tenant_id: Tenant ID for isolation.
+        title: Optional caller-supplied title override.
+        metadata: Optional caller metadata.
+    """
+    import asyncio
+
+    async def _run() -> dict:
+        import os
+        import tempfile
+
+        from pymongo import AsyncMongoClient
+
+        from src.models.document import DocumentModel, DocumentStatus
+        from src.services.ingestion.chunker import ChunkingConfig, create_chunker
+        from src.services.ingestion.embedder import create_embedder
+        from src.services.ingestion.ingest import DocumentIngestionPipeline, IngestionConfig
+        from src.services.ingestion.service import IngestionService
+        from src.services.ingestion.url_loader import (
+            URLFetchError,
+            URLValidationError,
+            fetch_url,
+            html_to_markdown,
+        )
+
+        client = AsyncMongoClient(settings.mongodb_uri, serverSelectionTimeoutMS=5000)
+        db = client[settings.mongodb_database]
+        service = IngestionService(
+            documents_collection=db[settings.mongodb_collection_documents],
+            chunks_collection=db[settings.mongodb_collection_chunks],
+        )
+
+        temp_dir = tempfile.mkdtemp(prefix="mongorag-url-")
+        try:
+            await service.update_status(document_id, tenant_id, DocumentStatus.PROCESSING)
+
+            try:
+                fetched = await fetch_url(url, settings)
+            except URLValidationError as e:
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message=f"URL rejected: {e}",
+                )
+                return {"document_id": document_id, "status": "failed", "chunk_count": 0}
+            except URLFetchError as e:
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message=f"Fetch failed: {e}",
+                )
+                return {"document_id": document_id, "status": "failed", "chunk_count": 0}
+
+            # Pick an extension based on detected MIME so Docling routes correctly.
+            _docx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            _pptx = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            _xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            mime_to_ext = {
+                "text/html": ".html",
+                "application/xhtml+xml": ".html",
+                "text/plain": ".txt",
+                "text/markdown": ".md",
+                "application/pdf": ".pdf",
+                "application/msword": ".doc",
+                _docx: ".docx",
+                "application/vnd.ms-powerpoint": ".ppt",
+                _pptx: ".pptx",
+                "application/vnd.ms-excel": ".xls",
+                _xlsx: ".xlsx",
+            }
+            ext = mime_to_ext.get(fetched.content_type, ".bin")
+            temp_path = os.path.join(temp_dir, f"document{ext}")
+            with open(temp_path, "wb") as f:
+                f.write(fetched.content)
+
+            config = IngestionConfig()
+            pipeline = DocumentIngestionPipeline(config=config)
+
+            content = ""
+            docling_doc = None
+            try:
+                content, docling_doc = pipeline.read_document(temp_path)
+            except Exception as docling_err:  # noqa: BLE001
+                task_logger.warning(
+                    "Docling failed for URL ingestion (doc=%s): %s — falling back",
+                    document_id,
+                    docling_err,
+                )
+
+            # Fallback: pure-Python HTML→markdown if Docling produced nothing useful.
+            if (not content or not content.strip()) and fetched.content_type in {
+                "text/html",
+                "application/xhtml+xml",
+            }:
+                content = html_to_markdown(fetched.content, fetched.charset)
+
+            if not content or not content.strip():
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message="Could not extract text from URL",
+                )
+                return {"document_id": document_id, "status": "failed", "chunk_count": 0}
+
+            content_hash = DocumentModel.hash_content(content)
+            source = fetched.final_url
+
+            existing_doc = await service.check_duplicate(tenant_id, source, content_hash)
+            if existing_doc:
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message="Duplicate of existing document",
+                )
+                existing_id = str(existing_doc["_id"])
+                return {
+                    "document_id": existing_id,
+                    "status": "ready",
+                    "chunk_count": existing_doc.get("chunk_count", 0),
+                }
+
+            latest_version = await service.get_latest_version(tenant_id, source)
+            version = latest_version + 1
+
+            resolved_title = title if title else pipeline.extract_title(content, temp_path)
+
+            chunker = create_chunker(ChunkingConfig(max_tokens=config.max_tokens))
+            merged_meta = dict(metadata or {})
+            merged_meta.update(
+                {
+                    "source_url": fetched.url,
+                    "final_url": fetched.final_url,
+                    "content_type": fetched.content_type,
+                }
+            )
+            chunks = await chunker.chunk_document(
+                content=content,
+                title=resolved_title,
+                source=source,
+                metadata=merged_meta,
+                docling_doc=docling_doc,
+            )
+
+            if not chunks:
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message="No chunks created from URL",
+                )
+                return {"document_id": document_id, "status": "failed", "chunk_count": 0}
+
+            embedder = create_embedder()
+            embedded_chunks = await embedder.embed_chunks(chunks)
+
+            chunk_count = await service.store_chunks(
+                chunks=embedded_chunks,
+                document_id=document_id,
+                tenant_id=tenant_id,
+                source=source,
+                version=version,
+                embedding_model=settings.embedding_model,
+            )
+
+            await service.update_status(
+                document_id,
+                tenant_id,
+                DocumentStatus.READY,
+                chunk_count=chunk_count,
+                content_hash=content_hash,
+                version=version,
+                content=content,
+            )
+
+            task_logger.info(
+                "URL ingestion complete: doc=%s tenant=%s url=%s chunks=%d",
+                document_id,
+                tenant_id,
+                source,
+                chunk_count,
+            )
+            return {
+                "document_id": document_id,
+                "status": "ready",
+                "chunk_count": chunk_count,
+            }
+
+        except Exception as e:
+            task_logger.exception("URL ingestion failed: doc=%s err=%s", document_id, e)
+            safe_error = type(e).__name__
+            try:
+                await service.update_status(
+                    document_id,
+                    tenant_id,
+                    DocumentStatus.FAILED,
+                    error_message=safe_error,
+                )
+            except Exception:
+                task_logger.exception("Failed to update status after error")
+            raise
+        finally:
+            await client.close()
+            import shutil as _shutil
+
+            if os.path.exists(temp_dir):
+                _shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return asyncio.run(_run())

--- a/apps/api/tests/test_ingest_router.py
+++ b/apps/api/tests/test_ingest_router.py
@@ -155,3 +155,89 @@ def test_document_status_not_found(app_client):
         )
 
         assert response.status_code == 404
+
+
+# --- URL ingestion endpoint -----------------------------------------------
+
+
+@pytest.mark.unit
+def test_ingest_url_rejects_invalid_scheme(app_client):
+    """POST /ingest-url with file:// returns 422 from Pydantic validator."""
+    client, _ = app_client
+    response = client.post(
+        "/api/v1/documents/ingest-url",
+        json={"url": "file:///etc/passwd"},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_ingest_url_rejects_missing_auth(app_client):
+    """Missing JWT returns 401."""
+    client, _ = app_client
+    response = client.post(
+        "/api/v1/documents/ingest-url",
+        json={"url": "https://example.com/"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+def test_ingest_url_rejects_private_ip(app_client):
+    """Private-IP URL is rejected at request time (422), not after enqueue."""
+    client, _ = app_client
+    response = client.post(
+        "/api/v1/documents/ingest-url",
+        json={"url": "http://10.0.0.1/secret"},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_ingest_url_rejects_credentials_in_url(app_client):
+    """URLs with embedded credentials are rejected."""
+    client, _ = app_client
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        response = client.post(
+            "/api/v1/documents/ingest-url",
+            json={"url": "https://user:pw@example.com/"},
+            headers=make_auth_header(),
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_ingest_url_dispatches_celery_task(app_client):
+    """Valid URL returns 202 with document_id and task_id."""
+    client, _ = app_client
+
+    with (
+        patch("src.routers.ingest.ingest_url") as mock_task,
+        patch("src.routers.ingest.IngestionService") as mock_service_cls,
+        patch(
+            "src.services.ingestion.url_loader.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ),
+    ):
+        mock_task.delay.return_value = MagicMock(id="celery-url-task-456")
+        mock_service = MagicMock()
+        mock_service.create_pending_document = AsyncMock(return_value="doc-url-789")
+        mock_service.update_status = AsyncMock()
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/api/v1/documents/ingest-url",
+            json={"url": "https://example.com/article", "title": "Override"},
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["document_id"] == "doc-url-789"
+    assert body["status"] == "pending"
+    assert body["task_id"] == "celery-url-task-456"

--- a/apps/api/tests/test_url_loader.py
+++ b/apps/api/tests/test_url_loader.py
@@ -1,0 +1,327 @@
+"""Unit tests for URL loader: SSRF defense, MIME allowlist, size guard.
+
+These tests exercise validate_url() against the IP/host blocklists and
+fetch_url() against a fake httpx transport so they run with no network access.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.core.settings import Settings
+from src.services.ingestion.url_loader import (
+    URLFetchError,
+    URLValidationError,
+    fetch_url,
+    html_to_markdown,
+    validate_url,
+)
+
+
+def _settings(**overrides) -> Settings:
+    """Build a Settings instance with safe test defaults."""
+    base = {
+        "mongodb_uri": "mongodb://localhost:27017/test",
+        "llm_api_key": "x",
+        "embedding_api_key": "x",
+        "nextauth_secret": "test-secret-for-unit-tests-minimum-32chars",
+        "url_fetch_timeout_seconds": 5.0,
+        "url_fetch_max_redirects": 3,
+        "url_fetch_max_size_mb": 1,
+        "url_fetch_allow_private_ips": False,
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+# --- validate_url ---------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_non_http_schemes():
+    """file://, ftp://, gopher://, javascript: must be rejected."""
+    for bad in [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "gopher://example.com",
+        "javascript:alert(1)",
+        "data:text/html,<script>1</script>",
+    ]:
+        with pytest.raises(URLValidationError):
+            validate_url(bad)
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_credentials_in_url():
+    """URLs with embedded basic-auth must be rejected."""
+    with pytest.raises(URLValidationError):
+        validate_url("https://user:pass@example.com/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_loopback_literal():
+    with pytest.raises(URLValidationError):
+        validate_url("http://127.0.0.1/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_localhost_resolving_to_loopback():
+    """`localhost` typically resolves to 127.0.0.1 — must be blocked."""
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("127.0.0.1", 0))],
+    ):
+        with pytest.raises(URLValidationError):
+            validate_url("http://localhost/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_private_rfc1918():
+    for ip in ["10.0.0.1", "192.168.1.1", "172.16.5.5"]:
+        with pytest.raises(URLValidationError):
+            validate_url(f"http://{ip}/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_link_local_and_metadata():
+    """169.254.0.0/16 covers AWS/GCP/Azure metadata + the explicit blocklist."""
+    with pytest.raises(URLValidationError):
+        validate_url("http://169.254.169.254/")
+    with pytest.raises(URLValidationError):
+        validate_url("http://metadata.google.internal/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_ipv6_loopback():
+    with pytest.raises(URLValidationError):
+        validate_url("http://[::1]/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_ipv6_link_local():
+    with pytest.raises(URLValidationError):
+        validate_url("http://[fe80::1]/")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_dns_rebind_mixed_resolution():
+    """If a hostname resolves to one public + one private IP, reject it."""
+    addrs = [
+        (2, 1, 6, "", ("203.0.113.10", 0)),  # public
+        (2, 1, 6, "", ("10.0.0.5", 0)),  # private — must trigger reject
+    ]
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=addrs,
+    ):
+        with pytest.raises(URLValidationError):
+            validate_url("http://rebound.example.com/")
+
+
+@pytest.mark.unit
+def test_validate_url_accepts_public_ip():
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        out = validate_url("https://example.com/page")
+        assert out.startswith("https://example.com")
+
+
+@pytest.mark.unit
+def test_validate_url_rejects_oversized_url():
+    long_url = "https://example.com/" + ("a" * 5000)
+    with pytest.raises(URLValidationError):
+        validate_url(long_url)
+
+
+# --- html_to_markdown -----------------------------------------------------
+
+
+@pytest.mark.unit
+def test_html_to_markdown_strips_scripts_and_styles():
+    html = b"""<html><head><style>body{}</style><script>alert(1)</script></head>
+    <body><h1>Hello</h1><p>World</p></body></html>"""
+    out = html_to_markdown(html)
+    assert "alert" not in out
+    assert "Hello" in out
+    assert "World" in out
+
+
+@pytest.mark.unit
+def test_html_to_markdown_handles_invalid_charset():
+    out = html_to_markdown(b"<p>hi</p>", charset="not-a-real-encoding")
+    assert "hi" in out
+
+
+# --- fetch_url ------------------------------------------------------------
+
+
+def _make_client(handler) -> httpx.AsyncClient:
+    """Wrap a request handler in an httpx AsyncClient using MockTransport."""
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(
+        transport=transport,
+        follow_redirects=False,
+        timeout=httpx.Timeout(5.0),
+        max_redirects=0,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_returns_body_for_allowed_mime():
+    body = b"<html><body><h1>Hi</h1></body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=body, headers={"content-type": "text/html; charset=utf-8"}
+        )
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        result = await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()
+
+    assert result.content == body
+    assert result.content_type == "text/html"
+    assert result.charset == "utf-8"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_rejects_disallowed_mime():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=b"binary", headers={"content-type": "application/x-msdownload"}
+        )
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url("https://example.com/x", _settings(), client=client)
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_rejects_missing_content_type():
+    """Server with no Content-Type header is suspicious — reject."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # httpx auto-sets content-type when content is given, so override.
+        return httpx.Response(200, content=b"<p>hi</p>", headers={"content-type": ""})
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_rejects_oversized_via_content_length():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"x" * 100,
+            headers={
+                "content-type": "text/html",
+                "content-length": str(50 * 1024 * 1024),
+            },
+        )
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_rejects_oversized_via_streaming():
+    """Server lies (no content-length) but body exceeds the cap mid-stream."""
+    big = b"x" * (2 * 1024 * 1024)  # 2MB; cap is 1MB per _settings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=big, headers={"content-type": "text/html"})
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_redirect_to_private_ip_blocked():
+    """Open-redirect → 127.0.0.1 must be rejected on the redirect hop."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "example.com":
+            return httpx.Response(302, headers={"location": "http://127.0.0.1/admin"})
+        return httpx.Response(200, content=b"secret", headers={"content-type": "text/html"})
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLValidationError):
+            await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_too_many_redirects():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "https://example.com/next"})
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url(
+                "https://example.com/", _settings(url_fetch_max_redirects=2), client=client
+            )
+        await client.aclose()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_url_propagates_http_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b"err", headers={"content-type": "text/html"})
+
+    with patch(
+        "src.services.ingestion.url_loader.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        client = _make_client(handler)
+        with pytest.raises(URLFetchError):
+            await fetch_url("https://example.com/", _settings(), client=client)
+        await client.aclose()


### PR DESCRIPTION
Closes #19

## Summary
- New `POST /api/v1/documents/ingest-url` accepts `{url, title?, metadata?}`, validates the URL synchronously, dispatches a Celery task that fetches, chunks, embeds, and persists the page through the existing ingestion pipeline.
- Strict SSRF defense in `apps/api/src/services/ingestion/url_loader.py`:
  - http/https only; no credentials in URL; max-length cap.
  - Hostname resolved and ALL returned IPs checked (private/RFC1918, loopback, link-local, multicast, reserved, metadata endpoints incl. 169.254.169.254, fd00:ec2::254, 100.100.100.200, metadata.google.internal).
  - Manual redirect handling with re-validation each hop — defeats open-redirect → internal-IP and DNS-rebinding-on-redirect.
  - MIME allowlist matching Docling's supported formats; missing Content-Type rejected.
  - Streaming response cap with both Content-Length pre-flight and per-chunk hard limit.
- Pure-Python HTML→markdown fallback when Docling can't convert.
- New settings: `URL_FETCH_TIMEOUT_SECONDS`, `URL_FETCH_MAX_REDIRECTS`, `URL_FETCH_MAX_SIZE_MB`, `URL_FETCH_ALLOW_PRIVATE_IPS` (defaults to `false`).

## Test plan
- [x] `uv run pytest -m unit` — 185 passed (31 new tests covering scheme/credentials/loopback/RFC1918/IPv6/metadata/DNS-rebinding/oversize/redirect-to-private/MIME-spoof/missing-content-type)
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [ ] Manual smoke against a public URL once deployed