### PR TITLE
feat(eval): add RAG quality evaluation harness

### DIFF
--- a/apps/api/src/eval/__init__.py
+++ b/apps/api/src/eval/__init__.py
@@ -1,0 +1,27 @@
+"""RAG quality evaluation harness.
+
+Measures retrieval and answer quality over a labeled dataset of
+{question, expected_answer, expected_doc_ids, expected_chunk_ids}.
+"""
+
+from src.eval.dataset import EvalExample, load_dataset
+from src.eval.metrics import (
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    recall_at_k,
+    substring_match,
+)
+from src.eval.report import EvalReport, EvalRowResult
+from src.eval.runner import run_eval
+
+__all__ = [
+    "EvalExample",
+    "EvalReport",
+    "EvalRowResult",
+    "load_dataset",
+    "mean_reciprocal_rank",
+    "ndcg_at_k",
+    "recall_at_k",
+    "run_eval",
+    "substring_match",
+]

--- a/apps/api/src/eval/dataset.py
+++ b/apps/api/src/eval/dataset.py
@@ -1,0 +1,98 @@
+"""Eval dataset loader.
+
+Dataset format: JSONL — one JSON object per line.
+
+Required fields:
+    question (str)
+    expected_answer (str)              # gold answer text (substring used for grading)
+
+Optional fields:
+    id (str)                           # stable identifier; defaults to line number
+    expected_chunk_ids (list[str])     # gold chunk ids for retrieval metrics
+    expected_doc_ids (list[str])       # gold document ids (used if chunk ids absent)
+    tags (list[str])                   # categorical tags for slice analysis
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class EvalExample(BaseModel):
+    """A single labeled eval example."""
+
+    id: str = Field(..., description="Stable identifier for this example")
+    question: str = Field(..., min_length=1)
+    expected_answer: str = Field(default="", description="Gold answer text")
+    expected_chunk_ids: list[str] = Field(default_factory=list)
+    expected_doc_ids: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("expected_chunk_ids", "expected_doc_ids", mode="before")
+    @classmethod
+    def _coerce_to_str_list(cls, v: object) -> list[str]:
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return [str(x) for x in v]
+        raise TypeError("expected_chunk_ids/expected_doc_ids must be a list")
+
+    def has_retrieval_labels(self) -> bool:
+        """True when at least one retrieval-grading label is present."""
+        return bool(self.expected_chunk_ids) or bool(self.expected_doc_ids)
+
+
+def load_dataset(path: str | Path) -> list[EvalExample]:
+    """Load and validate a JSONL eval dataset.
+
+    Args:
+        path: Path to a .jsonl file. Blank lines and lines starting with `#` are skipped.
+
+    Returns:
+        List of EvalExample, in file order.
+
+    Raises:
+        FileNotFoundError: if path does not exist.
+        ValueError: if any line fails JSON parsing or schema validation.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Eval dataset not found: {p}")
+
+    examples: list[EvalExample] = []
+    for line_no, raw in _iter_data_lines(p):
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{p}:{line_no}: invalid JSON ({e.msg})") from e
+
+        if "id" not in obj or obj["id"] in (None, ""):
+            obj["id"] = f"ex-{line_no:04d}"
+
+        try:
+            examples.append(EvalExample.model_validate(obj))
+        except Exception as e:  # pydantic ValidationError
+            raise ValueError(f"{p}:{line_no}: schema error: {e}") from e
+
+    if not examples:
+        raise ValueError(f"Eval dataset is empty: {p}")
+
+    ids = [e.id for e in examples]
+    if len(set(ids)) != len(ids):
+        dupes = sorted({i for i in ids if ids.count(i) > 1})
+        raise ValueError(f"Duplicate example ids in dataset: {dupes}")
+
+    return examples
+
+
+def _iter_data_lines(path: Path) -> Iterable[tuple[int, str]]:
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            yield line_no, stripped

--- a/apps/api/src/eval/datasets/sample.jsonl
+++ b/apps/api/src/eval/datasets/sample.jsonl
@@ -1,0 +1,12 @@
+# Synthetic smoke-test dataset for the RAG eval harness.
+# One JSON object per line. Lines starting with '#' are ignored.
+{"id": "q1", "question": "What is the default RRF constant used in hybrid search?", "expected_answer": "60", "expected_chunk_ids": ["chunk-rrf-001"], "expected_doc_ids": ["doc-search-design"], "tags": ["search", "rrf"]}
+{"id": "q2", "question": "Which embedding model does MongoRAG use by default?", "expected_answer": "text-embedding-3-small", "expected_chunk_ids": ["chunk-embed-001", "chunk-embed-002"], "expected_doc_ids": ["doc-providers"], "tags": ["providers"]}
+{"id": "q3", "question": "How is tenant isolation enforced for chunk queries?", "expected_answer": "Every MongoDB query filters by tenant_id", "expected_chunk_ids": ["chunk-tenancy-001"], "expected_doc_ids": ["doc-tenancy"], "tags": ["security"]}
+{"id": "q4", "question": "What chunker library does the ingestion pipeline use?", "expected_answer": "Docling HybridChunker", "expected_chunk_ids": ["chunk-ingest-001"], "expected_doc_ids": ["doc-ingestion"], "tags": ["ingestion"]}
+{"id": "q5", "question": "How many dimensions does the default embedding produce?", "expected_answer": "1536", "expected_chunk_ids": ["chunk-embed-002"], "expected_doc_ids": ["doc-providers"], "tags": ["providers"]}
+{"id": "q6", "question": "Which Atlas tier supports Vector Search?", "expected_answer": "M0 (free tier)", "expected_chunk_ids": ["chunk-atlas-001"], "expected_doc_ids": ["doc-atlas"], "tags": ["mongo"]}
+{"id": "q7", "question": "What Pydantic feature is used for configuration?", "expected_answer": "Pydantic Settings", "expected_chunk_ids": ["chunk-config-001"], "expected_doc_ids": ["doc-config"], "tags": ["config"]}
+{"id": "q8", "question": "Name one supported LLM provider.", "expected_answer": "OpenAI", "expected_chunk_ids": ["chunk-providers-001", "chunk-providers-002"], "expected_doc_ids": ["doc-providers"], "tags": ["providers"]}
+{"id": "q9", "question": "What text search feature is enabled in Atlas Search?", "expected_answer": "fuzzy matching", "expected_chunk_ids": ["chunk-search-fuzzy"], "expected_doc_ids": ["doc-search-design"], "tags": ["search"]}
+{"id": "q10", "question": "Which package manager does the API use?", "expected_answer": "uv", "expected_chunk_ids": ["chunk-tooling-001"], "expected_doc_ids": ["doc-tooling"], "tags": ["tooling"]}

