### PR TITLE
feat(security): input validation, CORS allow-list, CSP, secrets hygiene

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -45,5 +45,40 @@ SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.0
 SENTRY_RELEASE=
 
-# Redis Configuration (Celery broker)
+# Redis Configuration (Celery broker / result backend)
 REDIS_URL=redis://localhost:6379/0
+
+# Upload limits
+MAX_UPLOAD_SIZE_MB=50
+UPLOAD_TEMP_DIR=/tmp/mongorag-uploads
+
+# --- Auth ---
+# Must match NEXTAUTH_SECRET in apps/web/.env.local. Use `openssl rand -hex 32`.
+NEXTAUTH_SECRET=replace-with-32-byte-random-hex
+APP_URL=http://localhost:3100
+
+# --- Email (Resend) ---
+RESEND_API_KEY=re_...
+RESET_EMAIL_FROM=noreply@example.com
+
+# --- Stripe ---
+# sk_test_... in test mode, sk_live_... in production. Never commit live keys.
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+# whsec_... — set after creating the webhook endpoint in Stripe.
+STRIPE_WEBHOOK_SECRET=whsec_...
+# Per-(plan, model_tier) Stripe Price IDs (price_...). Leave empty in dev.
+STRIPE_PRICE_PRO_STARTER=
+STRIPE_PRICE_PRO_STANDARD=
+STRIPE_PRICE_PRO_PREMIUM=
+STRIPE_PRICE_PRO_ULTRA=
+STRIPE_PRICE_ENTERPRISE_STARTER=
+STRIPE_PRICE_ENTERPRISE_STANDARD=
+STRIPE_PRICE_ENTERPRISE_PREMIUM=
+STRIPE_PRICE_ENTERPRISE_ULTRA=
+
+# --- Security / CORS ---
+# Comma-separated list of explicit dashboard origins. No wildcards in production.
+CORS_ALLOWED_ORIGINS=http://localhost:3100
+# Maximum body size for non-multipart requests (bytes). 1 MiB default.
+MAX_REQUEST_BODY_BYTES=1048576

--- a/apps/api/src/core/middleware.py
+++ b/apps/api/src/core/middleware.py
@@ -1,10 +1,10 @@
-"""Tenant guard middleware -- safety net for missing tenant context."""
+"""HTTP middleware: tenant guard, security headers, body-size limits."""
 
 import logging
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,14 @@ _EXEMPT_PREFIXES = (
     "/docs",
     "/openapi.json",
     "/redoc",
+)
+
+# Endpoints that legitimately accept large bodies (file uploads).
+# Body-size limiting for these is enforced inside the handler using the
+# tenant's plan-aware max_upload_size_mb setting.
+_BODY_SIZE_EXEMPT_PREFIXES = (
+    "/api/v1/documents/ingest",
+    "/api/v1/documents/",  # reingest variants stream multipart bodies
 )
 
 
@@ -57,3 +65,81 @@ class TenantGuardMiddleware(BaseHTTPMiddleware):
             )
 
         return response
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach baseline security response headers to every response.
+
+    The dashboard CSP lives in the Next.js layer (next.config.ts). Here we
+    set the Helmet-equivalent baseline that protects API responses from
+    being reflected/embedded by malicious origins.
+    """
+
+    def __init__(self, app, *, is_production: bool = False) -> None:
+        super().__init__(app)
+        self._is_production = is_production
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        response = await call_next(request)
+        headers = response.headers
+
+        headers.setdefault("X-Content-Type-Options", "nosniff")
+        headers.setdefault("X-Frame-Options", "DENY")
+        headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        headers.setdefault(
+            "Permissions-Policy",
+            "geolocation=(), microphone=(), camera=(), payment=()",
+        )
+        headers.setdefault("Cross-Origin-Opener-Policy", "same-origin")
+        headers.setdefault("Cross-Origin-Resource-Policy", "same-site")
+
+        # API responses should never be cached by intermediaries by default.
+        # Individual handlers (e.g. SSE) override Cache-Control intentionally.
+        headers.setdefault("Cache-Control", "no-store")
+
+        if self._is_production:
+            headers.setdefault(
+                "Strict-Transport-Security",
+                "max-age=63072000; includeSubDomains; preload",
+            )
+
+        return response
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests that exceed the configured maximum body size.
+
+    Uses the Content-Length header for fast rejection. Multipart upload
+    endpoints are exempt — they enforce their own per-plan size limit
+    after streaming the body to disk.
+    """
+
+    def __init__(self, app, *, max_bytes: int) -> None:
+        super().__init__(app)
+        self._max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+        if any(path.startswith(p) for p in _BODY_SIZE_EXEMPT_PREFIXES):
+            return await call_next(request)
+
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                size = int(content_length)
+            except ValueError:
+                return JSONResponse(
+                    status_code=400,
+                    content={"detail": "Invalid Content-Length header"},
+                )
+            if size > self._max_bytes:
+                logger.warning(
+                    "request_body_too_large",
+                    extra={"path": path, "size": size, "limit": self._max_bytes},
+                )
+                return JSONResponse(
+                    status_code=413,
+                    content={"detail": (f"Request body too large (max {self._max_bytes} bytes)")},
+                )
+
+        return await call_next(request)

