### PR TITLE
feat(api): document CRUD API

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -12,6 +12,7 @@ from src.core.middleware import TenantGuardMiddleware
 from src.routers.auth import router as auth_router
 from src.routers.billing import router as billing_router
 from src.routers.chat import router as chat_router
+from src.routers.documents import router as documents_router
 from src.routers.health import router as health_router
 from src.routers.ingest import router as ingest_router
 from src.routers.keys import router as keys_router
@@ -72,6 +73,10 @@ app.add_middleware(TenantGuardMiddleware)
 # Include routers
 app.include_router(health_router)
 app.include_router(ingest_router)
+# documents_router shares the /api/v1/documents prefix with ingest_router but
+# owns the CRUD verbs; registered after so its dynamic /{id} routes don't
+# shadow the literal /ingest path on the ingest router.
+app.include_router(documents_router)
 app.include_router(chat_router)
 app.include_router(auth_router)
 app.include_router(keys_router)

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -26,6 +26,78 @@ class DocumentStatusResponse(BaseModel):
     error_message: Optional[str] = None
 
 
+# --- Document CRUD ---
+
+
+class DocumentRecord(BaseModel):
+    """A single document as returned by CRUD endpoints (no content/embeddings)."""
+
+    document_id: str
+    title: str
+    source: str
+    status: str
+    chunk_count: int = 0
+    format: str = ""
+    size_bytes: Optional[int] = None
+    metadata: dict = Field(default_factory=dict)
+    version: int = 1
+    error_message: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DocumentListResponse(BaseModel):
+    """Paginated document listing."""
+
+    items: list[DocumentRecord]
+    total: int
+    page: int
+    page_size: int
+
+
+class DocumentUpdateRequest(BaseModel):
+    """PATCH body for updating user-editable document metadata."""
+
+    title: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    metadata: Optional[dict] = Field(default=None, description="Replace metadata dict wholesale")
+
+    @field_validator("metadata")
+    @classmethod
+    def metadata_must_be_dict(cls, v: Optional[dict]) -> Optional[dict]:
+        if v is None:
+            return v
+        if not isinstance(v, dict):
+            raise ValueError("metadata must be a JSON object")
+        return v
+
+
+class BulkDeleteRequest(BaseModel):
+    """Body for bulk delete: {ids: [...]}."""
+
+    ids: list[str] = Field(..., min_length=1, max_length=100)
+
+    @field_validator("ids")
+    @classmethod
+    def ids_must_be_unique_nonempty(cls, v: list[str]) -> list[str]:
+        if any(not isinstance(i, str) or not i.strip() for i in v):
+            raise ValueError("ids must be non-empty strings")
+        return list({i for i in v})  # de-dupe
+
+
+class BulkDeleteResponse(BaseModel):
+    """Result of a bulk delete operation."""
+
+    requested: int
+    deleted: int
+
+
+class ReingestResponse(BaseModel):
+    """Response from re-ingestion trigger."""
+
+    document_id: str
+    status: str
+
+
 # --- Chat ---
 
 