--- a/apps/api/src/eval/judge.py
+++ b/apps/api/src/eval/judge.py
@@ -1,0 +1,120 @@
+"""Optional LLM-as-judge for answer faithfulness/relevance.
+
+Disabled by default. The runner only invokes a judge when one is passed
+explicitly. The CLI builds this judge ONLY when both:
+    - the user passes `--llm-judge`, AND
+    - LLM_API_KEY is present in the environment.
+
+The judge uses the same provider as the production agent (via core.providers),
+so we never introduce a second secret. We never include or echo the API key
+in logs or report output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_JUDGE_PROMPT = """You are an evaluator scoring a RAG answer.
+
+Question:
+{question}
+
+Reference answer (gold):
+{expected}
+
+Candidate answer:
+{candidate}
+
+Retrieved context (may be partial):
+{context}
+
+Score the candidate from 0.0 to 1.0 considering:
+1. Faithfulness - does the candidate stay grounded in the retrieved context?
+2. Correctness - does it match the reference answer's key facts?
+3. Relevance - does it answer the question?
+
+Respond with strict JSON: {{"score": <float 0..1>, "reasoning": "<one sentence>"}}.
+"""
+
+
+async def make_openai_judge(model: Optional[str] = None) -> Optional[object]:
+    """Build a judge_fn closure backed by the project's LLM provider.
+
+    Returns None when the environment cannot supply an LLM (missing key, etc.).
+    The function imports lazily so the harness has no hard dependency on
+    pydantic_ai during unit tests.
+    """
+    try:
+        from pydantic_ai import Agent
+
+        from src.core.providers import get_llm_model
+    except Exception as e:  # noqa: BLE001
+        logger.warning("llm_judge_unavailable: %s", e)
+        return None
+
+    try:
+        llm_model = get_llm_model() if model is None else get_llm_model()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("llm_judge_provider_init_failed: %s", e)
+        return None
+
+    agent = Agent(llm_model, system_prompt="You are a strict, terse evaluator.")
+
+    async def _judge(question: str, expected: str, answer: str, context: str) -> tuple[float, str]:
+        prompt = _JUDGE_PROMPT.format(
+            question=question.strip(),
+            expected=expected.strip(),
+            candidate=answer.strip(),
+            context=(context or "").strip()[:8000],
+        )
+        result = await agent.run(prompt)
+        raw = getattr(result, "output", None) or getattr(result, "data", "") or ""
+        score, reasoning = _parse_judge_output(str(raw))
+        return score, reasoning
+
+    return _judge
+
+
+def _parse_judge_output(raw: str) -> tuple[float, str]:
+    """Parse a JSON judge response, falling back to a regex score scrape."""
+    text = raw.strip()
+    # Try strict JSON first.
+    try:
+        obj = json.loads(text)
+        score = float(obj.get("score", 0.0))
+        reasoning = str(obj.get("reasoning", ""))[:500]
+        return _clamp01(score), reasoning
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Fallback: extract first JSON object substring.
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            obj = json.loads(match.group(0))
+            score = float(obj.get("score", 0.0))
+            reasoning = str(obj.get("reasoning", ""))[:500]
+            return _clamp01(score), reasoning
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Last resort: pull the first float.
+    num = re.search(r"[01](?:\.\d+)?", text)
+    if num:
+        return _clamp01(float(num.group(0))), text[:200]
+    return 0.0, "judge_parse_failed"
+
+
+def _clamp01(x: float) -> float:
+    if x != x:  # NaN
+        return 0.0
+    return max(0.0, min(1.0, x))
+
+
+__all__ = ["make_openai_judge"]

--- a/apps/api/src/eval/metrics.py
+++ b/apps/api/src/eval/metrics.py
@@ -1,0 +1,95 @@
+"""Retrieval and answer-quality metrics for the RAG eval harness.
+
+Conventions:
+    - All ranked-list inputs are 0-indexed lists; rank 1 == position 0.
+    - Metrics return 0.0 when the gold set is empty (caller should skip such
+      examples; this module does not silently inflate scores).
+    - nDCG uses binary relevance with the standard log2(rank+1) discount.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Sequence
+
+
+def recall_at_k(predicted: Sequence[str], gold: Iterable[str], k: int) -> float:
+    """Recall@k: fraction of gold items present in the top-k predicted ids.
+
+    Returns 0.0 if `gold` is empty (no labels to evaluate against).
+    """
+    if k <= 0:
+        return 0.0
+    gold_set = {g for g in gold if g}
+    if not gold_set:
+        return 0.0
+    top_k = list(predicted)[:k]
+    hits = sum(1 for item in top_k if item in gold_set)
+    return hits / len(gold_set)
+
+
+def mean_reciprocal_rank(predicted: Sequence[str], gold: Iterable[str]) -> float:
+    """Reciprocal rank of the first gold hit. 0.0 if no gold appears.
+
+    Note: per-example reciprocal rank. Caller averages across the dataset to get MRR.
+    Rank is 1-indexed: first position contributes 1/1, second 1/2, etc.
+    """
+    gold_set = {g for g in gold if g}
+    if not gold_set:
+        return 0.0
+    for idx, item in enumerate(predicted):
+        if item in gold_set:
+            return 1.0 / (idx + 1)
+    return 0.0
+
+
+def ndcg_at_k(predicted: Sequence[str], gold: Iterable[str], k: int) -> float:
+    """Binary-relevance nDCG@k with log2 discount.
+
+    DCG = sum_{i=1..k} rel_i / log2(i + 1)   (ranks are 1-indexed)
+    IDCG is the DCG of an ideal ranking with min(|gold|, k) hits at the top.
+    Returns 0.0 if gold is empty.
+    """
+    if k <= 0:
+        return 0.0
+    gold_set = {g for g in gold if g}
+    if not gold_set:
+        return 0.0
+    top_k = list(predicted)[:k]
+    dcg = 0.0
+    for idx, item in enumerate(top_k):
+        if item in gold_set:
+            # idx is 0-based; rank is idx+1; discount uses log2(rank+1) = log2(idx+2)
+            dcg += 1.0 / math.log2(idx + 2)
+
+    ideal_hits = min(len(gold_set), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(ideal_hits))
+    if idcg == 0.0:
+        return 0.0
+    return dcg / idcg
+
+
+def substring_match(answer: str, expected: str, *, case_sensitive: bool = False) -> float:
+    """1.0 if `expected` appears in `answer`, else 0.0.
+
+    Empty `expected` returns 0.0 (no signal). Whitespace is collapsed before matching
+    so multi-line answers do not falsely miss.
+    """
+    if not expected:
+        return 0.0
+    a = " ".join(answer.split())
+    e = " ".join(expected.split())
+    if not case_sensitive:
+        a = a.lower()
+        e = e.lower()
+    return 1.0 if e in a else 0.0
+
+
+def hit_at_k(predicted: Sequence[str], gold: Iterable[str], k: int) -> float:
+    """1.0 if any gold item appears in top-k, else 0.0."""
+    if k <= 0:
+        return 0.0
+    gold_set = {g for g in gold if g}
+    if not gold_set:
+        return 0.0
+    return 1.0 if any(item in gold_set for item in list(predicted)[:k]) else 0.0