--- a/apps/api/src/core/rate_limit_dep.py
+++ b/apps/api/src/core/rate_limit_dep.py
@@ -31,6 +31,55 @@ def _principal_key(authorization: Optional[str], tenant_id: str) -> str:
     return "tenant:" + tenant_id
 
 
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP for unauthenticated rate limiting.
+
+    Honours X-Forwarded-For only when the deployment terminates TLS at a
+    trusted proxy (the proxy must strip client-set XFF). We take the
+    left-most token because most proxies append.
+    """
+    fwd = request.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip() or "unknown"
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+# Per-IP limit for unauthenticated endpoints (login/signup/forgot/reset).
+# Tighter than per-tenant limits to slow brute-force credential attacks.
+_AUTH_IP_LIMIT_PER_MINUTE = 20
+
+
+async def enforce_auth_ip_rate_limit(request: Request) -> None:
+    """Apply a per-IP rate limit to unauthenticated auth endpoints.
+
+    Returns 429 with ``Retry-After`` when exceeded. Used on login,
+    signup, forgot-password, reset-password — endpoints that do not yet
+    have a tenant_id we could rate-limit by.
+    """
+    ip = _client_ip(request)
+    limiter = get_default_limiter()
+    key = "ip:" + ip
+    result = await limiter.check(key, _AUTH_IP_LIMIT_PER_MINUTE, window_seconds=60)
+
+    if not result.allowed:
+        logger.warning(
+            "auth_ip_rate_limited",
+            extra={"ip_prefix": ip.rsplit(".", 1)[0] if "." in ip else ip[:6]},
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Too many requests — please retry shortly",
+            headers={
+                "Retry-After": str(result.reset_in),
+                "X-RateLimit-Limit": str(result.limit),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(result.reset_in),
+            },
+        )
+
+
 async def enforce_rate_limit(
     request: Request,
     authorization: Optional[str] = Header(default=None),

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -180,6 +180,38 @@ class Settings(BaseSettings):
         description="Frontend app URL (used in password reset email links)",
     )
 
+    # Application environment — gates dev-only relaxations
+    app_env: str = Field(
+        default="development",
+        description="Environment label: development, staging, production",
+    )
+
+    # CORS configuration — explicit allow-list, no wildcards in production
+    cors_allowed_origins: str = Field(
+        default="http://localhost:3100",
+        description=(
+            "Comma-separated list of allowed CORS origins for the dashboard. "
+            "Production must enumerate explicit origins — no wildcards."
+        ),
+    )
+
+    # Maximum allowed request body size (bytes) for non-multipart endpoints.
+    # File uploads use max_upload_size_mb separately.
+    max_request_body_bytes: int = Field(
+        default=1_048_576,  # 1 MiB
+        description="Maximum body size for JSON/form requests (bytes).",
+    )
+
+    @property
+    def cors_origins_list(self) -> list[str]:
+        """Parse comma-separated origins into a clean list."""
+        return [o.strip() for o in (self.cors_allowed_origins or "").split(",") if o.strip()]
+
+    @property
+    def is_production(self) -> bool:
+        """Whether the app is running in production mode."""
+        return self.app_env.lower() == "production"
+
     reset_email_from: str = Field(
         default="noreply@mongorag.com",
         description="From address for password reset emails",

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -9,9 +9,14 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.core.database import ensure_indexes
 from src.core.dependencies import AgentDependencies
-from src.core.middleware import TenantGuardMiddleware
+from src.core.middleware import (
+    BodySizeLimitMiddleware,
+    SecurityHeadersMiddleware,
+    TenantGuardMiddleware,
+)
 from src.core.observability import configure_logging, init_sentry
 from src.core.request_logging import RequestLoggingMiddleware, install_exception_handlers
+from src.core.settings import load_settings
 from src.routers.auth import router as auth_router
 from src.routers.billing import router as billing_router
 from src.routers.bots import router as bots_router
@@ -74,22 +79,65 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3100"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
-# Tenant guard middleware (safety net -- logs warnings, never blocks)
-app.add_middleware(TenantGuardMiddleware)
+def _configure_middleware(application: FastAPI) -> None:
+    """Wire security middleware in the right order.
 
-# Request logging middleware — must be added LAST so it runs FIRST (Starlette
-# wraps middleware in reverse-add order). This guarantees every request, even
-# those rejected by tenant guard / CORS, gets a request_id + access log.
-app.add_middleware(RequestLoggingMiddleware)
+    Order matters — Starlette runs middleware in reverse-add order, so the
+    last added is outermost. We want, on the way in:
+        CORS -> RequestLogging -> SecurityHeaders -> BodySizeLimit ->
+        TenantGuard -> route
+    """
+    settings = load_settings()
+
+    origins = settings.cors_origins_list
+    if not origins:
+        # Fail closed: an empty allow-list means no browser may call us.
+        # In production this is the right default rather than `*`.
+        origins = []
+
+    if settings.is_production and ("*" in origins or any(o.strip() == "*" for o in origins)):
+        raise RuntimeError("CORS_ALLOWED_ORIGINS must not contain '*' in production")
+
+    # Tenant guard runs closest to the handler (added first → innermost).
+    application.add_middleware(TenantGuardMiddleware)
+
+    # Body-size limit before tenant guard to reject oversized payloads
+    # before any business logic runs.
+    application.add_middleware(BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes)
+
+    # Security headers wrap the business response.
+    application.add_middleware(SecurityHeadersMiddleware, is_production=settings.is_production)
+
+    # Request logging sits just inside CORS so every request — even those
+    # rejected by tenant guard or body-size — gets a request_id and access
+    # log entry. Adding it here (after security headers) means it runs
+    # BEFORE them on the way in (Starlette reverses add order).
+    application.add_middleware(RequestLoggingMiddleware)
+
+    # CORS is the outermost layer — it must see preflight OPTIONS and
+    # apply Access-Control headers even on error responses.
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=[
+            "Authorization",
+            "Content-Type",
+            "Accept",
+            "X-Requested-With",
+        ],
+        expose_headers=[
+            "X-RateLimit-Limit",
+            "X-RateLimit-Remaining",
+            "X-RateLimit-Reset",
+        ],
+        max_age=600,
+    )
+
+
+_configure_middleware(app)
 
 # Sanitized exception handlers — never leak stack traces to clients.
 install_exception_handlers(app)

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -3,7 +3,18 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+
+class StrictRequest(BaseModel):
+    """Base for request bodies — rejects unknown fields and strips whitespace.
+
+    Forbidding extra fields prevents mass-assignment style bugs where a
+    client passes fields the model author did not intend to accept.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
 
 # --- Ingestion ---
 
