### PR TITLE
test: comprehensive test suite + Playwright e2e harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,42 @@ jobs:
       - run: uv sync --dev
       - run: uv run pytest -m unit --tb=short -q
 
+  api-integration:
+    name: "API: Integration Tests"
+    runs-on: ubuntu-latest
+    # Only runs when explicitly dispatched. Requires MONGODB_TEST_URI to be
+    # provisioned as a repository secret pointing at a throwaway database.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_integration }}
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1}).ok' | grep 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    defaults:
+      run:
+        working-directory: apps/api
+    env:
+      MONGODB_TEST_URI: mongodb://localhost:27017
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/api/pyproject.toml"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: uv sync --dev
+      - run: uv run pytest -m integration --tb=short -q
+
   # ─── Next.js Frontend ──────────────────────────────────────────
   web-lint:
     name: "Web: Lint"
@@ -144,6 +180,74 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+
+  web-test:
+    name: "Web: Unit Tests"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  # ─── End-to-End ────────────────────────────────────────────────
+  e2e:
+    name: "E2E: Playwright"
+    runs-on: ubuntu-latest
+    # Opt-in only: dispatched manually with run_e2e=true. Requires the local
+    # stack (docker compose) to be reachable; we skip otherwise to keep PRs
+    # green while infra is still landing.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_e2e }}
+    defaults:
+      run:
+        working-directory: e2e
+    env:
+      E2E: "1"
+      WEB_BASE_URL: http://localhost:3100
+      API_BASE_URL: http://localhost:8100
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Start application stack
+        run: docker compose up -d --wait
+        working-directory: ${{ github.workspace }}
+
+      - run: pnpm install
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v
+        working-directory: ${{ github.workspace }}
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report
+          retention-days: 7
 
   # ─── Docker Build Smoke Test ───────────────────────────────────
   docker-build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev api web install lint test widget-build clean
+.PHONY: dev api web install lint test test-unit test-integration test-web test-e2e widget-build clean
 
 # Run both API and web dev servers concurrently
 dev:
@@ -24,10 +24,26 @@ lint:
 	cd apps/api && uv run ruff check .
 	cd apps/web && pnpm lint
 
-# Run all tests
-test:
-	cd apps/api && uv run pytest
+# Run all default tests (api unit + web). Integration and e2e are opt-in.
+test: test-unit test-web
+
+# API unit tests (no external deps required)
+test-unit:
+	cd apps/api && uv run pytest -m unit
+
+# API integration tests against a real MongoDB.
+# Requires MONGODB_TEST_URI in the environment.
+test-integration:
+	cd apps/api && uv run pytest -m integration
+
+# Web unit tests (vitest)
+test-web:
 	cd apps/web && pnpm test