--- a/apps/api/src/eval/report.py
+++ b/apps/api/src/eval/report.py
@@ -1,0 +1,77 @@
+"""Eval report types and formatting helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class EvalRowResult(BaseModel):
+    """Per-example result row."""
+
+    id: str
+    question: str
+    predicted_chunk_ids: list[str] = Field(default_factory=list)
+    predicted_doc_ids: list[str] = Field(default_factory=list)
+    answer: str = ""
+    metrics: dict[str, float] = Field(default_factory=dict)
+    judge_score: Optional[float] = None
+    judge_reasoning: Optional[str] = None
+    error: Optional[str] = None
+
+
+class EvalReport(BaseModel):
+    """Aggregate report across the whole dataset."""
+
+    dataset_path: str
+    tenant_id: str
+    k: int
+    search_type: str
+    timestamp_utc: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    total_examples: int = 0
+    examples_with_retrieval_labels: int = 0
+    examples_with_answer_labels: int = 0
+    aggregate: dict[str, float] = Field(default_factory=dict)
+    rows: list[EvalRowResult] = Field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        """Render a compact Markdown summary suitable for a CI comment."""
+        lines: list[str] = []
+        lines.append(f"# RAG Eval Report — {self.timestamp_utc}")
+        lines.append("")
+        lines.append(f"- Dataset: `{self.dataset_path}`")
+        lines.append(f"- Tenant: `{self.tenant_id}`")
+        lines.append(f"- Search type: `{self.search_type}`")
+        lines.append(f"- k: `{self.k}`")
+        lines.append(f"- Examples: {self.total_examples}")
+        lines.append(f"  - with retrieval labels: {self.examples_with_retrieval_labels}")
+        lines.append(f"  - with answer labels: {self.examples_with_answer_labels}")
+        lines.append("")
+        lines.append("## Aggregate metrics")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("| --- | --- |")
+        for name, value in sorted(self.aggregate.items()):
+            lines.append(f"| `{name}` | {value:.4f} |")
+        lines.append("")
+        if self.rows:
+            lines.append("## Per-example")
+            lines.append("")
+            lines.append("| id | recall@k | mrr | ndcg@k | answer | error |")
+            lines.append("| --- | --- | --- | --- | --- | --- |")
+            for row in self.rows:
+                lines.append(
+                    "| {id} | {r:.2f} | {m:.2f} | {n:.2f} | {a:.2f} | {e} |".format(
+                        id=row.id,
+                        r=row.metrics.get("recall_at_k", 0.0),
+                        m=row.metrics.get("mrr", 0.0),
+                        n=row.metrics.get("ndcg_at_k", 0.0),
+                        a=row.metrics.get("answer_substring", 0.0),
+                        e=(row.error or "").replace("|", "\\|")[:40],
+                    )
+                )
+        return "\n".join(lines) + "\n"

--- a/apps/api/src/eval/run.py
+++ b/apps/api/src/eval/run.py
@@ -1,0 +1,160 @@
+"""CLI entrypoint:  uv run python -m src.eval.run --dataset <path> --tenant <id>
+
+Outputs:
+    - JSON report (full row detail) to --out-json (default: stdout)
+    - Markdown summary to --out-md (default: skipped)
+
+LLM-as-judge:
+    Disabled by default. Pass --llm-judge AND set LLM_API_KEY to enable. The
+    judge is *additive* - retrieval metrics still run without it.
+
+Regression gate:
+    --min-recall, --min-mrr, --min-ndcg cause non-zero exit if aggregate falls
+    below the threshold. Useful in CI smoke tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from src.eval.dataset import load_dataset
+from src.eval.report import EvalReport
+from src.eval.runner import make_default_search_fn, run_eval
+
+logger = logging.getLogger("src.eval.run")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m src.eval.run",
+        description="Run the RAG quality evaluation harness.",
+    )
+    p.add_argument("--dataset", required=True, help="Path to JSONL dataset file.")
+    p.add_argument("--tenant", required=True, help="Tenant id for every search call.")
+    p.add_argument("--k", type=int, default=10, help="Top-k cutoff (default: 10).")
+    p.add_argument(
+        "--search-type",
+        choices=("hybrid", "semantic", "text"),
+        default="hybrid",
+        help="Which search backend to evaluate.",
+    )
+    p.add_argument("--out-json", default="-", help="JSON output path or '-' for stdout.")
+    p.add_argument("--out-md", default=None, help="Optional Markdown summary output path.")
+    p.add_argument(
+        "--llm-judge",
+        action="store_true",
+        help="Enable LLM-as-judge (requires LLM_API_KEY).",
+    )
+    p.add_argument("--min-recall", type=float, default=None)
+    p.add_argument("--min-mrr", type=float, default=None)
+    p.add_argument("--min-ndcg", type=float, default=None)
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+async def _amain(argv: Optional[list[str]] = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    dataset = load_dataset(args.dataset)
+    logger.info("loaded_dataset: path=%s examples=%d", args.dataset, len(dataset))
+
+    from src.core.dependencies import AgentDependencies
+
+    deps = AgentDependencies()
+    await deps.initialize()
+    try:
+        search_fn = make_default_search_fn(deps, search_type=args.search_type)
+
+        judge_fn = None
+        if args.llm_judge:
+            if not os.environ.get("LLM_API_KEY"):
+                logger.error("llm_judge requested but LLM_API_KEY is unset")
+                return 2
+            from src.eval.judge import make_openai_judge
+
+            judge_fn = await make_openai_judge()
+            if judge_fn is None:
+                logger.error("llm_judge_unavailable - aborting")
+                return 2
+
+        report = await run_eval(
+            dataset,
+            search_fn,
+            tenant_id=args.tenant,
+            k=args.k,
+            search_type=args.search_type,
+            dataset_path=args.dataset,
+            judge_fn=judge_fn,
+        )
+    finally:
+        await deps.cleanup()
+
+    _emit_outputs(report, out_json=args.out_json, out_md=args.out_md)
+
+    return _check_thresholds(
+        report,
+        min_recall=args.min_recall,
+        min_mrr=args.min_mrr,
+        min_ndcg=args.min_ndcg,
+    )
+
+
+def _emit_outputs(report: EvalReport, *, out_json: str, out_md: Optional[str]) -> None:
+    json_blob = report.model_dump_json(indent=2)
+    if out_json == "-":
+        sys.stdout.write(json_blob + "\n")
+    else:
+        Path(out_json).write_text(json_blob + "\n", encoding="utf-8")
+    if out_md:
+        Path(out_md).write_text(report.to_markdown(), encoding="utf-8")
+
+
+def _check_thresholds(
+    report: EvalReport,
+    *,
+    min_recall: Optional[float],
+    min_mrr: Optional[float],
+    min_ndcg: Optional[float],
+) -> int:
+    failures: list[str] = []
+    agg = report.aggregate
+    if min_recall is not None and agg.get("recall_at_k", 0.0) < min_recall:
+        failures.append(f"recall_at_k={agg.get('recall_at_k', 0.0):.3f} < {min_recall}")
+    if min_mrr is not None and agg.get("mrr", 0.0) < min_mrr:
+        failures.append(f"mrr={agg.get('mrr', 0.0):.3f} < {min_mrr}")
+    if min_ndcg is not None and agg.get("ndcg_at_k", 0.0) < min_ndcg:
+        failures.append(f"ndcg_at_k={agg.get('ndcg_at_k', 0.0):.3f} < {min_ndcg}")
+    if failures:
+        sys.stderr.write("regression: " + "; ".join(failures) + "\n")
+        return 1
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    return asyncio.run(_amain(argv))
+
+
+def parse_args_for_test(argv: list[str]) -> argparse.Namespace:
+    """Test seam: parse args without running the pipeline."""
+    return _build_arg_parser().parse_args(argv)
+
+
+to_json = json.dumps
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main", "parse_args_for_test"]

--- a/apps/api/src/eval/runner.py
+++ b/apps/api/src/eval/runner.py
@@ -1,0 +1,182 @@
+"""Runner: drives a search function over a dataset and aggregates metrics.
+
+Design:
+    - Decoupled from MongoDB. Tests inject a `search_fn` callable;
+      the CLI wires in real hybrid_search via a thin adapter.
+    - Tenant isolation: tenant_id is passed to every search call. The runner
+      itself never reads the gold examples' tenant - the caller controls it.
+    - Optional answer judging: enabled only when an explicit `judge_fn` is
+      supplied (CLI gates this behind LLM_API_KEY + an opt-in flag).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Optional, Protocol
+
+from src.eval.dataset import EvalExample
+from src.eval.metrics import mean_reciprocal_rank, ndcg_at_k, recall_at_k, substring_match
+from src.eval.report import EvalReport, EvalRowResult
+from src.models.search import SearchResult
+
+logger = logging.getLogger(__name__)
+
+SearchFn = Callable[[str, str, int], Awaitable[list[SearchResult]]]
+"""Callable signature: (query, tenant_id, k) -> list[SearchResult]."""
+
+AnswerFn = Callable[[str, list[SearchResult]], Awaitable[str]]
+"""Callable signature: (question, top_results) -> generated answer."""
+
+
+class JudgeFn(Protocol):
+    async def __call__(
+        self, question: str, expected: str, answer: str, context: str
+    ) -> tuple[float, str]:
+        """Return (score in [0,1], short reasoning)."""
+
+
+async def run_eval(
+    dataset: list[EvalExample],
+    search_fn: SearchFn,
+    *,
+    tenant_id: str,
+    k: int = 10,
+    search_type: str = "hybrid",
+    dataset_path: str = "<in-memory>",
+    answer_fn: Optional[AnswerFn] = None,
+    judge_fn: Optional[JudgeFn] = None,
+) -> EvalReport:
+    """Run the harness and return an aggregated report."""
+    if k <= 0:
+        raise ValueError("k must be > 0")
+    if not tenant_id:
+        raise ValueError("tenant_id is required (tenant isolation)")
+
+    rows: list[EvalRowResult] = []
+    for example in dataset:
+        rows.append(
+            await _run_single(
+                example,
+                search_fn=search_fn,
+                tenant_id=tenant_id,
+                k=k,
+                answer_fn=answer_fn,
+                judge_fn=judge_fn,
+            )
+        )
+
+    aggregate = _aggregate(rows)
+    return EvalReport(
+        dataset_path=dataset_path,
+        tenant_id=tenant_id,
+        k=k,
+        search_type=search_type,
+        total_examples=len(rows),
+        examples_with_retrieval_labels=sum(1 for ex in dataset if ex.has_retrieval_labels()),
+        examples_with_answer_labels=sum(1 for ex in dataset if ex.expected_answer),
+        aggregate=aggregate,
+        rows=rows,
+    )
+
+
+async def _run_single(
+    example: EvalExample,
+    *,
+    search_fn: SearchFn,
+    tenant_id: str,
+    k: int,
+    answer_fn: Optional[AnswerFn],
+    judge_fn: Optional[JudgeFn],
+) -> EvalRowResult:
+    row = EvalRowResult(id=example.id, question=example.question)
+    try:
+        results = await search_fn(example.question, tenant_id, k)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("eval_search_failed: id=%s", example.id)
+        row.error = f"search: {type(e).__name__}: {e}"
+        return row
+
+    chunk_ids = [r.chunk_id for r in results]
+    doc_ids = [r.document_id for r in results]
+    row.predicted_chunk_ids = chunk_ids
+    row.predicted_doc_ids = doc_ids
+
+    # Choose label set: prefer chunk-level if provided, else doc-level.
+    if example.expected_chunk_ids:
+        gold = example.expected_chunk_ids
+        predicted = chunk_ids
+    else:
+        gold = example.expected_doc_ids
+        predicted = doc_ids
+
+    if gold:
+        row.metrics["recall_at_k"] = recall_at_k(predicted, gold, k)
+        row.metrics["mrr"] = mean_reciprocal_rank(predicted, gold)
+        row.metrics["ndcg_at_k"] = ndcg_at_k(predicted, gold, k)
+        row.metrics["hit_at_k"] = 1.0 if row.metrics["recall_at_k"] > 0 else 0.0
+
+    if answer_fn is not None:
+        try:
+            row.answer = await answer_fn(example.question, results)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("eval_answer_failed: id=%s", example.id)
+            row.error = f"answer: {type(e).__name__}: {e}"
+            return row
+
+        if example.expected_answer:
+            row.metrics["answer_substring"] = substring_match(row.answer, example.expected_answer)
+
+        if judge_fn is not None and example.expected_answer:
+            context = "\n\n".join(r.content for r in results)
+            try:
+                score, reasoning = await judge_fn(
+                    example.question, example.expected_answer, row.answer, context
+                )
+                row.judge_score = float(score)
+                row.judge_reasoning = reasoning
+                row.metrics["judge_score"] = float(score)
+            except Exception as e:  # noqa: BLE001
+                logger.exception("eval_judge_failed: id=%s", example.id)
+                row.error = f"judge: {type(e).__name__}: {e}"
+
+    return row
+
+
+def _aggregate(rows: list[EvalRowResult]) -> dict[str, float]:
+    """Average each metric across rows that reported it.
+
+    Skipping rows without a metric (rather than treating absence as 0) avoids
+    deflating scores for examples that lacked the necessary labels.
+    """
+    sums: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for row in rows:
+        for name, value in row.metrics.items():
+            sums[name] = sums.get(name, 0.0) + float(value)
+            counts[name] = counts.get(name, 0) + 1
+    return {name: sums[name] / counts[name] for name in sums if counts[name]}
+
+
+# --- Adapter for the production hybrid search ----------------------------------
+
+
+def make_default_search_fn(deps, search_type: str = "hybrid") -> SearchFn:
+    """Bind production search functions to a runner-shaped callable."""
+    from src.services.search import hybrid_search, semantic_search, text_search
+
+    if search_type == "semantic":
+        backend = semantic_search
+    elif search_type == "text":
+        backend = text_search
+    elif search_type == "hybrid":
+        backend = hybrid_search
+    else:
+        raise ValueError(f"Unknown search_type: {search_type!r}")
+
+    async def _call(query: str, tenant_id: str, k: int) -> list[SearchResult]:
+        return await backend(deps, query, tenant_id, k)
+
+    return _call
+
+
+__all__ = ["AnswerFn", "JudgeFn", "SearchFn", "make_default_search_fn", "run_eval"]

--- a/apps/api/tests/eval/test_dataset.py
+++ b/apps/api/tests/eval/test_dataset.py
@@ -1,0 +1,96 @@
+"""Dataset loader tests (JSONL parsing + validation)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.eval.dataset import EvalExample, load_dataset
+
+
+@pytest.mark.unit
+def test_load_dataset_round_trip(tmp_path: Path):
+    path = tmp_path / "ds.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "# comment line",
+                "",
+                json.dumps(
+                    {
+                        "id": "q1",
+                        "question": "What is 2+2?",
+                        "expected_answer": "4",
+                        "expected_chunk_ids": ["c1"],
+                    }
+                ),
+                json.dumps({"question": "Just a question?"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    examples = load_dataset(path)
+
+    assert len(examples) == 2
+    assert examples[0].id == "q1"
+    assert examples[0].expected_chunk_ids == ["c1"]
+    # Auto-assigned id uses line number.
+    assert examples[1].id.startswith("ex-")
+
+
+@pytest.mark.unit
+def test_load_dataset_rejects_invalid_json(tmp_path: Path):
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"question": "ok"}\nnot-json\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid JSON"):
+        load_dataset(path)
+
+
+@pytest.mark.unit
+def test_load_dataset_rejects_duplicate_ids(tmp_path: Path):
+    path = tmp_path / "dup.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "x", "question": "q1"}),
+                json.dumps({"id": "x", "question": "q2"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Duplicate"):
+        load_dataset(path)
+
+
+@pytest.mark.unit
+def test_load_dataset_rejects_empty(tmp_path: Path):
+    path = tmp_path / "empty.jsonl"
+    path.write_text("# all comments\n\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="empty"):
+        load_dataset(path)
+
+
+@pytest.mark.unit
+def test_load_dataset_missing_file(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        load_dataset(tmp_path / "nope.jsonl")
+
+
+@pytest.mark.unit
+def test_has_retrieval_labels():
+    assert EvalExample(id="a", question="q", expected_chunk_ids=["c"]).has_retrieval_labels()
+    assert EvalExample(id="b", question="q", expected_doc_ids=["d"]).has_retrieval_labels()
+    assert not EvalExample(id="c", question="q").has_retrieval_labels()
+
+
+@pytest.mark.unit
+def test_committed_sample_dataset_loads():
+    """The shipped sample dataset must always parse cleanly."""
+    path = Path(__file__).parents[2] / "src" / "eval" / "datasets" / "sample.jsonl"
+    examples = load_dataset(path)
+    assert len(examples) >= 5
+    assert all(ex.question for ex in examples)
+    assert all(ex.has_retrieval_labels() for ex in examples)

--- a/apps/api/tests/eval/test_metrics.py
+++ b/apps/api/tests/eval/test_metrics.py
@@ -1,0 +1,153 @@
+"""Hand-computed expectations for retrieval and answer metrics."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.eval.metrics import (
+    hit_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    recall_at_k,
+    substring_match,
+)
+
+# ---------------- recall_at_k ----------------
+
+
+@pytest.mark.unit
+def test_recall_at_k_full_recovery():
+    assert recall_at_k(["a", "b", "c"], ["a", "b"], k=3) == 1.0
+
+
+@pytest.mark.unit
+def test_recall_at_k_partial():
+    # 1 of 2 gold items in top-2 -> 0.5
+    assert recall_at_k(["a", "x"], ["a", "b"], k=2) == 0.5
+
+
+@pytest.mark.unit
+def test_recall_at_k_respects_cutoff():
+    # gold "b" sits at rank 3; with k=2 it is excluded -> recall 0
+    assert recall_at_k(["a", "x", "b"], ["b"], k=2) == 0.0
+
+
+@pytest.mark.unit
+def test_recall_at_k_empty_gold_is_zero():
+    assert recall_at_k(["a", "b"], [], k=5) == 0.0
+
+
+@pytest.mark.unit
+def test_recall_at_k_zero_k_is_zero():
+    assert recall_at_k(["a"], ["a"], k=0) == 0.0
+
+
+@pytest.mark.unit
+def test_recall_at_k_dedupes_gold():
+    # Duplicate gold ids should not inflate recall.
+    assert recall_at_k(["a"], ["a", "a"], k=3) == 1.0
+
+
+# ---------------- mean_reciprocal_rank ----------------
+
+
+@pytest.mark.unit
+def test_mrr_first_position():
+    assert mean_reciprocal_rank(["a", "b"], ["a"]) == 1.0
+
+
+@pytest.mark.unit
+def test_mrr_third_position():
+    # Rank 3 -> 1/3 (1-indexed)
+    assert mean_reciprocal_rank(["x", "y", "a"], ["a"]) == pytest.approx(1.0 / 3.0)
+
+
+@pytest.mark.unit
+def test_mrr_no_hit_is_zero():
+    assert mean_reciprocal_rank(["x", "y"], ["a"]) == 0.0
+
+
+@pytest.mark.unit
+def test_mrr_uses_first_gold_hit_only():
+    # Two gold; first appears at rank 2 -> 1/2.
+    assert mean_reciprocal_rank(["x", "b", "a"], ["a", "b"]) == pytest.approx(0.5)
+
+
+# ---------------- ndcg_at_k ----------------
+
+
+@pytest.mark.unit
+def test_ndcg_perfect_single_hit():
+    # Single gold at rank 1: DCG = 1/log2(2) = 1; IDCG = 1; nDCG = 1.
+    assert ndcg_at_k(["a", "b"], ["a"], k=2) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_ndcg_hit_at_rank_2():
+    # Single gold at rank 2: DCG = 1/log2(3); IDCG = 1.
+    expected = 1.0 / math.log2(3)
+    assert ndcg_at_k(["x", "a"], ["a"], k=2) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_ndcg_two_gold_one_hit():
+    # Gold = {a,b}; predicted only contains a at rank 1.
+    # IDCG with 2 ideal hits = 1/log2(2) + 1/log2(3).
+    # DCG = 1/log2(2) = 1.
+    idcg = 1.0 + 1.0 / math.log2(3)
+    assert ndcg_at_k(["a", "x"], ["a", "b"], k=2) == pytest.approx(1.0 / idcg)
+
+
+@pytest.mark.unit
+def test_ndcg_idcg_capped_by_k():
+    # Three gold but k=1 -> ideal can place at most 1.
+    assert ndcg_at_k(["a"], ["a", "b", "c"], k=1) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_ndcg_zero_when_no_hits():
+    assert ndcg_at_k(["x"], ["a"], k=5) == 0.0
+
+
+@pytest.mark.unit
+def test_ndcg_empty_gold_is_zero():
+    assert ndcg_at_k(["a"], [], k=5) == 0.0
+
+
+# ---------------- substring_match ----------------
+
+
+@pytest.mark.unit
+def test_substring_match_case_insensitive_default():
+    assert substring_match("The Answer Is 42.", "answer is 42") == 1.0
+
+
+@pytest.mark.unit
+def test_substring_match_case_sensitive():
+    assert substring_match("foo BAR", "bar", case_sensitive=True) == 0.0
+    assert substring_match("foo BAR", "BAR", case_sensitive=True) == 1.0
+
+
+@pytest.mark.unit
+def test_substring_match_collapses_whitespace():
+    assert substring_match("hello\n\n  world", "hello world") == 1.0
+
+
+@pytest.mark.unit
+def test_substring_match_empty_expected_is_zero():
+    assert substring_match("anything", "") == 0.0
+
+
+# ---------------- hit_at_k ----------------
+
+
+@pytest.mark.unit
+def test_hit_at_k_true_when_any_in_topk():
+    assert hit_at_k(["x", "a", "y"], ["a"], k=3) == 1.0
+
+
+@pytest.mark.unit
+def test_hit_at_k_respects_cutoff():
+    assert hit_at_k(["x", "y", "a"], ["a"], k=2) == 0.0

--- a/apps/api/tests/eval/test_runner.py
+++ b/apps/api/tests/eval/test_runner.py
@@ -1,0 +1,258 @@
+"""Runner tests with mocked search backend.
+
+Verifies:
+    - Tenant id is forwarded to every search call (isolation boundary).
+    - Per-row metrics + aggregates are computed correctly.
+    - Search exceptions are captured per-row, not propagated.
+    - Answer + judge hooks fire only when supplied.
+    - Examples with no retrieval labels are skipped for retrieval metrics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.eval.dataset import EvalExample
+from src.eval.runner import run_eval
+from src.models.search import SearchResult
+
+
+def _make_result(chunk_id: str, doc_id: str = "doc-x", content: str = "...") -> SearchResult:
+    return SearchResult(
+        chunk_id=chunk_id,
+        document_id=doc_id,
+        content=content,
+        similarity=0.5,
+        metadata={},
+        document_title="t",
+        document_source="s",
+    )
+
+
+@pytest.mark.unit
+async def test_runner_forwards_tenant_id():
+    seen: list[tuple[str, str, int]] = []
+
+    async def search_fn(query: str, tenant_id: str, k: int) -> list[SearchResult]:
+        seen.append((query, tenant_id, k))
+        return [_make_result("c1")]
+
+    dataset = [
+        EvalExample(id="a", question="q1", expected_chunk_ids=["c1"]),
+        EvalExample(id="b", question="q2", expected_chunk_ids=["c1"]),
+    ]
+    report = await run_eval(dataset, search_fn, tenant_id="tenant-zzz", k=5)
+
+    assert len(seen) == 2
+    assert all(t == "tenant-zzz" for _, t, _ in seen)
+    assert all(k == 5 for _, _, k in seen)
+    assert report.tenant_id == "tenant-zzz"
+
+
+@pytest.mark.unit
+async def test_runner_rejects_empty_tenant():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return []
+
+    with pytest.raises(ValueError, match="tenant_id"):
+        await run_eval([], search_fn, tenant_id="", k=5)
+
+
+@pytest.mark.unit
+async def test_runner_rejects_zero_k():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return []
+
+    with pytest.raises(ValueError, match="k must be > 0"):
+        await run_eval([], search_fn, tenant_id="t", k=0)
+
+
+@pytest.mark.unit
+async def test_runner_computes_perfect_recall():
+    async def search_fn(query: str, tenant_id: str, k: int) -> list[SearchResult]:
+        return [_make_result("c1"), _make_result("c2"), _make_result("c3")]
+
+    dataset = [EvalExample(id="ok", question="q", expected_chunk_ids=["c1", "c2"])]
+    report = await run_eval(dataset, search_fn, tenant_id="t", k=3)
+
+    row = report.rows[0]
+    assert row.metrics["recall_at_k"] == pytest.approx(1.0)
+    assert row.metrics["mrr"] == pytest.approx(1.0)
+    assert row.metrics["hit_at_k"] == 1.0
+    assert report.aggregate["recall_at_k"] == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+async def test_runner_falls_back_to_doc_ids_when_no_chunk_labels():
+    async def search_fn(query: str, tenant_id: str, k: int) -> list[SearchResult]:
+        return [_make_result("c1", doc_id="doc-1"), _make_result("c2", doc_id="doc-2")]
+
+    dataset = [EvalExample(id="d", question="q", expected_doc_ids=["doc-2"])]
+    report = await run_eval(dataset, search_fn, tenant_id="t", k=2)
+
+    row = report.rows[0]
+    assert row.metrics["recall_at_k"] == pytest.approx(1.0)
+    assert row.metrics["mrr"] == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+async def test_runner_skips_metrics_when_no_labels():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return [_make_result("c1")]
+
+    dataset = [EvalExample(id="nolabels", question="q")]
+    report = await run_eval(dataset, search_fn, tenant_id="t", k=5)
+
+    row = report.rows[0]
+    assert "recall_at_k" not in row.metrics
+    assert report.examples_with_retrieval_labels == 0
+
+
+@pytest.mark.unit
+async def test_runner_captures_search_errors_per_row():
+    async def search_fn(query: str, tenant_id: str, k: int) -> list[SearchResult]:
+        if "boom" in query:
+            raise RuntimeError("backend exploded")
+        return [_make_result("c1")]
+
+    dataset = [
+        EvalExample(id="bad", question="boom", expected_chunk_ids=["c1"]),
+        EvalExample(id="good", question="ok", expected_chunk_ids=["c1"]),
+    ]
+    report = await run_eval(dataset, search_fn, tenant_id="t", k=3)
+
+    rows = {r.id: r for r in report.rows}
+    assert "RuntimeError" in (rows["bad"].error or "")
+    assert rows["good"].error is None
+    assert report.aggregate["recall_at_k"] == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+async def test_runner_invokes_answer_and_judge():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return [_make_result("c1")]
+
+    async def answer_fn(question: str, results: list[SearchResult]) -> str:
+        return f"the answer is 42 for {question}"
+
+    judge_calls: list[dict] = []
+
+    async def judge_fn(question: str, expected: str, answer: str, context: str):
+        judge_calls.append(
+            {"question": question, "expected": expected, "answer": answer, "ctx": context}
+        )
+        return 0.75, "looks ok"
+
+    dataset = [
+        EvalExample(
+            id="a",
+            question="what is the answer?",
+            expected_answer="42",
+            expected_chunk_ids=["c1"],
+        )
+    ]
+    report = await run_eval(
+        dataset,
+        search_fn,
+        tenant_id="t",
+        k=3,
+        answer_fn=answer_fn,
+        judge_fn=judge_fn,
+    )
+
+    row = report.rows[0]
+    assert row.metrics["answer_substring"] == 1.0
+    assert row.metrics["judge_score"] == pytest.approx(0.75)
+    assert len(judge_calls) == 1
+    assert "42" in judge_calls[0]["answer"]
+
+
+@pytest.mark.unit
+async def test_runner_skips_judge_when_no_expected_answer():
+    """Judge must not run without a gold answer (saves API spend)."""
+
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return [_make_result("c1")]
+
+    async def answer_fn(*_: Any) -> str:
+        return "anything"
+
+    judge_calls: list[Any] = []
+
+    async def judge_fn(*args, **kwargs):
+        judge_calls.append((args, kwargs))
+        return 1.0, ""
+
+    dataset = [EvalExample(id="x", question="q", expected_chunk_ids=["c1"])]
+    await run_eval(
+        dataset,
+        search_fn,
+        tenant_id="t",
+        k=3,
+        answer_fn=answer_fn,
+        judge_fn=judge_fn,
+    )
+
+    assert judge_calls == []
+
+
+@pytest.mark.unit
+async def test_runner_captures_judge_error_without_killing_run():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return [_make_result("c1")]
+
+    async def answer_fn(*_: Any) -> str:
+        return "yes"
+
+    async def judge_fn(*_: Any, **__: Any):
+        raise RuntimeError("judge offline")
+
+    dataset = [EvalExample(id="x", question="q", expected_answer="yes", expected_chunk_ids=["c1"])]
+    report = await run_eval(
+        dataset, search_fn, tenant_id="t", k=3, answer_fn=answer_fn, judge_fn=judge_fn
+    )
+
+    row = report.rows[0]
+    assert "judge" in (row.error or "")
+    assert row.metrics.get("answer_substring") == 1.0
+
+
+@pytest.mark.unit
+async def test_report_markdown_renders():
+    async def search_fn(*_: Any) -> list[SearchResult]:
+        return [_make_result("c1")]
+
+    dataset = [EvalExample(id="a", question="q", expected_chunk_ids=["c1"])]
+    report = await run_eval(dataset, search_fn, tenant_id="t", k=3)
+    md = report.to_markdown()
+    assert "Aggregate metrics" in md
+    assert "recall_at_k" in md
+
+
+@pytest.mark.unit
+def test_cli_arg_parser_wires_flags():
+    from src.eval.run import parse_args_for_test
+
+    args = parse_args_for_test(
+        [
+            "--dataset",
+            "ds.jsonl",
+            "--tenant",
+            "abc",
+            "--k",
+            "7",
+            "--search-type",
+            "semantic",
+            "--llm-judge",
+            "--min-recall",
+            "0.5",
+        ]
+    )
+    assert args.dataset == "ds.jsonl"
+    assert args.tenant == "abc"
+    assert args.k == 7
+    assert args.search_type == "semantic"
+    assert args.llm_judge is True
+    assert args.min_recall == 0.5


### PR DESCRIPTION
## Summary

Adds a self-contained eval harness under `apps/api/src/eval/` that measures retrieval and answer quality over a labeled JSONL dataset, satisfying every acceptance criterion in #23.

- Dataset loader (JSONL): `{ question, expected_answer, expected_chunk_ids, expected_doc_ids, tags }` with duplicate-id and validation guards
- Async runner with injectable `search_fn`; `tenant_id` is required and forwarded to every search call (tenant-isolation boundary). Per-row error capture so one bad query doesn't kill the run
- Retrieval metrics: `recall_at_k`, `mrr`, `ndcg_at_k` (binary relevance, `log2(rank+1)` discount with IDCG capped by k), `hit_at_k` — all with hand-computed unit tests
- Answer metrics: whitespace-collapsed substring match; optional LLM-as-judge gated on both `--llm-judge` flag and `LLM_API_KEY` env (disabled by default; reuses the project's existing LLM provider so no new secret is introduced)
- CLI: `uv run python -m src.eval.run --dataset <path> --tenant <id> --k 10 --search-type {hybrid,semantic,text}` → JSON report (stdout or file) + optional Markdown summary
- Optional regression gate: `--min-recall`, `--min-mrr`, `--min-ndcg` exit non-zero so CI smoke tests can fail on regression
- Synthetic 10-example dataset committed at `apps/api/src/eval/datasets/sample.jsonl` for CI/smoke runs
- 41 new unit tests; full unit suite: 201 passed

Closes #23

## Test plan

- [x] `uv run pytest tests/eval/ -q` — 41 passed
- [x] `uv run pytest -q -m unit` — 201 passed (no regression)
- [x] `uv run ruff check src/eval tests/eval && uv run ruff format --check src/eval tests/eval`
- [ ] Manual: run against a populated MongoDB tenant with the sample dataset
- [ ] CI: confirm dataset loads in the test container and threshold gates work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)