@@ -134,11 +145,13 @@ class ReingestResponse(BaseModel):
 # --- Chat ---
 
 
-class ChatRequest(BaseModel):
+class ChatRequest(StrictRequest):
     """Request body for chat endpoint."""
 
     message: str = Field(..., min_length=1, max_length=10000, description="User message")
-    conversation_id: Optional[str] = Field(default=None, description="Existing conversation ID")
+    conversation_id: Optional[str] = Field(
+        default=None, max_length=128, description="Existing conversation ID"
+    )
     search_type: Literal["semantic", "text", "hybrid"] = Field(
         default="hybrid", description="Search type: semantic, text, hybrid"
     )
@@ -163,21 +176,23 @@ class ChatResponse(BaseModel):
 # --- WebSocket ---
 
 
-class WSMessage(BaseModel):
+class WSMessage(StrictRequest):
     """Incoming WebSocket message from client."""
 
-    type: str = Field(..., description="Message type: message, cancel")
-    content: Optional[str] = Field(default=None, description="Message content")
-    conversation_id: Optional[str] = Field(default=None, description="Conversation ID")
+    type: Literal["message", "cancel"] = Field(..., description="Message type: message or cancel")
+    content: Optional[str] = Field(default=None, max_length=10000, description="Message content")
+    conversation_id: Optional[str] = Field(
+        default=None, max_length=128, description="Conversation ID"
+    )
 
 
 # --- Auth ---
 
 
-class SignupRequest(BaseModel):
+class SignupRequest(StrictRequest):
     """Request body for user signup."""
 