+
+# Playwright e2e suite. Requires the local stack to be running
+# (`docker compose up`) and E2E=1 in the environment.
+test-e2e:
+	cd e2e && pnpm install && E2E=1 pnpm test
 
 # Build widget
 widget-build:

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -1,0 +1,47 @@
+"""Shared fixtures for integration tests against a real MongoDB.
+
+Integration tests require a reachable MongoDB instance. Set
+``MONGODB_TEST_URI`` in the environment to enable; otherwise the tests
+in this directory are skipped at collection time.
+
+The test database is dropped before *and* after each test to keep
+isolation explicit — never point ``MONGODB_TEST_URI`` at production data.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import AsyncIterator
+
+import pytest
+
+MONGODB_TEST_URI = os.environ.get("MONGODB_TEST_URI")
+
+
+def _skip_if_no_mongo() -> None:
+    if not MONGODB_TEST_URI:
+        pytest.skip(
+            "MONGODB_TEST_URI not set — integration tests require a live MongoDB",
+            allow_module_level=False,
+        )
+
+
+@pytest.fixture
+async def mongo_db() -> AsyncIterator:
+    """Yield an empty, isolated test database. Drops on teardown."""
+    _skip_if_no_mongo()
+
+    try:
+        from pymongo import AsyncMongoClient
+    except ImportError as exc:  # pragma: no cover - depends on pymongo version
+        pytest.skip(f"pymongo async client unavailable: {exc}")
+
+    db_name = f"mongorag_it_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoClient(MONGODB_TEST_URI)
+    db = client[db_name]
+    try:
+        yield db
+    finally:
+        await client.drop_database(db_name)
+        await client.close()

--- a/apps/api/tests/integration/test_ingestion_service_integration.py
+++ b/apps/api/tests/integration/test_ingestion_service_integration.py
@@ -1,0 +1,158 @@
+"""Integration tests for IngestionService against a real MongoDB.
+
+Skipped automatically when ``MONGODB_TEST_URI`` is not set. The fixtures
+in ``conftest.py`` create and drop a fresh database per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.ingestion.chunker import DocumentChunk
+from src.services.ingestion.service import IngestionService
+
+pytestmark = pytest.mark.integration
+
+
+async def test_create_pending_then_get_status(mongo_db) -> None:
+    """A freshly created pending document is readable via get_document_status."""
+    service = IngestionService(
+        documents_collection=mongo_db["documents"],
+        chunks_collection=mongo_db["chunks"],
+    )
+
+    doc_id = await service.create_pending_document(
+        tenant_id="tenant-A", title="Spec", source="spec.pdf"
+    )
+
+    status = await service.get_document_status(doc_id, "tenant-A")
+    assert status is not None
+    assert status["status"] == "pending"
+    assert status["title"] == "Spec"
+
+
+async def test_get_status_isolated_by_tenant(mongo_db) -> None:
+    """Tenant B cannot read Tenant A's document via get_document_status."""
+    service = IngestionService(
+        documents_collection=mongo_db["documents"],
+        chunks_collection=mongo_db["chunks"],
+    )
+    doc_id = await service.create_pending_document(
+        tenant_id="tenant-A", title="Confidential", source="a.pdf"
+    )
+
+    leaked = await service.get_document_status(doc_id, "tenant-B")
+    assert leaked is None
+
+
+async def test_store_chunks_writes_with_tenant_id(mongo_db) -> None:
+    """store_chunks persists chunks with the correct tenant_id."""
+    service = IngestionService(
+        documents_collection=mongo_db["documents"],
+        chunks_collection=mongo_db["chunks"],
+    )
+    doc_id = await service.create_pending_document(
+        tenant_id="tenant-A", title="Doc", source="doc.pdf"
+    )
+
+    chunks = [
+        DocumentChunk(
+            content=f"chunk {i}",
+            index=i,
+            start_char=0,
+            end_char=len(f"chunk {i}"),
+            metadata={"source": "doc.pdf"},
+            token_count=2,
+            embedding=[0.1] * 4,
+        )
+        for i in range(3)
+    ]
+
+    written = await service.store_chunks(
+        chunks=chunks,
+        document_id=doc_id,
+        tenant_id="tenant-A",
+        source="doc.pdf",
+        version=1,
+        embedding_model="text-embedding-3-small",
+    )
+
+    assert written == 3
+    count_a = await mongo_db["chunks"].count_documents({"tenant_id": "tenant-A"})
+    count_b = await mongo_db["chunks"].count_documents({"tenant_id": "tenant-B"})
+    assert count_a == 3
+    assert count_b == 0
+
+
+async def test_store_chunks_replaces_existing_for_document(mongo_db) -> None:
+    """Re-storing chunks deletes prior chunks scoped to the same doc+tenant."""
+    service = IngestionService(
+        documents_collection=mongo_db["documents"],
+        chunks_collection=mongo_db["chunks"],
+    )
+    doc_id = await service.create_pending_document(
+        tenant_id="tenant-A", title="Doc", source="doc.pdf"
+    )
+
+    def _make(i: int, content: str) -> DocumentChunk:
+        return DocumentChunk(
+            content=content,
+            index=i,
+            start_char=0,
+            end_char=len(content),
+            metadata={"source": "doc.pdf"},
+            token_count=1,
+            embedding=[0.0] * 4,
+        )
+
+    await service.store_chunks(
+        [_make(0, "old-1"), _make(1, "old-2")],
+        document_id=doc_id,
+        tenant_id="tenant-A",
+        source="doc.pdf",
+        version=1,
+        embedding_model="m",
+    )
+    await service.store_chunks(
+        [_make(0, "new-1")],
+        document_id=doc_id,
+        tenant_id="tenant-A",
+        source="doc.pdf",
+        version=2,
+        embedding_model="m",
+    )
+
+    remaining = [c async for c in mongo_db["chunks"].find({"document_id": doc_id})]
+    assert len(remaining) == 1
+    assert remaining[0]["content"] == "new-1"
+
+
+async def test_check_duplicate_scoped_to_tenant(mongo_db) -> None:
+    """check_duplicate does not match documents owned by another tenant."""
+    service = IngestionService(
+        documents_collection=mongo_db["documents"],
+        chunks_collection=mongo_db["chunks"],
+    )
+
+    # Insert a "ready" document for tenant-A directly to set the status field.
+    await mongo_db["documents"].insert_one(
+        {
+            "_id": "doc-A",
+            "tenant_id": "tenant-A",
+            "title": "T",
+            "source": "shared.pdf",
+            "content": "x",
+            "content_hash": "hash-1",
+            "version": 1,
+            "status": "ready",
+            "chunk_count": 0,
+            "metadata": {},
+        }
+    )
+
+    found_a = await service.check_duplicate("tenant-A", "shared.pdf", "hash-1")
+    found_b = await service.check_duplicate("tenant-B", "shared.pdf", "hash-1")
+
+    assert found_a is not None
+    assert found_a["_id"] == "doc-A"
+    assert found_b is None