--- a/apps/api/src/routers/documents.py
+++ b/apps/api/src/routers/documents.py
@@ -1,0 +1,206 @@
+"""Document CRUD endpoints (list, get, patch, delete, reingest).
+
+These endpoints are tenant-scoped via the JWT-or-API-key dependency.
+The tenant_id is ALWAYS derived from the auth principal — it is never
+read from request body or query string.
+
+Companion to ``routers/ingest.py`` which owns POST /ingest and the
+status polling endpoint at /{id}/status.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated, Literal, Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
+
+from src.core.dependencies import AgentDependencies
+from src.core.deps import get_deps
+from src.core.tenant import get_tenant_id
+from src.models.api import (
+    BulkDeleteRequest,
+    BulkDeleteResponse,
+    DocumentListResponse,
+    DocumentRecord,
+    DocumentUpdateRequest,
+    ReingestResponse,
+)
+from src.services.ingestion.service import IngestionService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/documents", tags=["documents"])
+
+
+def _ingestion_service(
+    deps: AgentDependencies = Depends(get_deps),
+) -> IngestionService:
+    return IngestionService(
+        documents_collection=deps.documents_collection,
+        chunks_collection=deps.chunks_collection,
+    )
+
+
+def _to_record(doc: dict) -> DocumentRecord:
+    """Convert a stored document dict to the API response model.
+
+    Derives ``format`` from the file extension of ``source`` if not stored.
+    """
+    source = doc.get("source", "") or ""
+    fmt = doc.get("format")
+    if not fmt:
+        ext = os.path.splitext(source)[1].lower().lstrip(".")
+        fmt = ext or ""
+
+    return DocumentRecord(
+        document_id=str(doc["_id"]),
+        title=doc.get("title", ""),
+        source=source,
+        status=str(doc.get("status", "unknown")),
+        chunk_count=int(doc.get("chunk_count", 0) or 0),
+        format=fmt,
+        size_bytes=doc.get("size_bytes"),
+        metadata=doc.get("metadata") or {},
+        version=int(doc.get("version", 1) or 1),
+        error_message=doc.get("error_message"),
+        created_at=doc["created_at"],
+        updated_at=doc.get("updated_at", doc["created_at"]),
+    )
+
+
+@router.get("", response_model=DocumentListResponse)
+async def list_documents(
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+    page: int = Query(default=1, ge=1, le=10_000),
+    page_size: int = Query(default=20, ge=1, le=100),
+    status_filter: Optional[Literal["pending", "processing", "ready", "failed"]] = Query(
+        default=None, alias="status"
+    ),
+    search: Optional[str] = Query(default=None, max_length=200),
+    sort: Literal["created_at", "updated_at", "title", "status"] = Query(default="created_at"),
+    order: Literal["asc", "desc"] = Query(default="desc"),
+) -> DocumentListResponse:
+    """List documents for the authenticated tenant.
+
+    Pagination is offset-based (page/page_size). Tenant_id is forced from
+    the JWT/API-key — it cannot be supplied by the caller.
+    """
+    items, total = await service.list_documents(
+        tenant_id=tenant_id,
+        page=page,
+        page_size=page_size,
+        status=status_filter,
+        search=search,
+        sort=sort,
+        order=order,
+    )
+    return DocumentListResponse(
+        items=[_to_record(d) for d in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.delete("", response_model=BulkDeleteResponse)
+async def bulk_delete_documents(
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+    body: BulkDeleteRequest = Body(...),
+) -> BulkDeleteResponse:
+    """Cascade-delete a list of documents (and their chunks) for this tenant.
+
+    Tenant scope is enforced per-id; ids that do not belong to this tenant
+    are silently ignored (counted as not deleted) to prevent enumeration.
+    """
+    deleted = await service.bulk_delete_with_cascade(body.ids, tenant_id)
+    logger.info(
+        "bulk_delete_documents tenant=%s requested=%d deleted=%d",
+        tenant_id,
+        len(body.ids),
+        deleted,
+    )
+    return BulkDeleteResponse(requested=len(body.ids), deleted=deleted)
+
+
+@router.get("/{document_id}", response_model=DocumentRecord)
+async def get_document(
+    document_id: str,
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+) -> DocumentRecord:
+    """Fetch a single document. 404 for missing OR cross-tenant ids."""
+    doc = await service.get_document(document_id, tenant_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return _to_record(doc)
+
+
+@router.patch("/{document_id}", response_model=DocumentRecord)
+async def update_document(
+    document_id: str,
+    body: DocumentUpdateRequest,
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+) -> DocumentRecord:
+    """Update title and/or metadata. Other fields are immutable here."""
+    if body.title is None and body.metadata is None:
+        raise HTTPException(status_code=422, detail="No fields to update")
+
+    updated = await service.update_metadata(
+        document_id=document_id,
+        tenant_id=tenant_id,
+        title=body.title,
+        metadata=body.metadata,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return _to_record(updated)
+
+
+@router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document(
+    document_id: str,
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+) -> Response:
+    """Cascade-delete a document and all of its chunks.
+
+    Atomic via a Mongo transaction when supported; falls back to a
+    sequenced delete (chunks first, then doc) on standalone deployments.
+    """
+    deleted = await service.delete_document_with_cascade(document_id, tenant_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{document_id}/reingest", response_model=ReingestResponse, status_code=202)
+async def reingest_document_endpoint(
+    document_id: str,
+    tenant_id: Annotated[str, Depends(get_tenant_id)],
+    service: Annotated[IngestionService, Depends(_ingestion_service)],
+) -> ReingestResponse:
+    """Mark a document for re-processing.
+
+    Flips status back to ``pending`` so the worker can re-chunk and re-embed
+    on its next sweep. Refuses if the document is currently ``processing``
+    to avoid racing the existing worker run.
+    """
+    updated = await service.mark_for_reingestion(document_id, tenant_id)
+    if not updated:
+        # Could be: missing, wrong tenant, OR already in-flight.
+        # We can't distinguish without an extra read — but a second read
+        # could leak existence to other tenants, so return 404/409 only
+        # after confirming tenant ownership.
+        existing = await service.get_document(document_id, tenant_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Document not found")
+        raise HTTPException(
+            status_code=409,
+            detail="Document is currently processing; reingest not allowed",
+        )
+    return ReingestResponse(document_id=str(updated["_id"]), status=updated["status"])

--- a/apps/api/src/services/ingestion/service.py
+++ b/apps/api/src/services/ingestion/service.py
@@ -3,14 +3,34 @@
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.errors import OperationFailure
 
 from src.models.document import ChunkModel, DocumentStatus
 from src.services.ingestion.chunker import DocumentChunk
 
 logger = logging.getLogger(__name__)
+
+# Fields exposed in API responses (whitelist — never leak content/embedding).
+DOCUMENT_PROJECTION: dict[str, int] = {
+    "_id": 1,
+    "tenant_id": 1,
+    "title": 1,
+    "source": 1,
+    "status": 1,
+    "chunk_count": 1,
+    "version": 1,
+    "metadata": 1,
+    "size_bytes": 1,
+    "format": 1,
+    "error_message": 1,
+    "created_at": 1,
+    "updated_at": 1,
+}
+
+ALLOWED_SORT_FIELDS = {"created_at", "updated_at", "title", "status"}
 
 
 class IngestionService:
@@ -245,3 +265,187 @@ class IngestionService:
             },
         )
         return doc
+
+    # -- CRUD helpers --
+
+    async def get_document(self, document_id: str, tenant_id: str) -> Optional[dict[str, Any]]:
+        """Fetch a single document scoped by tenant_id.
+
+        Returns the document dict (whitelisted projection) or None.
+        Tenant_id is part of the filter so cross-tenant reads return None
+        with the same shape as a true 404 — preventing enumeration.
+        """
+        return await self.documents.find_one(
+            {"_id": document_id, "tenant_id": tenant_id},
+            projection=DOCUMENT_PROJECTION,
+        )
+
+    async def list_documents(
+        self,
+        tenant_id: str,
+        page: int = 1,
+        page_size: int = 20,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+        sort: str = "created_at",
+        order: str = "desc",
+    ) -> tuple[list[dict[str, Any]], int]:
+        """List documents for a tenant with pagination, filter and sort.
+
+        Tenant_id is forced — never trusted from caller's filter dict.
+        Returns (items, total).
+        """
+        filter_q: dict[str, Any] = {"tenant_id": tenant_id}
+        if status:
+            filter_q["status"] = status
+        if search:
+            # Escape regex meta and anchor case-insensitive prefix-friendly search
+            escaped = _escape_regex(search)
+            filter_q["title"] = {"$regex": escaped, "$options": "i"}
+
+        sort_field = sort if sort in ALLOWED_SORT_FIELDS else "created_at"
+        sort_dir = -1 if order == "desc" else 1
+        # Tie-breaker on _id so paging is stable when sort field has ties.
+        sort_spec: list[tuple[str, int]] = [(sort_field, sort_dir), ("_id", -1)]
+
+        skip = max(0, (page - 1) * page_size)
+        cursor = (
+            self.documents.find(filter_q, projection=DOCUMENT_PROJECTION)
+            .sort(sort_spec)
+            .skip(skip)
+            .limit(page_size)
+        )
+        items = [doc async for doc in cursor]
+        total = await self.documents.count_documents(filter_q)
+        return items, total
+
+    async def update_metadata(
+        self,
+        document_id: str,
+        tenant_id: str,
+        title: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Update title and/or metadata on a document, tenant-scoped.
+
+        Returns the updated document or None if not found.
+        Refuses to update tenant_id, content, embeddings, status — those
+        are owned by the ingestion pipeline.
+        """
+        update_set: dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+        if title is not None:
+            update_set["title"] = title
+        if metadata is not None:
+            update_set["metadata"] = metadata
+
+        if len(update_set) == 1:
+            # Nothing user-provided — no-op, but still return current state.
+            return await self.get_document(document_id, tenant_id)
+
+        result = await self.documents.find_one_and_update(
+            {"_id": document_id, "tenant_id": tenant_id},
+            {"$set": update_set},
+            projection=DOCUMENT_PROJECTION,
+            return_document=True,  # return updated doc (ReturnDocument.AFTER == True)
+        )
+        return result
+
+    async def delete_document_with_cascade(self, document_id: str, tenant_id: str) -> bool:
+        """Atomically delete a document and all its chunks within a tenant.
+
+        Tries a Mongo transaction first; falls back to sequenced deletes
+        (chunks first, then document) for non-replica-set deployments.
+        Returns True if a document was deleted, False if not found.
+        """
+        client = self.documents.database.client
+        # Pre-flight: confirm doc exists for this tenant before touching chunks.
+        doc = await self.documents.find_one(
+            {"_id": document_id, "tenant_id": tenant_id},
+            projection={"_id": 1},
+        )
+        if not doc:
+            return False
+
+        try:
+            async with client.start_session() as session:
+
+                async def _txn_body(s) -> int:
+                    await self.chunks.delete_many(
+                        {"document_id": document_id, "tenant_id": tenant_id},
+                        session=s,
+                    )
+                    res = await self.documents.delete_one(
+                        {"_id": document_id, "tenant_id": tenant_id},
+                        session=s,
+                    )
+                    return res.deleted_count
+
+                deleted_count = await session.with_transaction(_txn_body)
+                return deleted_count == 1
+        except OperationFailure as e:
+            # Standalone Mongo (e.g. local dev) doesn't support transactions.
+            # Fall back to sequenced deletes — chunks first so a mid-failure
+            # leaves a stale doc (visible, recoverable) rather than orphan
+            # chunks (invisible, undeletable via API).
+            if _is_no_transaction_support(e):
+                logger.info("transactions_unsupported_falling_back")
+            else:
+                logger.warning("transaction_delete_failed: %s", e)
+
+            await self.chunks.delete_many({"document_id": document_id, "tenant_id": tenant_id})
+            res = await self.documents.delete_one({"_id": document_id, "tenant_id": tenant_id})
+            return res.deleted_count == 1
+
+    async def bulk_delete_with_cascade(self, document_ids: Iterable[str], tenant_id: str) -> int:
+        """Cascade-delete a batch of documents, tenant-scoped.
+
+        Returns the number of documents actually deleted.
+        Iterates per-id so a single failure can't corrupt others.
+        """
+        deleted = 0
+        for doc_id in document_ids:
+            if await self.delete_document_with_cascade(doc_id, tenant_id):
+                deleted += 1
+        return deleted
+
+    async def mark_for_reingestion(
+        self, document_id: str, tenant_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Flip a document back to 'pending' for re-processing.
+
+        Returns the updated document or None if not found.
+        Does NOT touch chunks here — the worker will rebuild them.
+        Refuses if the document is already in-flight (processing).
+        """
+        result = await self.documents.find_one_and_update(
+            {
+                "_id": document_id,
+                "tenant_id": tenant_id,
+                "status": {"$ne": DocumentStatus.PROCESSING.value},
+            },
+            {
+                "$set": {
+                    "status": DocumentStatus.PENDING.value,
+                    "error_message": None,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+            projection=DOCUMENT_PROJECTION,
+            return_document=True,
+        )
+        return result
+
+
+def _escape_regex(s: str) -> str:
+    """Escape regex metacharacters for safe substring search."""
+    import re
+
+    return re.escape(s)
+
+
+def _is_no_transaction_support(e: OperationFailure) -> bool:
+    """Detect 'transactions require replica set' style errors."""
+    msg = str(e).lower()
+    return "transaction" in msg and (
+        "replica" in msg or "not supported" in msg or "standalone" in msg
+    )

--- a/apps/api/tests/test_documents_router.py
+++ b/apps/api/tests/test_documents_router.py
@@ -1,0 +1,414 @@
+"""Tests for the document CRUD router (#18).
+
+Covers list/get/patch/delete/reingest plus tenant isolation, validation,
+and cascade-delete semantics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.conftest import MOCK_TENANT_ID, make_auth_header, make_auth_header_b
+
+
+def _make_doc(
+    doc_id: str = "doc-1",
+    tenant_id: str = MOCK_TENANT_ID,
+    status: str = "ready",
+    title: str = "Sample Doc",
+    chunk_count: int = 5,
+    source: str = "sample.pdf",
+) -> dict:
+    now = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    return {
+        "_id": doc_id,
+        "tenant_id": tenant_id,
+        "title": title,
+        "source": source,
+        "status": status,
+        "chunk_count": chunk_count,
+        "version": 1,
+        "metadata": {"foo": "bar"},
+        "size_bytes": 1024,
+        "format": "",
+        "created_at": now,
+        "updated_at": now,
+        "error_message": None,
+    }
+
+
+@pytest.fixture
+def app_client():
+    """Test client with mocked deps wired through app.state."""
+    from src.main import app
+    from src.services.rate_limit import reset_default_limiter
+
+    reset_default_limiter()
+
+    deps = MagicMock()
+    deps.initialize = AsyncMock()
+    deps.cleanup = AsyncMock()
+    deps.db = MagicMock()
+    deps.settings = MagicMock()
+    deps.documents_collection = MagicMock()
+    deps.chunks_collection = MagicMock()
+    deps.api_keys_collection = MagicMock()
+    # Quota deps
+    deps.subscriptions_collection = MagicMock()
+    deps.subscriptions_collection.find_one = AsyncMock(
+        return_value={"plan": "free", "status": "active"}
+    )
+    deps.usage_collection = MagicMock()
+    deps.usage_collection.find_one_and_update = AsyncMock(
+        return_value={
+            "tenant_id": MOCK_TENANT_ID,
+            "period_key": "2026-04",
+            "queries_count": 1,
+        }
+    )
+
+    with TestClient(app) as c:
+        app.state.deps = deps
+        yield c, deps
+
+
+# --- list_documents ---
+
+
+@pytest.mark.unit
+def test_list_documents_requires_auth(app_client):
+    client, _ = app_client
+    response = client.get("/api/v1/documents")
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+def test_list_documents_returns_paginated(app_client):
+    client, _ = app_client
+    docs = [_make_doc(f"doc-{i}", title=f"Doc {i}") for i in range(3)]
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.list_documents = AsyncMock(return_value=(docs, 3))
+        svc_cls.return_value = svc
+
+        response = client.get(
+            "/api/v1/documents?page=1&page_size=10",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 3
+        assert body["page"] == 1
+        assert body["page_size"] == 10
+        assert len(body["items"]) == 3
+        assert body["items"][0]["document_id"] == "doc-0"
+
+        # tenant_id was forwarded from auth, not body/query
+        kwargs = svc.list_documents.call_args.kwargs
+        assert kwargs["tenant_id"] == MOCK_TENANT_ID
+
+
+@pytest.mark.unit
+def test_list_documents_passes_filters(app_client):
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.list_documents = AsyncMock(return_value=([], 0))
+        svc_cls.return_value = svc
+
+        response = client.get(
+            "/api/v1/documents?status=ready&search=invoice&sort=title&order=asc",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        kwargs = svc.list_documents.call_args.kwargs
+        assert kwargs["status"] == "ready"
+        assert kwargs["search"] == "invoice"
+        assert kwargs["sort"] == "title"
+        assert kwargs["order"] == "asc"
+
+
+@pytest.mark.unit
+def test_list_documents_invalid_status_rejected(app_client):
+    client, _ = app_client
+    response = client.get(
+        "/api/v1/documents?status=bogus",
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_list_documents_page_size_capped(app_client):
+    client, _ = app_client
+    response = client.get(
+        "/api/v1/documents?page_size=1000",
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+# --- get_document ---
+
+
+@pytest.mark.unit
+def test_get_document_returns_record(app_client):
+    client, _ = app_client
+    doc = _make_doc("doc-abc", title="Abc")
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.get_document = AsyncMock(return_value=doc)
+        svc_cls.return_value = svc
+
+        response = client.get(
+            "/api/v1/documents/doc-abc",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["document_id"] == "doc-abc"
+        assert body["chunk_count"] == 5
+        assert body["format"] == "pdf"
+        # tenant came from auth
+        assert svc.get_document.call_args.args[1] == MOCK_TENANT_ID
+
+
+@pytest.mark.unit
+def test_get_document_not_found_for_other_tenant(app_client):
+    """Cross-tenant read returns 404 (not 403) — no enumeration leak."""
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.get_document = AsyncMock(return_value=None)
+        svc_cls.return_value = svc
+
+        response = client.get(
+            "/api/v1/documents/doc-xyz",
+            headers=make_auth_header_b(),
+        )
+        assert response.status_code == 404
+
+
+# --- update_document ---
+
+
+@pytest.mark.unit
+def test_patch_document_updates_title(app_client):
+    client, _ = app_client
+    updated = _make_doc("doc-1", title="New Title")
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.update_metadata = AsyncMock(return_value=updated)
+        svc_cls.return_value = svc
+
+        response = client.patch(
+            "/api/v1/documents/doc-1",
+            json={"title": "New Title"},
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "New Title"
+
+
+@pytest.mark.unit
+def test_patch_document_rejects_empty_body(app_client):
+    client, _ = app_client
+    response = client.patch(
+        "/api/v1/documents/doc-1",
+        json={},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_patch_document_ignores_tenant_id_in_body(app_client):
+    """Even if caller sends tenant_id, server uses auth value."""
+    client, _ = app_client
+    updated = _make_doc("doc-1")
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.update_metadata = AsyncMock(return_value=updated)
+        svc_cls.return_value = svc
+
+        # tenant_id is silently dropped by the request model
+        response = client.patch(
+            "/api/v1/documents/doc-1",
+            json={"title": "X", "tenant_id": "evil-tenant"},
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        kwargs = svc.update_metadata.call_args.kwargs
+        assert kwargs["tenant_id"] == MOCK_TENANT_ID
+
+
+@pytest.mark.unit
+def test_patch_document_not_found(app_client):
+    client, _ = app_client
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.update_metadata = AsyncMock(return_value=None)
+        svc_cls.return_value = svc
+
+        response = client.patch(
+            "/api/v1/documents/missing",
+            json={"title": "X"},
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 404
+
+
+# --- delete_document ---
+
+
+@pytest.mark.unit
+def test_delete_document_returns_204(app_client):
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.delete_document_with_cascade = AsyncMock(return_value=True)
+        svc_cls.return_value = svc
+
+        response = client.delete(
+            "/api/v1/documents/doc-1",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 204
+        # Verify cascade was scoped to authed tenant
+        assert svc.delete_document_with_cascade.call_args.args == ("doc-1", MOCK_TENANT_ID)
+
+
+@pytest.mark.unit
+def test_delete_document_not_found(app_client):
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.delete_document_with_cascade = AsyncMock(return_value=False)
+        svc_cls.return_value = svc
+
+        response = client.delete(
+            "/api/v1/documents/missing",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 404
+
+
+# --- bulk delete ---
+
+
+@pytest.mark.unit
+def test_bulk_delete_documents(app_client):
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.bulk_delete_with_cascade = AsyncMock(return_value=2)
+        svc_cls.return_value = svc
+
+        response = client.request(
+            "DELETE",
+            "/api/v1/documents",
+            json={"ids": ["a", "b", "c"]},
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["deleted"] == 2
+        assert body["requested"] == 3
+        # tenant scoped
+        kwargs_or_args = svc.bulk_delete_with_cascade.call_args
+        assert MOCK_TENANT_ID in kwargs_or_args.args
+
+
+@pytest.mark.unit
+def test_bulk_delete_requires_nonempty(app_client):
+    client, _ = app_client
+    response = client.request(
+        "DELETE",
+        "/api/v1/documents",
+        json={"ids": []},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_bulk_delete_caps_batch(app_client):
+    client, _ = app_client
+    response = client.request(
+        "DELETE",
+        "/api/v1/documents",
+        json={"ids": [str(i) for i in range(101)]},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+# --- reingest ---
+
+
+@pytest.mark.unit
+def test_reingest_marks_pending(app_client):
+    client, _ = app_client
+    updated = _make_doc("doc-1", status="pending")
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.mark_for_reingestion = AsyncMock(return_value=updated)
+        svc_cls.return_value = svc
+
+        response = client.post(
+            "/api/v1/documents/doc-1/reingest",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 202
+        body = response.json()
+        assert body["status"] == "pending"
+
+
+@pytest.mark.unit
+def test_reingest_409_when_processing(app_client):
+    """Doc exists but is currently processing → 409."""
+    client, _ = app_client
+    existing = _make_doc("doc-1", status="processing")
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.mark_for_reingestion = AsyncMock(return_value=None)
+        svc.get_document = AsyncMock(return_value=existing)
+        svc_cls.return_value = svc
+
+        response = client.post(
+            "/api/v1/documents/doc-1/reingest",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 409
+
+
+@pytest.mark.unit
+def test_reingest_404_when_missing(app_client):
+    client, _ = app_client
+
+    with patch("src.routers.documents.IngestionService") as svc_cls:
+        svc = MagicMock()
+        svc.mark_for_reingestion = AsyncMock(return_value=None)
+        svc.get_document = AsyncMock(return_value=None)
+        svc_cls.return_value = svc
+
+        response = client.post(
+            "/api/v1/documents/missing/reingest",
+            headers=make_auth_header(),
+        )
+        assert response.status_code == 404

--- a/apps/api/tests/test_documents_service.py
+++ b/apps/api/tests/test_documents_service.py
@@ -1,0 +1,282 @@
+"""Service-level tests for IngestionService CRUD additions (#18)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import OperationFailure
+
+from src.services.ingestion.service import IngestionService
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def service():
+    documents = MagicMock()
+    chunks = MagicMock()
+
+    # Wire up an async client.start_session() context manager so cascade
+    # delete tests can switch between transaction-supported and standalone.
+    db = MagicMock()
+    client = MagicMock()
+    db.client = client
+    documents.database = db
+    return IngestionService(documents_collection=documents, chunks_collection=chunks)
+
+
+# --- list_documents ---
+
+
+@pytest.mark.unit
+async def test_list_documents_filters_by_tenant(service):
+    """Tenant_id is always added to the filter regardless of caller input."""
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.skip.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.__aiter__ = lambda self: _aiter([])
+    service.documents.find = MagicMock(return_value=cursor)
+    service.documents.count_documents = AsyncMock(return_value=0)
+
+    items, total = await service.list_documents(tenant_id="t1")
+    assert items == []
+    assert total == 0
+
+    filter_q = service.documents.find.call_args.args[0]
+    assert filter_q == {"tenant_id": "t1"}
+
+
+@pytest.mark.unit
+async def test_list_documents_search_is_regex_safe(service):
+    """Special regex characters in search input are escaped."""
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.skip.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.__aiter__ = lambda self: _aiter([])
+    service.documents.find = MagicMock(return_value=cursor)
+    service.documents.count_documents = AsyncMock(return_value=0)
+
+    await service.list_documents(tenant_id="t1", search=".*evil.*")
+
+    f = service.documents.find.call_args.args[0]
+    # Escaped pattern, not raw .*
+    assert f["title"]["$regex"].startswith(r"\.")
+
+
+@pytest.mark.unit
+async def test_list_documents_status_filter(service):
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.skip.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.__aiter__ = lambda self: _aiter([])
+    service.documents.find = MagicMock(return_value=cursor)
+    service.documents.count_documents = AsyncMock(return_value=0)
+
+    await service.list_documents(tenant_id="t1", status="ready")
+    assert service.documents.find.call_args.args[0]["status"] == "ready"
+
+
+@pytest.mark.unit
+async def test_list_documents_invalid_sort_field_falls_back(service):
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.skip.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.__aiter__ = lambda self: _aiter([])
+    service.documents.find = MagicMock(return_value=cursor)
+    service.documents.count_documents = AsyncMock(return_value=0)
+
+    await service.list_documents(tenant_id="t1", sort="; DROP TABLE; --")
+    sort_arg = cursor.sort.call_args.args[0]
+    # Falls back to created_at; never injects the bogus field
+    assert sort_arg[0][0] == "created_at"
+
+
+# --- update_metadata ---
+
+
+@pytest.mark.unit
+async def test_update_metadata_filters_by_tenant(service):
+    service.documents.find_one_and_update = AsyncMock(
+        return_value={
+            "_id": "d1",
+            "tenant_id": "t1",
+            "title": "x",
+            "source": "s",
+            "status": "ready",
+            "chunk_count": 0,
+            "version": 1,
+            "metadata": {},
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+    )
+    await service.update_metadata("d1", "t1", title="x")
+    f = service.documents.find_one_and_update.call_args.args[0]
+    assert f == {"_id": "d1", "tenant_id": "t1"}
+
+
+@pytest.mark.unit
+async def test_update_metadata_no_op_returns_current(service):
+    service.documents.find_one = AsyncMock(
+        return_value={
+            "_id": "d1",
+            "tenant_id": "t1",
+            "title": "x",
+            "source": "s.pdf",
+            "status": "ready",
+            "chunk_count": 0,
+            "version": 1,
+            "metadata": {},
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+    )
+    res = await service.update_metadata("d1", "t1")  # no fields
+    assert res["_id"] == "d1"
+
+
+# --- delete_document_with_cascade ---
+
+
+@pytest.mark.unit
+async def test_cascade_delete_returns_false_when_missing(service):
+    service.documents.find_one = AsyncMock(return_value=None)
+    res = await service.delete_document_with_cascade("missing", "t1")
+    assert res is False
+
+
+@pytest.mark.unit
+async def test_cascade_delete_uses_transaction_when_supported(service):
+    service.documents.find_one = AsyncMock(return_value={"_id": "d1"})
+
+    session = MagicMock()
+    session.with_transaction = AsyncMock()
+
+    async def _fake_with_tx(body):
+        # Run the body as if we were inside a transaction
+        return await body(session)
+
+    session.with_transaction.side_effect = _fake_with_tx
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    service.documents.database.client.start_session = MagicMock(return_value=cm)
+
+    service.chunks.delete_many = AsyncMock(return_value=MagicMock(deleted_count=3))
+    delete_result = MagicMock(deleted_count=1)
+    service.documents.delete_one = AsyncMock(return_value=delete_result)
+
+    ok = await service.delete_document_with_cascade("d1", "t1")
+    assert ok is True
+    # chunks delete was scoped by tenant + document
+    chunks_filter = service.chunks.delete_many.call_args.args[0]
+    assert chunks_filter == {"document_id": "d1", "tenant_id": "t1"}
+    # doc delete was scoped by tenant
+    doc_filter = service.documents.delete_one.call_args.args[0]
+    assert doc_filter == {"_id": "d1", "tenant_id": "t1"}
+
+
+@pytest.mark.unit
+async def test_cascade_delete_falls_back_on_standalone(service):
+    """When transactions are unsupported, falls back to sequenced deletes."""
+    service.documents.find_one = AsyncMock(return_value={"_id": "d1"})
+
+    cm = MagicMock()
+    session = MagicMock()
+    err = OperationFailure("Transaction numbers are only allowed on a replica set member or mongos")
+    session.with_transaction = AsyncMock(side_effect=err)
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    service.documents.database.client.start_session = MagicMock(return_value=cm)
+
+    service.chunks.delete_many = AsyncMock(return_value=MagicMock(deleted_count=2))
+    service.documents.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+
+    ok = await service.delete_document_with_cascade("d1", "t1")
+    assert ok is True
+    # Fallback path: chunks first, then doc — both tenant-scoped
+    assert service.chunks.delete_many.call_count == 1
+    assert service.documents.delete_one.call_count == 1
+
+
+@pytest.mark.unit
+async def test_bulk_delete_iterates_per_id(service):
+    """Bulk delete is per-id so a single id failure can't cascade.
+
+    Returns the total deleted count.
+    """
+    # First two ids exist, third doesn't.
+    service.documents.find_one = AsyncMock(side_effect=[{"_id": "a"}, {"_id": "b"}, None])
+
+    cm = MagicMock()
+    session = MagicMock()
+
+    async def _fake_with_tx(body):
+        return await body(session)
+
+    session.with_transaction = AsyncMock(side_effect=_fake_with_tx)
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    service.documents.database.client.start_session = MagicMock(return_value=cm)
+
+    service.chunks.delete_many = AsyncMock(return_value=MagicMock(deleted_count=0))
+    service.documents.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+
+    deleted = await service.bulk_delete_with_cascade(["a", "b", "c"], "t1")
+    assert deleted == 2
+
+
+# --- mark_for_reingestion ---
+
+
+@pytest.mark.unit
+async def test_reingest_skips_when_processing(service):
+    """The find filter excludes processing — the call returns None for racing docs."""
+    service.documents.find_one_and_update = AsyncMock(return_value=None)
+    res = await service.mark_for_reingestion("d1", "t1")
+    assert res is None
+    f = service.documents.find_one_and_update.call_args.args[0]
+    # Tenant scope + status guard both present
+    assert f["tenant_id"] == "t1"
+    assert f["_id"] == "d1"
+    assert f["status"]["$ne"] == "processing"
+
+
+@pytest.mark.unit
+async def test_reingest_flips_to_pending(service):
+    service.documents.find_one_and_update = AsyncMock(
+        return_value={
+            "_id": "d1",
+            "tenant_id": "t1",
+            "status": "pending",
+            "title": "x",
+            "source": "s.pdf",
+            "chunk_count": 0,
+            "version": 1,
+            "metadata": {},
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+    )
+    res = await service.mark_for_reingestion("d1", "t1")
+    assert res["status"] == "pending"
+    update = service.documents.find_one_and_update.call_args.args[1]
+    assert update["$set"]["status"] == "pending"
+    assert update["$set"]["error_message"] is None
+
+
+# --- helper ---
+
+
+async def _aiter(items):
+    for i in items:
+        yield i


### PR DESCRIPTION
## Summary

Implements the document management endpoints from #18.

- `GET /api/v1/documents` — paginated list with search, sort, status filter
- `GET /api/v1/documents/{id}` — single document details
- `PATCH /api/v1/documents/{id}` — update title and metadata only
- `DELETE /api/v1/documents/{id}` — cascade-delete (chunks first, then doc)
- `DELETE /api/v1/documents` — bulk delete by ids
- `POST /api/v1/documents/{id}/reingest` — flip status to pending

All endpoints derive `tenant_id` from the JWT/API-key dependency — never trusted from request body or query string. Cascade delete tries a Mongo transaction first and falls back to sequenced deletes for standalone deployments. Reingest refuses (409) if the document is currently `processing` to avoid racing the worker.

The contract matches `apps/web/lib/api/documents.ts` shipped in #47.

## Test plan

- [x] `uv run pytest -m unit` — 191 passing (31 new across router + service)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] Tenant isolation verified per-endpoint in router tests (cross-tenant returns 404, not 403)
- [x] Cascade delete tested for both transaction and standalone-fallback paths
- [x] Reingest 409 verified when status == processing
- [x] Bulk delete capped at 100 ids, rejects empty list

Closes #18