-    email: EmailStr = Field(..., description="User email address")
+    email: EmailStr = Field(..., max_length=320, description="User email address")
     password: str = Field(..., min_length=8, max_length=128, description="Password")
     organization_name: str = Field(
         ..., min_length=2, max_length=100, description="Organization name"
@@ -192,11 +207,11 @@ class SignupResponse(BaseModel):
     email: str
 
 
-class LoginRequest(BaseModel):
+class LoginRequest(StrictRequest):
     """Request body for user login."""
 
-    email: EmailStr = Field(..., description="User email address")
-    password: str = Field(..., min_length=1, description="Password")
+    email: EmailStr = Field(..., max_length=320, description="User email address")
+    password: str = Field(..., min_length=1, max_length=128, description="Password")
 
 
 class LoginResponse(BaseModel):
@@ -209,16 +224,16 @@ class LoginResponse(BaseModel):
     role: str
 
 
-class ForgotPasswordRequest(BaseModel):
+class ForgotPasswordRequest(StrictRequest):
     """Request body for forgot password."""
 
-    email: EmailStr = Field(..., description="User email address")
+    email: EmailStr = Field(..., max_length=320, description="User email address")
 
 
-class ResetPasswordRequest(BaseModel):
+class ResetPasswordRequest(StrictRequest):
     """Request body for password reset."""
 
-    token: str = Field(..., min_length=1, description="Reset token from email")
+    token: str = Field(..., min_length=1, max_length=512, description="Reset token from email")
     new_password: str = Field(..., min_length=8, max_length=128, description="New password")
 
 
@@ -240,12 +255,13 @@ class WSTicketResponse(BaseModel):
 VALID_PERMISSIONS = {"chat", "search"}
 
 
-class CreateKeyRequest(BaseModel):
+class CreateKeyRequest(StrictRequest):
     """Request body for creating an API key."""
 
     name: str = Field(..., min_length=2, max_length=100, description="Human-readable key name")
     permissions: list[str] = Field(
         default_factory=lambda: ["chat", "search"],
+        max_length=8,
         description="Allowed operations",
     )
 

--- a/apps/api/src/models/billing.py
+++ b/apps/api/src/models/billing.py
@@ -12,7 +12,7 @@ Aligned with `docs/superpowers/specs/2026-04-04-stripe-billing-design.md`.
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.models.tenant import PlanTier
 
@@ -84,6 +84,8 @@ FREE_TIER_MODEL = "openai/gpt-5.4-nano"
 
 class CheckoutRequest(BaseModel):
     """Request body for POST /api/v1/billing/checkout."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     plan: PlanTier = Field(..., description="Target plan: pro or enterprise")
     model_tier: ModelTier = Field(..., description="Model tier inside the plan")

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
+from src.core.rate_limit_dep import enforce_auth_ip_rate_limit
 from src.core.settings import Settings
 from src.core.tenant import get_tenant_id
 from src.models.api import (
@@ -63,7 +64,12 @@ async def _send_reset_email(email: str, token: str, settings: Settings) -> None:
         logger.exception("Failed to send reset email to %s", email)
 
 
-@router.post("/signup", response_model=SignupResponse, status_code=201)
+@router.post(
+    "/signup",
+    response_model=SignupResponse,
+    status_code=201,
+    dependencies=[Depends(enforce_auth_ip_rate_limit)],
+)
 async def signup(
     body: SignupRequest,
     service: AuthService = Depends(_get_auth_service),
@@ -81,7 +87,11 @@ async def signup(
     return SignupResponse(**result)
 
 
-@router.post("/login", response_model=LoginResponse)
+@router.post(
+    "/login",
+    response_model=LoginResponse,
+    dependencies=[Depends(enforce_auth_ip_rate_limit)],
+)
 async def login(
     body: LoginRequest,
     service: AuthService = Depends(_get_auth_service),
@@ -95,7 +105,11 @@ async def login(
     return LoginResponse(**result)
 
 
-@router.post("/forgot-password", response_model=MessageResponse)
+@router.post(
+    "/forgot-password",
+    response_model=MessageResponse,
+    dependencies=[Depends(enforce_auth_ip_rate_limit)],
+)
 async def forgot_password(
     body: ForgotPasswordRequest,
     service: AuthService = Depends(_get_auth_service),
@@ -117,7 +131,11 @@ async def forgot_password(
     )
 
 
-@router.post("/reset-password", response_model=MessageResponse)
+@router.post(
+    "/reset-password",
+    response_model=MessageResponse,
+    dependencies=[Depends(enforce_auth_ip_rate_limit)],
+)
 async def reset_password(
     body: ResetPasswordRequest,
     service: AuthService = Depends(_get_auth_service),

--- a/apps/api/src/routers/billing.py
+++ b/apps/api/src/routers/billing.py
@@ -3,6 +3,7 @@
 Webhook handling is intentionally out of scope here — see issue #43.
 """
 
+import ipaddress
 import logging
 from urllib.parse import urlparse
 
@@ -49,6 +50,26 @@ def _get_billing_service(deps: AgentDependencies = Depends(get_deps)) -> Billing
         raise HTTPException(status_code=503, detail=str(exc))
 
 
+def _is_private_host(host: str) -> bool:
+    """Return True for hostnames that resolve to private/loopback ranges.
+
+    We block IP-literal hosts in private, loopback, link-local, and
+    multicast ranges to prevent SSRF-style abuse via the redirect URL.
+    """
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    )
+
+
 def _validate_redirect_url(url: str, field: str) -> None:
     """Reject obviously dangerous URLs before forwarding to Stripe.
 
@@ -56,7 +77,10 @@ def _validate_redirect_url(url: str, field: str) -> None:
     and cannot be enumerated up-front). We do enforce:
       - scheme is http or https
       - a host is present
+      - no embedded credentials (user@host)
       - http is only allowed for localhost (dev)
+      - IP-literal hosts in private ranges are rejected to harden against
+        SSRF probes injected into the redirect chain
     """
     try:
         parsed = urlparse(url)
@@ -69,13 +93,23 @@ def _validate_redirect_url(url: str, field: str) -> None:
         )
     if not parsed.hostname:
         raise HTTPException(status_code=400, detail=f"{field} is missing a host")
+    if parsed.username or parsed.password:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must not include user credentials",
+        )
+    host = parsed.hostname.lower()
     if parsed.scheme == "http":
-        host = parsed.hostname.lower()
         if host != "localhost" and not host.startswith("127."):
             raise HTTPException(
                 status_code=400,
                 detail=f"{field} must use https outside of localhost",
             )
+    elif _is_private_host(host):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must not point to a private network address",
+        )
 
 
 @router.get("/plans", response_model=PlansResponse)