--- a/apps/api/tests/test_chunker_config.py
+++ b/apps/api/tests/test_chunker_config.py
@@ -1,0 +1,83 @@
+"""Unit tests for ingestion chunker config and DocumentChunk dataclass.
+
+These tests cover behaviour that does not require the heavy
+``transformers`` tokenizer download — i.e. config validation and
+``DocumentChunk`` invariants.
+"""
+
+import pytest
+
+from src.services.ingestion.chunker import ChunkingConfig, DocumentChunk
+
+
+@pytest.mark.unit
+def test_chunking_config_accepts_valid_overlap():
+    """ChunkingConfig accepts overlap strictly less than chunk_size."""
+    config = ChunkingConfig(chunk_size=1000, chunk_overlap=200)
+    assert config.chunk_size == 1000
+    assert config.chunk_overlap == 200
+
+
+@pytest.mark.unit
+def test_chunking_config_rejects_overlap_equal_to_chunk_size():
+    """ChunkingConfig rejects overlap == chunk_size (would yield no progress)."""
+    with pytest.raises(ValueError, match="Chunk overlap must be less than chunk size"):
+        ChunkingConfig(chunk_size=500, chunk_overlap=500)
+
+
+@pytest.mark.unit
+def test_chunking_config_rejects_overlap_larger_than_chunk_size():
+    """ChunkingConfig rejects overlap greater than chunk_size."""
+    with pytest.raises(ValueError, match="Chunk overlap must be less than chunk size"):
+        ChunkingConfig(chunk_size=400, chunk_overlap=900)
+
+
+@pytest.mark.unit
+def test_chunking_config_rejects_zero_min_chunk_size():
+    """ChunkingConfig rejects min_chunk_size <= 0 to avoid division-by-zero loops."""
+    with pytest.raises(ValueError, match="Minimum chunk size must be positive"):
+        ChunkingConfig(chunk_size=1000, chunk_overlap=200, min_chunk_size=0)
+
+
+@pytest.mark.unit
+def test_chunking_config_defaults_match_documented_constants():
+    """Config defaults are stable — changing them is a behaviour change."""
+    config = ChunkingConfig()
+    assert config.chunk_size == 1000
+    assert config.chunk_overlap == 200
+    assert config.max_chunk_size == 2000
+    assert config.min_chunk_size == 100
+    assert config.max_tokens == 512
+
+
+@pytest.mark.unit
+def test_document_chunk_estimates_token_count_when_missing():
+    """DocumentChunk auto-estimates token_count via ~4 chars/token rule."""
+    text = "a" * 400
+    chunk = DocumentChunk(
+        content=text, index=0, start_char=0, end_char=400, metadata={"source": "x"}
+    )
+    assert chunk.token_count == 100  # 400 // 4
+
+
+@pytest.mark.unit
+def test_document_chunk_preserves_explicit_token_count():
+    """DocumentChunk does not overwrite an explicitly-provided token_count."""
+    chunk = DocumentChunk(
+        content="hello world",
+        index=0,
+        start_char=0,
+        end_char=11,
+        metadata={},
+        token_count=7,
+    )
+    assert chunk.token_count == 7
+
+
+@pytest.mark.unit
+def test_document_chunk_embedding_starts_none():
+    """Embedding field is None until the embedder fills it in."""
+    chunk = DocumentChunk(
+        content="x", index=0, start_char=0, end_char=1, metadata={}, token_count=1
+    )
+    assert chunk.embedding is None

--- a/apps/api/tests/test_embedder.py
+++ b/apps/api/tests/test_embedder.py
@@ -1,0 +1,152 @@
+"""Unit tests for the embedder service.
+
+Patches the module-level ``embedding_client`` so we can assert behaviour
+without making real OpenAI API calls.
+"""
+
+from datetime import datetime
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.ingestion.chunker import DocumentChunk
+from src.services.ingestion.embedder import EmbeddingGenerator, create_embedder
+
+
+def _make_response(vectors: List[List[float]]) -> MagicMock:
+    """Build a stub OpenAI embeddings response."""
+    response = MagicMock()
+    response.data = [MagicMock(embedding=v) for v in vectors]
+    return response
+
+
+@pytest.mark.unit
+async def test_generate_embedding_returns_provider_vector():
+    """generate_embedding returns the vector from the provider response."""
+    embedder = EmbeddingGenerator(model="text-embedding-3-small")
+
+    fake_client = MagicMock()
+    fake_client.embeddings.create = AsyncMock(return_value=_make_response([[0.1, 0.2, 0.3]]))
+
+    with patch("src.services.ingestion.embedder.embedding_client", fake_client):
+        result = await embedder.generate_embedding("hello")
+
+    assert result == [0.1, 0.2, 0.3]
+    fake_client.embeddings.create.assert_awaited_once()
+    kwargs = fake_client.embeddings.create.call_args.kwargs
+    assert kwargs["input"] == "hello"
+    assert kwargs["model"] == "text-embedding-3-small"
+
+
+@pytest.mark.unit
+async def test_generate_embedding_truncates_overlong_text():
+    """Texts longer than max_tokens*4 chars are truncated before embedding."""
+    embedder = EmbeddingGenerator(model="text-embedding-3-small")
+    max_chars = embedder.config["max_tokens"] * 4
+    overlong = "x" * (max_chars + 50)
+
+    fake_client = MagicMock()
+    fake_client.embeddings.create = AsyncMock(return_value=_make_response([[0.0] * 1536]))
+
+    with patch("src.services.ingestion.embedder.embedding_client", fake_client):
+        await embedder.generate_embedding(overlong)
+
+    sent_text = fake_client.embeddings.create.call_args.kwargs["input"]
+    assert len(sent_text) == max_chars
+
+
+@pytest.mark.unit
+async def test_generate_embeddings_batch_returns_one_vector_per_text():
+    """generate_embeddings_batch preserves order and one-to-one mapping."""
+    embedder = EmbeddingGenerator(model="text-embedding-3-small")
+
+    fake_client = MagicMock()
+    fake_client.embeddings.create = AsyncMock(return_value=_make_response([[1.0], [2.0], [3.0]]))
+
+    with patch("src.services.ingestion.embedder.embedding_client", fake_client):
+        result = await embedder.generate_embeddings_batch(["a", "b", "c"])
+
+    assert result == [[1.0], [2.0], [3.0]]
+
+
+@pytest.mark.unit
+async def test_embed_chunks_returns_empty_for_empty_input():
+    """embed_chunks short-circuits with no provider calls for an empty input."""
+    embedder = EmbeddingGenerator(model="text-embedding-3-small")
+
+    fake_client = MagicMock()
+    fake_client.embeddings.create = AsyncMock()
+
+    with patch("src.services.ingestion.embedder.embedding_client", fake_client):
+        result = await embedder.embed_chunks([])
+
+    assert result == []
+    fake_client.embeddings.create.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_embed_chunks_batches_and_attaches_embeddings():
+    """embed_chunks batches by batch_size and attaches embeddings to each chunk."""
+    embedder = EmbeddingGenerator(model="text-embedding-3-small", batch_size=2)
+    chunks = [
+        DocumentChunk(
+            content=f"c{i}",
+            index=i,
+            start_char=0,
+            end_char=2,
+            metadata={"src": "t"},
+            token_count=1,
+        )
+        for i in range(3)
+    ]
+
+    fake_client = MagicMock()
+    # 2 batches: first returns 2 vectors, second returns 1
+    fake_client.embeddings.create = AsyncMock(
+        side_effect=[
+            _make_response([[0.1], [0.2]]),
+            _make_response([[0.3]]),
+        ]
+    )
+
+    progress: list = []
+
+    with patch("src.services.ingestion.embedder.embedding_client", fake_client):
+        result = await embedder.embed_chunks(
+            chunks, progress_callback=lambda c, t: progress.append((c, t))
+        )
+
+    assert len(result) == 3
+    assert [c.embedding for c in result] == [[0.1], [0.2], [0.3]]
+    # Original metadata preserved + augmented
+    for c in result:
+        assert c.metadata["src"] == "t"
+        assert c.metadata["embedding_model"] == "text-embedding-3-small"
+        # Generated-at field is an ISO timestamp
+        datetime.fromisoformat(c.metadata["embedding_generated_at"])
+    assert fake_client.embeddings.create.await_count == 2
+    assert progress == [(1, 2), (2, 2)]
+
+
+@pytest.mark.unit
+def test_embedding_dimension_known_models():
+    """Embedding dimensions for known models match OpenAI documentation."""
+    assert EmbeddingGenerator("text-embedding-3-small").get_embedding_dimension() == 1536
+    assert EmbeddingGenerator("text-embedding-3-large").get_embedding_dimension() == 3072
+    assert EmbeddingGenerator("text-embedding-ada-002").get_embedding_dimension() == 1536
+
+
+@pytest.mark.unit
+def test_embedding_dimension_falls_back_for_unknown_model():
+    """Unknown models default to 1536 dims (matches text-embedding-3-small)."""
+    assert EmbeddingGenerator("some-future-model").get_embedding_dimension() == 1536
+
+
+@pytest.mark.unit
+def test_create_embedder_factory():
+    """create_embedder returns an EmbeddingGenerator with the requested config."""
+    embedder = create_embedder(model="text-embedding-3-large", batch_size=42)
+    assert isinstance(embedder, EmbeddingGenerator)
+    assert embedder.model == "text-embedding-3-large"
+    assert embedder.batch_size == 42