--- a/apps/api/tests/test_security_hardening.py
+++ b/apps/api/tests/test_security_hardening.py
@@ -1,0 +1,449 @@
+"""Security hardening tests: CORS, security headers, body-size, input strictness.
+
+These tests use a tiny FastAPI app that mounts the same middleware as the
+production app so we can exercise it without standing up MongoDB.
+"""
+
+import os
+from typing import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from src.core.middleware import (
+    BodySizeLimitMiddleware,
+    SecurityHeadersMiddleware,
+)
+
+
+def _make_app(
+    *,
+    origins: list[str],
+    is_production: bool = False,
+    body_limit: int = 1024,
+) -> FastAPI:
+    app = FastAPI()
+
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=body_limit)
+    app.add_middleware(SecurityHeadersMiddleware, is_production=is_production)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type"],
+        max_age=600,
+    )
+
+    @app.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.post("/echo")
+    async def echo(payload: dict) -> dict:
+        return payload
+
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    app = _make_app(origins=["http://localhost:3100"])
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.mark.unit
+def test_security_headers_present_on_get(client: TestClient) -> None:
+    """Baseline security headers attach to every response."""
+    r = client.get("/ping")
+
+    assert r.status_code == 200
+    assert r.headers["X-Content-Type-Options"] == "nosniff"
+    assert r.headers["X-Frame-Options"] == "DENY"
+    assert r.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert "Permissions-Policy" in r.headers
+    assert r.headers["Cross-Origin-Opener-Policy"] == "same-origin"
+    assert r.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.unit
+def test_hsts_only_in_production() -> None:
+    """HSTS must not be set in development (would lock localhost into HTTPS)."""
+    dev = TestClient(_make_app(origins=["http://localhost:3100"], is_production=False))
+    prod = TestClient(_make_app(origins=["https://app.example.com"], is_production=True))
+
+    assert "Strict-Transport-Security" not in dev.get("/ping").headers
+    assert "max-age=" in prod.get("/ping").headers["Strict-Transport-Security"]
+
+
+@pytest.mark.unit
+def test_cors_allows_listed_origin() -> None:
+    """A request from an allow-listed origin gets the matching CORS header back."""
+    app = _make_app(origins=["http://localhost:3100"])
+    client = TestClient(app)
+
+    r = client.options(
+        "/echo",
+        headers={
+            "Origin": "http://localhost:3100",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+
+    assert r.status_code in (200, 204)
+    assert r.headers.get("access-control-allow-origin") == "http://localhost:3100"
+    assert r.headers.get("access-control-allow-credentials") == "true"
+
+
+@pytest.mark.unit
+def test_cors_blocks_unlisted_origin() -> None:
+    """An origin not on the allow-list does not receive the CORS allow header."""
+    app = _make_app(origins=["http://localhost:3100"])
+    client = TestClient(app)
+
+    r = client.options(
+        "/echo",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    # CORS middleware does not echo unknown origins back.
+    assert r.headers.get("access-control-allow-origin") != "https://evil.example.com"
+
+
+@pytest.mark.unit
+def test_cors_does_not_reflect_arbitrary_origins() -> None:
+    """Confirm origin reflection is impossible — defense against CORS bypass."""
+    app = _make_app(origins=["http://localhost:3100"])
+    client = TestClient(app)
+
+    r = client.get("/ping", headers={"Origin": "null"})
+
+    assert r.headers.get("access-control-allow-origin") not in {"null", "*"}
+
+
+@pytest.mark.unit
+def test_body_size_limit_rejects_large_content_length() -> None:
+    """Requests exceeding the configured body limit return 413."""
+    app = _make_app(origins=["http://localhost:3100"], body_limit=128)
+    client = TestClient(app)
+
+    big = "x" * 1024
+    r = client.post(
+        "/echo",
+        content=f'{{"v":"{big}"}}',
+        headers={
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert r.status_code == 413
+
+
+@pytest.mark.unit
+def test_body_size_limit_allows_small_payload() -> None:
+    """Requests inside the limit pass through normally."""
+    app = _make_app(origins=["http://localhost:3100"], body_limit=4096)
+    client = TestClient(app)
+
+    r = client.post("/echo", json={"hello": "world"})
+
+    assert r.status_code == 200
+    assert r.json() == {"hello": "world"}
+
+
+@pytest.mark.unit
+def test_body_size_limit_invalid_content_length_400() -> None:
+    """A non-numeric Content-Length is rejected with 400."""
+    app = _make_app(origins=["http://localhost:3100"], body_limit=4096)
+    client = TestClient(app)
+
+    r = client.post(
+        "/echo",
+        content=b'{"a":1}',
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": "not-a-number",
+        },
+    )
+
+    assert r.status_code == 400
+
+
+@pytest.mark.unit
+def test_body_size_exempt_upload_path_passes_large_content_length() -> None:
+    """Multipart upload paths are exempt — size enforced by the handler."""
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=10)
+
+    @app.post("/api/v1/documents/ingest")
+    async def ingest() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    client = TestClient(app)
+    r = client.post(
+        "/api/v1/documents/ingest",
+        content=b"x" * 200,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+
+    assert r.status_code == 200
+
+
+# --- Settings & CORS list parsing ---
+
+
+@pytest.mark.unit
+def test_settings_cors_origins_list_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cors_origins_list parses a comma-separated env value into a clean list."""
+    from src.core.settings import Settings
+
+    monkeypatch.setenv("MONGODB_URI", "mongodb://localhost:27017")
+    monkeypatch.setenv("LLM_API_KEY", "x")
+    monkeypatch.setenv("EMBEDDING_API_KEY", "x")
+    monkeypatch.setenv("NEXTAUTH_SECRET", "y" * 32)
+    monkeypatch.setenv(
+        "CORS_ALLOWED_ORIGINS",
+        "https://app.example.com, https://admin.example.com ,",
+    )
+
+    s = Settings()
+    assert s.cors_origins_list == [
+        "https://app.example.com",
+        "https://admin.example.com",
+    ]
+
+
+@pytest.mark.unit
+def test_settings_is_production_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """is_production reflects APP_ENV exactly."""
+    from src.core.settings import Settings
+
+    for k, v in {
+        "MONGODB_URI": "mongodb://localhost:27017",
+        "LLM_API_KEY": "x",
+        "EMBEDDING_API_KEY": "x",
+        "NEXTAUTH_SECRET": "y" * 32,
+    }.items():
+        monkeypatch.setenv(k, v)
+
+    monkeypatch.setenv("APP_ENV", "production")
+    assert Settings().is_production is True
+    monkeypatch.setenv("APP_ENV", "development")
+    assert Settings().is_production is False
+
+
+# --- Input validation strictness ---
+
+
+@pytest.mark.unit
+def test_chat_request_rejects_unknown_fields() -> None:
+    """ChatRequest must forbid mass-assignment of unexpected fields."""
+    from pydantic import ValidationError
+
+    from src.models.api import ChatRequest
+
+    with pytest.raises(ValidationError):
+        ChatRequest(
+            message="hello",
+            conversation_id=None,
+            tenant_id="other-tenant",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_chat_request_caps_message_length() -> None:
+    """ChatRequest enforces a maximum message length."""
+    from pydantic import ValidationError
+
+    from src.models.api import ChatRequest
+
+    with pytest.raises(ValidationError):
+        ChatRequest(message="a" * 10_001)
+
+
+@pytest.mark.unit
+def test_signup_request_rejects_extra_fields() -> None:
+    from pydantic import ValidationError
+
+    from src.models.api import SignupRequest
+
+    with pytest.raises(ValidationError):
+        SignupRequest(
+            email="foo@example.com",
+            password="password123",
+            organization_name="Acme",
+            role="owner",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_create_key_request_rejects_extra_fields() -> None:
+    from pydantic import ValidationError
+
+    from src.models.api import CreateKeyRequest
+
+    with pytest.raises(ValidationError):
+        CreateKeyRequest(
+            name="prod",
+            permissions=["chat", "search"],
+            tenant_id="other-tenant",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_ws_message_rejects_unknown_type() -> None:
+    """WSMessage type must be one of the literal values (no injection)."""
+    from pydantic import ValidationError
+
+    from src.models.api import WSMessage
+
+    with pytest.raises(ValidationError):
+        WSMessage(type="evil")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_checkout_request_rejects_extra_fields() -> None:
+    from pydantic import ValidationError
+
+    from src.models.billing import CheckoutRequest, ModelTier
+    from src.models.tenant import PlanTier
+
+    with pytest.raises(ValidationError):
+        CheckoutRequest(
+            plan=PlanTier.PRO,
+            model_tier=ModelTier.STARTER,
+            success_url="https://app.example.com/ok",
+            cancel_url="https://app.example.com/cancel",
+            tenant_id="other-tenant",  # type: ignore[call-arg]
+        )
+
+
+# --- Billing redirect URL hardening ---
+
+
+@pytest.mark.unit
+def test_validate_redirect_url_rejects_userinfo() -> None:
+    """Embedded credentials are rejected to block phishing-style redirects."""
+    from fastapi import HTTPException
+
+    from src.routers.billing import _validate_redirect_url
+
+    with pytest.raises(HTTPException) as exc:
+        _validate_redirect_url("https://attacker@evil.example.com/", "success_url")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.unit
+def test_validate_redirect_url_rejects_private_ip() -> None:
+    """Private/loopback IP-literal hosts are rejected (SSRF hardening)."""
+    from fastapi import HTTPException
+
+    from src.routers.billing import _validate_redirect_url
+
+    for url in (
+        "https://10.0.0.1/cb",
+        "https://192.168.1.5/cb",
+        "https://169.254.169.254/latest/meta-data/",
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _validate_redirect_url(url, "success_url")
+        assert exc.value.status_code == 400
+
+
+@pytest.mark.unit
+def test_validate_redirect_url_allows_https_public() -> None:
+    from src.routers.billing import _validate_redirect_url
+
+    # Should not raise.
+    _validate_redirect_url("https://app.example.com/billing/success", "success_url")
+
+
+# --- Auth IP rate limiter ---
+
+
+@pytest.mark.unit
+async def test_enforce_auth_ip_rate_limit_blocks_after_threshold() -> None:
+    """A burst of requests from the same IP eventually returns 429."""
+    from fastapi import HTTPException
+
+    from src.core.rate_limit_dep import enforce_auth_ip_rate_limit
+    from src.services.rate_limit import reset_default_limiter
+
+    reset_default_limiter()
+
+    class _Client:
+        host = "203.0.113.10"
+
+    class _Req:
+        headers: dict[str, str] = {"x-forwarded-for": "203.0.113.10"}
+        client = _Client()
+
+    # 20 calls allowed, 21st should raise.
+    for _ in range(20):
+        await enforce_auth_ip_rate_limit(_Req())  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc:
+        await enforce_auth_ip_rate_limit(_Req())  # type: ignore[arg-type]
+
+    assert exc.value.status_code == 429
+    assert "Retry-After" in exc.value.headers
+
+
+# --- Secret hygiene smoke test ---
+
+
+@pytest.mark.unit
+def test_no_live_stripe_keys_in_non_test_code() -> None:
+    """Static check: no sk_live_ keys checked into non-test files under apps/.
+
+    Test files may legitimately contain placeholder ``sk_live_…`` strings
+    as redaction fixtures; production code must not.
+    """
+    import re
+
+    pattern = re.compile(rb"sk_live_[A-Za-z0-9]{20,}")
+    here = os.path.dirname(__file__)
+    repo_apps = os.path.normpath(os.path.join(here, "..", "..", ".."))
+
+    offenders: list[str] = []
+    for root, dirs, files in os.walk(os.path.join(repo_apps, "apps")):
+        dirs[:] = [
+            d
+            for d in dirs
+            if d
+            not in {
+                "node_modules",
+                ".next",
+                "__pycache__",
+                ".pytest_cache",
+                ".venv",
+                "dist",
+                "build",
+                "tests",
+                "__tests__",
+            }
+        ]
+        for name in files:
+            if (
+                name.startswith("test_")
+                or name.endswith(".test.ts")
+                or name.endswith(".test.tsx")
+                or name.endswith(".spec.ts")
+            ):
+                continue
+            path = os.path.join(root, name)
+            try:
+                with open(path, "rb") as f:
+                    if pattern.search(f.read()):
+                        offenders.append(path)
+            except OSError:
+                continue
+
+    assert not offenders, f"Live Stripe keys found in: {offenders}"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,11 @@
+# --- API ---
+# Browser-visible. Used by Auth.js Credentials provider and client-side fetches.
+NEXT_PUBLIC_API_URL=http://localhost:8100
+
+# --- NextAuth ---
+# Must match the API's NEXTAUTH_SECRET. Generate with `openssl rand -hex 32`.
+NEXTAUTH_SECRET=replace-with-32-byte-random-hex
+NEXTAUTH_URL=http://localhost:3100
+
+# --- Stripe (publishable key only — never publish secret keys) ---
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,109 @@
 import type { NextConfig } from "next";
 
+const isProd = process.env.NODE_ENV === "production";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8100";
+
+/**
+ * Build a Content-Security-Policy header.
+ *
+ * - Dashboard CSP locks `frame-ancestors` to none and constrains scripts to
+ *   first-party + Stripe.
+ * - In dev we allow `'unsafe-eval'` and `'unsafe-inline'` so React Refresh
+ *   and Next.js HMR work; production scripts are tightly constrained.
+ * - Inline styles are required by the Geist fonts loader and Tailwind
+ *   in some cases — kept until we move to a nonce-based pipeline.
+ */
+function buildCsp(): string {
+  const apiOrigin = (() => {
+    try {
+      return new URL(apiUrl).origin;
+    } catch {
+      return "http://localhost:8100";
+    }
+  })();
+
+  const scriptSrc = isProd
+    ? ["'self'", "https://js.stripe.com", "https://checkout.stripe.com"]
+    : [
+        "'self'",
+        "'unsafe-inline'",
+        "'unsafe-eval'",
+        "https://js.stripe.com",
+        "https://checkout.stripe.com",
+      ];
+
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'", "https://checkout.stripe.com"],
+    "frame-ancestors": ["'none'"],
+    "object-src": ["'none'"],
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "data:", "https://fonts.gstatic.com"],
+    "style-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "https://fonts.googleapis.com",
+    ],
+    "script-src": scriptSrc,
+    "connect-src": [
+      "'self'",
+      apiOrigin,
+      "https://api.stripe.com",
+      "https://checkout.stripe.com",
+      ...(isProd ? [] : ["ws:", "wss:"]),
+    ],
+    "frame-src": [
+      "'self'",
+      "https://js.stripe.com",
+      "https://checkout.stripe.com",
+    ],
+    "worker-src": ["'self'", "blob:"],
+    "manifest-src": ["'self'"],
+  };
+
+  if (isProd) {
+    directives["upgrade-insecure-requests"] = [];
+  }
+
+  return Object.entries(directives)
+    .map(([key, values]) => (values.length ? `${key} ${values.join(" ")}` : key))
+    .join("; ");
+}
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: buildCsp() },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "geolocation=(), microphone=(), camera=(), payment=(self)",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-site" },
+  ...(isProd
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+      ]
+    : []),
+];
+
 const nextConfig: NextConfig = {
   output: "standalone",
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,96 @@
+# MongoRAG Security Posture
+
+This document is the operator-facing summary of the controls in place.
+Implementation lives in `apps/api/src/core/{settings,middleware,security,
+rate_limit_dep}.py` and `apps/web/{next.config.ts,middleware.ts}`.
+
+## Tenant isolation
+
+- Every MongoDB query filters by `tenant_id` (enforced at the query layer).
+- `tenant_id` is **never** trusted from the request body; it is derived
+  from a verified JWT (Auth.js) or hashed API key (`mrag_…`) lookup.
+- A `TenantGuardMiddleware` logs (does not block) any successful
+  `/api/v1/*` response that ran without a tenant context.
+
+## Input validation
+
+- All request bodies use Pydantic models with `extra="forbid"` (see
+  `StrictRequest` in `apps/api/src/models/api.py`) so unknown fields are
+  rejected — defending against mass-assignment.
+- All free-text fields have explicit `min_length` / `max_length` caps.
+- `Literal[...]` types are used for enum-like fields (`type`,
+  `search_type`) so injected values are rejected at parse time.
+- File uploads validate extension and size (per-tenant plan limit).
+
+## CORS
+
+- Origins are read from `CORS_ALLOWED_ORIGINS` (comma-separated).
+- The middleware refuses to start in production if `*` appears in the
+  list (see `_configure_middleware` in `apps/api/src/main.py`).
+- `allow_credentials=True` is used; combined with explicit origins this
+  closes the standard CORS-with-credentials bypass.
+
+## Security headers
+
+- API responses (Helmet equivalent): `X-Content-Type-Options`,
+  `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`,
+  `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`,
+  `Cache-Control: no-store`. `Strict-Transport-Security` only when
+  `APP_ENV=production`.
+- Dashboard CSP (in `apps/web/next.config.ts`):
+  - `default-src 'self'`, `frame-ancestors 'none'`, `object-src 'none'`,
+    `base-uri 'self'`, `form-action 'self' https://checkout.stripe.com`.
+  - `connect-src` includes the API origin and Stripe.
+  - Production drops `'unsafe-eval'`/`'unsafe-inline'` from `script-src`
+    and adds `upgrade-insecure-requests`.
+
+## Body-size limits
+
+- `BodySizeLimitMiddleware` (`MAX_REQUEST_BODY_BYTES`, default 1 MiB)
+  rejects oversized JSON / form bodies with HTTP 413 before any handler
+  runs.
+- Multipart upload paths (`/api/v1/documents/...`) are exempt — they
+  enforce the plan-aware `MAX_UPLOAD_SIZE_MB` limit inside the handler.
+
+## Rate limiting (#11)
+
+- `enforce_rate_limit` and `enforce_query_quota` dependencies apply
+  per-principal limits at chat, ingest, and quota-sensitive endpoints
+  using the tenant's plan (`PlanLimits.for_plan`).
+- Limits are keyed by API key hash when the caller authenticates with an
+  `mrag_…` key, otherwise by tenant id. The raw key is never logged.
+
+## SSRF hardening on Stripe redirects
+
+- `_validate_redirect_url` rejects URLs that:
+  - use a scheme other than `http`/`https`;
+  - embed user credentials (`user@host`);
+  - resolve to a private, loopback, link-local, or reserved IP literal;
+  - use plain `http` outside of `localhost`/`127.x`.
+
+## Webhook signature verification
+
+- Stripe webhooks are out of scope for this issue (see #43). The
+  setting `STRIPE_WEBHOOK_SECRET` is wired into `Settings`; the webhook
+  handler must call `stripe.Webhook.construct_event(...)` with this
+  secret before trusting the payload.
+
+## Secrets management
+
+- All secrets live in `apps/api/.env` (gitignored) and `apps/web/.env.local`
+  (gitignored). `.env*` is matched by the root `.gitignore`.
+- `.env.example` files document the full set of variables — populated
+  with placeholder values only. CI must fail any commit that introduces
+  a real secret (a static check in `tests/test_security_hardening.py`
+  guards against `sk_live_…` keys leaking into the apps tree).
+- Local Claude Code knowledge with credentials lives under
+  `.claude/secrets/` (also gitignored).
+
+## Pre-ship checklist
+
+- [ ] `git log -- apps/api/.env apps/web/.env.local apps/web/.env` is empty.
+- [ ] `pip audit` / `npm audit` show no critical vulnerabilities.
+- [ ] `CORS_ALLOWED_ORIGINS` enumerates production origins (no `*`).
+- [ ] `APP_ENV=production` is set so HSTS and strict CSP turn on.
+- [ ] Stripe keys in production env are `sk_live_…`; webhook secret is set.
+- [ ] All new request models inherit from `StrictRequest`.


### PR DESCRIPTION
## Summary

Phase-8 security hardening — issue #22.

### API (`apps/api/src/core/{middleware,settings,rate_limit_dep}.py`)
- **CORS** — explicit allow-list from `CORS_ALLOWED_ORIGINS`; refuses to start in production if `*` is configured; restricted methods/headers; credentials enabled.
- **Security headers** — Helmet-equivalent (`X-Content-Type-Options`, `X-Frame-Options DENY`, `Referrer-Policy`, `Permissions-Policy`, COOP/CORP, `Cache-Control: no-store`); HSTS only in production.
- **Body-size limit** — `MAX_REQUEST_BODY_BYTES` (1 MiB default) applied to JSON/form requests; multipart upload paths exempt (handler-side per-plan limit).
- **Per-IP rate limit** on `auth/{signup,login,forgot,reset}` — 20/min, 429 + `Retry-After`.

### Input validation (`apps/api/src/models/api.py`, `billing.py`)
- New `StrictRequest` base (`extra="forbid"`, `str_strip_whitespace=True`) applied to all request models — rejects unknown fields (mass-assignment defence), strips whitespace, caps lengths on every free-text field.
- `WSMessage.type` is a `Literal["message", "cancel"]`.

### SSRF (`apps/api/src/routers/billing.py`)
- Stripe redirect URLs reject embedded credentials and private/loopback/link-local IP literals.

### Web (`apps/web/next.config.ts`)
- Strict CSP (`default-src 'self'`, `frame-ancestors 'none'`, `object-src 'none'`, explicit allow-list for Stripe + API), plus the same Helmet baseline. `poweredByHeader: false`. Production drops `'unsafe-eval'/'unsafe-inline'` and adds `upgrade-insecure-requests`.

### Secrets management
- `apps/api/.env.example` now documents the full set (Stripe, NextAuth, Resend, CORS, body limits).
- New `apps/web/.env.example` for the dashboard.
- `docs/security.md` documents the posture and pre-ship checklist.
- Static unit test fails the build if any `sk_live_…` key sneaks into the apps/ tree.

### Tests
- 22 new unit tests in `apps/api/tests/test_security_hardening.py` covering CORS allow/block, header presence, HSTS gating, body-size limit (allow / reject / invalid CL / exempt path), IP rate-limit threshold, settings parsing, request-model strictness for every tightened model, and SSRF redirect hardening.
- Full unit suite (181 tests) green; affected router tests (auth, chat, billing, ingest, keys) green.

Closes #22

## Test plan
- [ ] CI green (`uv run pytest -m unit`, `uv run ruff check .`, `pnpm lint`, `pnpm build`)
- [ ] Manually verify dashboard CSP via browser devtools (no console violations)
- [ ] Confirm `OPTIONS` preflight from `http://localhost:3100` succeeds and from a foreign origin does not get echoed
- [ ] Confirm `curl -H 'Content-Length: 99999999' …` returns 413
- [ ] Confirm 21st `/auth/login` request from same IP within 60s returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)