--- a/apps/web/lib/api-client.test.ts
+++ b/apps/web/lib/api-client.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jwtVerify } from "jose";
+import type { ApiError as ApiErrorType } from "./api-client";
 
 // next-auth must be mocked before importing api-client because the module
 // imports `auth` eagerly via `@/lib/auth`.
@@ -97,10 +98,10 @@ describe("apiFetch", () => {
     );
 
     const { apiFetch, ApiError } = await import("./api-client");
-    const err = await apiFetch("/api/v1/chat").catch((e) => e);
+    const err = await apiFetch("/api/v1/chat").catch((e: unknown) => e);
     expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(429);
-    expect(err.message).toBe("quota exceeded");
+    expect((err as ApiErrorType).status).toBe(429);
+    expect((err as ApiErrorType).message).toBe("quota exceeded");
   });
 
   it("falls back to a generic message when the error body is unparseable", async () => {
@@ -112,9 +113,10 @@ describe("apiFetch", () => {
       vi.fn().mockResolvedValue(new Response("<html>500</html>", { status: 500 })),
     );
 
-    const { apiFetch } = await import("./api-client");
-    const err = await apiFetch("/api/v1/anything").catch((e) => e);
-    expect(err.status).toBe(500);
-    expect(err.message).toMatch(/Request failed \(500\)/);
+    const { apiFetch, ApiError } = await import("./api-client");
+    const err = await apiFetch("/api/v1/anything").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiErrorType).status).toBe(500);
+    expect((err as ApiErrorType).message).toMatch(/Request failed \(500\)/);
   });
 });

--- a/apps/web/lib/api-client.test.ts
+++ b/apps/web/lib/api-client.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the server-side API client.
+ *
+ * The client mints a short-lived HS256 JWT from the NextAuth session and
+ * forwards it as a Bearer token. These tests exercise the auth → token →
+ * fetch glue without spinning up a real backend.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { jwtVerify } from "jose";
+
+// next-auth must be mocked before importing api-client because the module
+// imports `auth` eagerly via `@/lib/auth`.
+const authMock = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: authMock }));
+// `server-only` throws in test env unless mocked away.
+vi.mock("server-only", () => ({}));
+
+const SECRET = "test-secret-for-unit-tests-minimum-32chars";
+
+beforeEach(() => {
+  process.env.NEXTAUTH_SECRET = SECRET;
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test";
+  authMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("apiFetch", () => {
+  it("throws ApiError(401) when no session is available", async () => {
+    authMock.mockResolvedValueOnce(null);
+    const { apiFetch, ApiError } = await import("./api-client");
+
+    await expect(apiFetch("/anything")).rejects.toBeInstanceOf(ApiError);
+    await expect(apiFetch("/anything")).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("mints a HS256 JWT with tenant_id and forwards as Bearer", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "user-1", tenant_id: "tenant-A", role: "owner" },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { apiFetch } = await import("./api-client");
+    const result = await apiFetch<{ ok: boolean }>("/api/v1/usage");
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://api.test/api/v1/usage");
+    expect(init.method).toBe("GET");
+    const auth = init.headers.Authorization as string;
+    expect(auth.startsWith("Bearer ")).toBe(true);
+
+    const token = auth.slice("Bearer ".length);
+    const { payload, protectedHeader } = await jwtVerify(
+      token,
+      new TextEncoder().encode(SECRET),
+    );
+    expect(protectedHeader.alg).toBe("HS256");
+    expect(payload.sub).toBe("user-1");
+    expect(payload.tenant_id).toBe("tenant-A");
+    expect(payload.role).toBe("owner");
+  });
+
+  it("returns undefined for 204 No Content responses", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u", tenant_id: "t", role: "owner" },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+
+    const { apiFetch } = await import("./api-client");
+    const result = await apiFetch<undefined>("/api/v1/keys/x", { method: "DELETE" });
+    expect(result).toBeUndefined();
+  });
+
+  it("surfaces backend `detail` strings on errors", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u", tenant_id: "t", role: "owner" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "quota exceeded" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const { apiFetch, ApiError } = await import("./api-client");
+    const err = await apiFetch("/api/v1/chat").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(429);
+    expect(err.message).toBe("quota exceeded");
+  });
+
+  it("falls back to a generic message when the error body is unparseable", async () => {
+    authMock.mockResolvedValue({
+      user: { id: "u", tenant_id: "t", role: "owner" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("<html>500</html>", { status: 500 })),
+    );
+
+    const { apiFetch } = await import("./api-client");
+    const err = await apiFetch("/api/v1/anything").catch((e) => e);
+    expect(err.status).toBe(500);
+    expect(err.message).toMatch(/Request failed \(500\)/);
+  });
+});

--- a/apps/web/lib/validations/auth.test.ts
+++ b/apps/web/lib/validations/auth.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  forgotPasswordSchema,
+  loginSchema,
+  resetPasswordSchema,
+  signupSchema,
+} from "./auth";
+
+describe("loginSchema", () => {
+  it("accepts a valid email and non-empty password", () => {
+    const result = loginSchema.safeParse({ email: "ok@x.io", password: "p" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects malformed emails", () => {
+    const result = loginSchema.safeParse({ email: "nope", password: "p" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty passwords", () => {
+    const result = loginSchema.safeParse({ email: "ok@x.io", password: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("signupSchema", () => {
+  it("requires password ≥ 8 chars", () => {
+    const result = signupSchema.safeParse({
+      email: "ok@x.io",
+      password: "1234567",
+      organizationName: "Acme",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 1-char organization names", () => {
+    const result = signupSchema.safeParse({
+      email: "ok@x.io",
+      password: "supersecret",
+      organizationName: "A",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 101-char organization names", () => {
+    const result = signupSchema.safeParse({
+      email: "ok@x.io",
+      password: "supersecret",
+      organizationName: "A".repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid signup payload", () => {
+    const result = signupSchema.safeParse({
+      email: "ok@x.io",
+      password: "supersecret",
+      organizationName: "Acme",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("forgotPasswordSchema", () => {
+  it("requires a valid email", () => {
+    expect(forgotPasswordSchema.safeParse({ email: "x" }).success).toBe(false);
+    expect(forgotPasswordSchema.safeParse({ email: "x@y.io" }).success).toBe(true);
+  });
+});
+
+describe("resetPasswordSchema", () => {
+  it("rejects mismatched passwords", () => {
+    const result = resetPasswordSchema.safeParse({
+      password: "supersecret",
+      confirmPassword: "different",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes("confirmPassword"))).toBe(true);
+    }
+  });
+
+  it("accepts matching ≥8-char passwords", () => {
+    const result = resetPasswordSchema.safeParse({
+      password: "supersecret",
+      confirmPassword: "supersecret",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+test-results
+playwright-report
+playwright/.cache

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,35 @@
+# MongoRAG E2E
+
+End-to-end Playwright harness covering the critical happy path:
+
+1. Sign up a new tenant
+2. Upload a document
+3. Ask a question and receive an answer
+
+## Run locally
+
+```bash
+# from repo root
+docker compose up -d
+cd e2e
+pnpm install
+pnpm install-browsers
+E2E=1 pnpm test
+```
+
+Override targets via env vars:
+
+| Variable           | Default                  | Purpose                          |
+|--------------------|--------------------------|----------------------------------|
+| `WEB_BASE_URL`     | `http://localhost:3100`  | Next.js dashboard URL            |
+| `API_BASE_URL`     | `http://localhost:8100`  | FastAPI backend URL              |
+| `TEST_USER_EMAIL`  | random `e2e+<ts>@…`      | Account email used for signup    |
+| `TEST_USER_PASSWORD` | `supersecret-e2e-pw`   | Account password                 |
+| `TEST_ORG_NAME`    | `E2E Org`                | Organisation name on signup form |
+
+## CI
+
+The `e2e` job in `.github/workflows/ci.yml` is skipped unless the workflow is
+dispatched with `run_e2e=true` (or `E2E=1` is set in the environment). This
+keeps the default PR pipeline fast and green even before the live stack is
+provisioned in CI.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mongorag-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "End-to-end Playwright harness for MongoRAG. Skipped unless E2E=1.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "install-browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * MongoRAG e2e configuration.
+ *
+ * The suite expects the dashboard at WEB_BASE_URL (default
+ * http://localhost:3100) and the API at API_BASE_URL (default
+ * http://localhost:8100). Spin up the local stack with `docker compose up`
+ * before running the tests, or set the env vars to point at a deployed
+ * preview environment.
+ */
+const WEB_BASE_URL = process.env.WEB_BASE_URL ?? "http://localhost:3100";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: WEB_BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/e2e/tests/happy-path.spec.ts
+++ b/e2e/tests/happy-path.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Happy-path e2e: signup → upload document → ask a question.
+ *
+ * Skipped by default. Set E2E=1 in the environment to run, after starting
+ * the local stack with `docker compose up` or pointing WEB_BASE_URL /
+ * API_BASE_URL at a live preview environment.
+ *
+ * The test is parameterised over the credentials in env vars below; falling
+ * back to throwaway local-only values when run against a fresh stack.
+ */
+
+import { expect, test } from "@playwright/test";
+
+const E2E_ENABLED = process.env.E2E === "1";
+const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:8100";
+
+const TEST_EMAIL =
+  process.env.TEST_USER_EMAIL ?? `e2e+${Date.now()}@mongorag.test`;
+const TEST_PASSWORD = process.env.TEST_USER_PASSWORD ?? "supersecret-e2e-pw";
+const TEST_ORG = process.env.TEST_ORG_NAME ?? "E2E Org";
+
+test.describe("happy path", () => {
+  test.skip(!E2E_ENABLED, "E2E=1 not set — skipping live e2e suite");
+
+  test("the API is reachable before we exercise the UI", async ({ request }) => {
+    const response = await request.get(`${API_BASE_URL}/health`);
+    expect(response.ok(), `health: ${response.status()}`).toBe(true);
+  });
+
+  test("a new tenant can sign up, upload a document, and chat", async ({ page, request }) => {
+    // ---- Signup ----------------------------------------------------------
+    await page.goto("/signup");
+    await page.getByLabel(/email/i).fill(TEST_EMAIL);
+    await page.getByLabel(/password/i).fill(TEST_PASSWORD);
+    await page.getByLabel(/organization/i).fill(TEST_ORG);
+    await page.getByRole("button", { name: /sign up|create account/i }).click();
+
+    // Land on the dashboard. Using URL assertion rather than text so we
+    // don't depend on copy.
+    await expect(page).toHaveURL(/\/(dashboard|documents)/, { timeout: 15_000 });
+
+    // ---- Upload a document ----------------------------------------------
+    await page.getByRole("button", { name: /upload|add document/i }).first().click();
+    const fileInput = page.locator('input[type="file"]').first();
+    const buf = Buffer.from(
+      "MongoRAG e2e fixture. The quick brown fox jumps over the lazy dog.\n",
+    );
+    await fileInput.setInputFiles({
+      name: "e2e-fixture.txt",
+      mimeType: "text/plain",
+      buffer: buf,
+    });
+    // Some upload dialogs auto-submit; others have a confirm button.
+    const confirm = page.getByRole("button", { name: /upload|confirm/i });
+    if (await confirm.isVisible().catch(() => false)) {
+      await confirm.click();
+    }
+
+    // The document row should appear with status "ready" or "processing".
+    await expect(page.getByText(/e2e-fixture\.txt/i)).toBeVisible({ timeout: 30_000 });
+
+    // ---- Ask a question --------------------------------------------------
+    // The chat panel is reachable from a "Chat" / "Test" tab.
+    const chatLink = page.getByRole("link", { name: /chat|test/i }).first();
+    if (await chatLink.isVisible().catch(() => false)) {
+      await chatLink.click();
+    }
+
+    const input = page.getByRole("textbox", { name: /message|question|ask/i }).first();
+    await input.fill("What does the fox do?");
+    await page.keyboard.press("Enter");
+
+    // We assert *some* answer renders within a generous timeout; we do not
+    // pin to specific copy because LLM output is non-deterministic.
+    await expect(page.locator("[data-role='assistant'], [data-message-role='assistant']").first()).toBeVisible({ timeout: 60_000 });
+  });
+});


### PR DESCRIPTION
Closes #21

## Summary
- Adds backend unit coverage for ingestion chunker config and embedder behaviour (truncation, batching, dimensions).
- Establishes a real-MongoDB integration suite under `apps/api/tests/integration/`, auto-skipped unless `MONGODB_TEST_URI` is set; covers ingestion service round-trip + tenant isolation.
- Adds web unit tests for the server-side API client (session->JWT->Bearer, 204, error detail surfacing) and zod auth schemas.
- Sets up a Playwright e2e harness at `e2e/` with a signup -> upload -> chat happy path, parameterised on `WEB_BASE_URL`/`API_BASE_URL`, skipped unless `E2E=1`.
- Extends CI with `web-test`, gated `api-integration` (mongo service container, `workflow_dispatch.inputs.run_integration`), and gated `e2e` (`docker compose up`, `workflow_dispatch.inputs.run_e2e`) jobs.
- Splits the Makefile into `test-unit` / `test-integration` / `test-web` / `test-e2e` targets.

Test counts: 160 -> 181 collected, 175 unit pass locally + 5 integration skipped without `MONGODB_TEST_URI`. Web vitest: 32 pass.

## Test plan
- [x] `cd apps/api && uv run pytest -m unit` passes
- [x] `cd apps/api && uv run pytest -m integration` skips cleanly without `MONGODB_TEST_URI`
- [x] `cd apps/web && pnpm test` passes (32 tests)
- [x] `cd apps/api && uv run ruff check . && uv run ruff format --check .` clean for new files
- [x] `cd apps/web && pnpm lint` clean
- [ ] Manual: `MONGODB_TEST_URI=mongodb://localhost:27017 uv run pytest -m integration` against a local Mongo
- [ ] Manual: `docker compose up && cd e2e && pnpm install && E2E=1 pnpm test`