### PR TITLE
feat(infra): DB backup, migrations, and disaster recovery

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,125 @@
+name: Database Backup
+
+# Scheduled and manual database backups for MongoDB and Postgres.
+#
+# Security note: this workflow only consumes `secrets.*` and a constrained
+# `inputs.target` choice. It never interpolates `github.event.*` strings
+# (issue/PR/commit author content) into shell, so command-injection vectors
+# from user-controlled input are not applicable here.
+#
+# Secrets required (configure under Repo Settings > Secrets and variables):
+#   - MONGODB_BACKUP_URI       (read-only or backup user)
+#   - POSTGRES_BACKUP_URL      (read-only role)
+# Optional (enables S3 upload):
+#   - BACKUP_S3_BUCKET
+#   - BACKUP_S3_ENDPOINT_URL   (set for non-AWS S3-compatible providers)
+#   - AWS_ACCESS_KEY_ID
+#   - AWS_SECRET_ACCESS_KEY
+#   - AWS_REGION
+#
+# When S3 secrets are absent the workflow uploads encrypted GitHub artifacts
+# only. Artifacts are retained for 14 days; long-term retention requires S3.
+
+on:
+  schedule:
+    # Daily at 03:17 UTC (off-peak, avoids hour-aligned thundering herd).
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which database(s) to back up"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - mongo
+          - postgres
+
+permissions:
+  contents: read
+
+concurrency:
+  group: db-backup-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mongo-backup:
+    if: ${{ github.event_name == 'schedule' || inputs.target == 'all' || inputs.target == 'mongo' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install MongoDB Database Tools
+        run: |
+          set -euo pipefail
+          wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc \
+            | sudo gpg --dearmor -o /usr/share/keyrings/mongodb.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/mongodb.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" \
+            | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+          sudo apt-get update -y
+          sudo apt-get install -y mongodb-database-tools
+
+      - name: Run mongo backup
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_BACKUP_URI }}
+          BACKUP_DIR: ${{ github.workspace }}/.backups/mongo
+          S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET && format('{0}/mongo', secrets.BACKUP_S3_BUCKET) || '' }}
+          S3_ENDPOINT_URL: ${{ secrets.BACKUP_S3_ENDPOINT_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          RETENTION_DAYS: "30"
+        run: |
+          if [[ -z "${MONGODB_URI}" ]]; then
+            echo "MONGODB_BACKUP_URI secret not configured; skipping." >&2
+            exit 0
+          fi
+          ./scripts/backup/mongo_backup.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mongo-backup-${{ github.run_id }}
+          path: .backups/mongo/*.archive.gz
+          retention-days: 14
+          if-no-files-found: warn
+
+  postgres-backup:
+    if: ${{ github.event_name == 'schedule' || inputs.target == 'all' || inputs.target == 'postgres' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install postgresql-client
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo apt-get install -y postgresql-client
+
+      - name: Run postgres backup
+        env:
+          DATABASE_URL: ${{ secrets.POSTGRES_BACKUP_URL }}
+          BACKUP_DIR: ${{ github.workspace }}/.backups/postgres
+          S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET && format('{0}/postgres', secrets.BACKUP_S3_BUCKET) || '' }}
+          S3_ENDPOINT_URL: ${{ secrets.BACKUP_S3_ENDPOINT_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          RETENTION_DAYS: "30"
+        run: |
+          if [[ -z "${DATABASE_URL}" ]]; then
+            echo "POSTGRES_BACKUP_URL secret not configured; skipping." >&2
+            exit 0
+          fi
+          ./scripts/backup/postgres_backup.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgres-backup-${{ github.run_id }}
+          path: .backups/postgres/*.dump
+          retention-days: 14
+          if-no-files-found: warn

--- a/apps/api/src/migrations/__init__.py
+++ b/apps/api/src/migrations/__init__.py
@@ -1,0 +1,6 @@
+"""MongoDB migration framework for MongoRAG.
+
+Lightweight, idempotent, versioned migration runner.
+Each migration is a Python module exposing async ``up(db)`` and ``down(db)``.
+Applied migrations are tracked in the ``_migrations`` collection.
+"""

--- a/apps/api/src/migrations/cli.py
+++ b/apps/api/src/migrations/cli.py
@@ -1,0 +1,109 @@
+"""CLI for the migration runner.
+
+Usage::
+
+    uv run python -m src.migrations.cli status
+    uv run python -m src.migrations.cli up
+    uv run python -m src.migrations.cli up --target 0003
+    uv run python -m src.migrations.cli down --steps 1
+
+Connects to MongoDB using ``MONGODB_URI`` from the environment. Refuses to run
+when ``MONGORAG_ALLOW_PROD=1`` is not set AND ``MONGODB_URI`` looks like a
+production cluster (basic guard — full safety is the operator's responsibility).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+from pymongo import AsyncMongoClient
+from pymongo.errors import ConnectionFailure
+
+from src.migrations import runner
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("migrations")
+
+
+def _looks_like_prod(uri: str) -> bool:
+    lowered = uri.lower()
+    return any(token in lowered for token in ("prod", "production"))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        print("MONGODB_URI is not set", file=sys.stderr)
+        return 2
+
+    if _looks_like_prod(uri) and os.environ.get("MONGORAG_ALLOW_PROD") != "1":
+        print(
+            "Refusing to run migrations against a production-looking URI. "
+            "Set MONGORAG_ALLOW_PROD=1 to override.",
+            file=sys.stderr,
+        )
+        return 3
+
+    db_name = os.environ.get("MONGODB_DATABASE", "mongorag")
+    client = AsyncMongoClient(uri, serverSelectionTimeoutMS=5000)
+    try:
+        try:
+            await client.admin.command("ping")
+        except ConnectionFailure as e:
+            print(f"MongoDB connection failed: {e}", file=sys.stderr)
+            return 4
+
+        db = client[db_name]
+        if args.command == "status":
+            rows = await runner.status(db)
+            for row in rows:
+                marker = "x" if row["applied"] else " "
+                print(f"[{marker}] {row['version']}  {row['name']}")
+            pending = [r for r in rows if not r["applied"]]
+            print(f"\n{len(rows)} known, {len(pending)} pending")
+            return 0
+
+        if args.command == "up":
+            applied = await runner.up(db, target=args.target)
+            if not applied:
+                print("No pending migrations.")
+            else:
+                print(f"Applied: {', '.join(applied)}")
+            return 0
+
+        if args.command == "down":
+            reverted = await runner.down(db, steps=args.steps)
+            if not reverted:
+                print("Nothing to revert.")
+            else:
+                print(f"Reverted: {', '.join(reverted)}")
+            return 0
+
+        print(f"Unknown command: {args.command}", file=sys.stderr)
+        return 1
+    finally:
+        await client.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="src.migrations.cli")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Show applied/pending migrations")
+
+    up_p = sub.add_parser("up", help="Apply pending migrations")
+    up_p.add_argument("--target", help="Apply up to and including this version")
+
+    down_p = sub.add_parser("down", help="Revert the last N migrations")
+    down_p.add_argument("--steps", type=int, default=1, help="Number of migrations to revert")
+
+    args = parser.parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/src/migrations/runner.py
+++ b/apps/api/src/migrations/runner.py
@@ -1,0 +1,144 @@
+"""Migration runner.
+
+Discovers ``NNNN_<name>.py`` migration modules in ``apps/api/src/migrations/versions``,
+applies pending ones in order, records them in ``_migrations``, and supports a
+single-step ``down``.
+
+Each version module must define::
+
+    VERSION: str = "0001"  # zero-padded, sortable
+    NAME: str = "baseline"
+
+    async def up(db) -> None: ...
+    async def down(db) -> None: ...
+
+The runner is idempotent: re-running ``up`` after a successful apply is a no-op.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Protocol
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+logger = logging.getLogger(__name__)
+
+MIGRATIONS_COLLECTION = "_migrations"
+_VERSION_RE = re.compile(r"^(\d{4,})_([a-z0-9_]+)$")
+
+
+class MigrationModule(Protocol):
+    VERSION: str
+    NAME: str
+
+    async def up(self, db: AsyncDatabase) -> None: ...
+    async def down(self, db: AsyncDatabase) -> None: ...
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: str
+    name: str
+    up: Callable[[AsyncDatabase], Awaitable[None]]
+    down: Callable[[AsyncDatabase], Awaitable[None]]
+
+    @property
+    def id(self) -> str:
+        return f"{self.version}_{self.name}"
+
+
+def discover_migrations(package: str = "src.migrations.versions") -> list[Migration]:
+    """Import all migration modules in ``package`` and return them sorted by version."""
+    try:
+        pkg = importlib.import_module(package)
+    except ModuleNotFoundError:
+        return []
+
+    migrations: list[Migration] = []
+    for mod_info in pkgutil.iter_modules(pkg.__path__):
+        if mod_info.ispkg or not _VERSION_RE.match(mod_info.name):
+            continue
+        module = importlib.import_module(f"{package}.{mod_info.name}")
+        version = getattr(module, "VERSION", None)
+        name = getattr(module, "NAME", None)
+        up = getattr(module, "up", None)
+        down = getattr(module, "down", None)
+        if not (version and name and up and down):
+            raise RuntimeError(f"Migration {mod_info.name} missing VERSION/NAME/up/down")
+        migrations.append(Migration(version=version, name=name, up=up, down=down))
+
+    migrations.sort(key=lambda m: m.version)
+    versions = [m.version for m in migrations]
+    if len(set(versions)) != len(versions):
+        raise RuntimeError(f"Duplicate migration versions: {versions}")
+    return migrations
+
+
+async def applied_versions(db: AsyncDatabase) -> set[str]:
+    cursor = db[MIGRATIONS_COLLECTION].find({}, {"version": 1, "_id": 0})
+    return {doc["version"] async for doc in cursor}
+
+
+async def status(db: AsyncDatabase) -> list[dict]:
+    """Return ordered status report for each known migration."""
+    migrations = discover_migrations()
+    applied = await applied_versions(db)
+    return [
+        {
+            "version": m.version,
+            "name": m.name,
+            "applied": m.version in applied,
+        }
+        for m in migrations
+    ]
+
+
+async def up(db: AsyncDatabase, target: str | None = None) -> list[str]:
+    """Apply pending migrations up to and including ``target`` (or all)."""
+    migrations = discover_migrations()
+    applied = await applied_versions(db)
+    applied_now: list[str] = []
+    for m in migrations:
+        if m.version in applied:
+            continue
+        if target is not None and m.version > target:
+            break
+        logger.info("migration_apply_start version=%s name=%s", m.version, m.name)
+        await m.up(db)
+        await db[MIGRATIONS_COLLECTION].insert_one(
+            {
+                "version": m.version,
+                "name": m.name,
+                "applied_at": datetime.now(timezone.utc),
+            }
+        )
+        applied_now.append(m.id)
+        logger.info("migration_apply_done version=%s", m.version)
+    return applied_now
+
+
+async def down(db: AsyncDatabase, steps: int = 1) -> list[str]:
+    """Revert the last ``steps`` applied migrations in reverse order."""
+    if steps < 1:
+        raise ValueError("steps must be >= 1")
+    migrations = {m.version: m for m in discover_migrations()}
+    cursor = db[MIGRATIONS_COLLECTION].find({}, {"version": 1, "_id": 0}).sort("version", -1)
+    history = [doc async for doc in cursor]
+    reverted: list[str] = []
+    for doc in history[:steps]:
+        version = doc["version"]
+        m = migrations.get(version)
+        if m is None:
+            raise RuntimeError(f"Cannot revert {version}: module not found")
+        logger.info("migration_revert_start version=%s", version)
+        await m.down(db)
+        await db[MIGRATIONS_COLLECTION].delete_one({"version": version})
+        reverted.append(m.id)
+        logger.info("migration_revert_done version=%s", version)
+    return reverted

--- a/apps/api/src/migrations/versions/0001_baseline_indexes.py
+++ b/apps/api/src/migrations/versions/0001_baseline_indexes.py
@@ -1,0 +1,65 @@
+"""0001 baseline — assert all standard indexes exist.
+
+This migration is idempotent. It calls ``pymongo.create_index`` for every
+collection used by MongoRAG. Atlas Vector Search and Atlas Search indexes
+are NOT created here — those must be managed via the Atlas UI or Atlas CLI.
+
+Down-migration drops only the indexes this migration created (by name).
+"""
+
+from __future__ import annotations
+
+from pymongo import ASCENDING as ASC
+from pymongo import DESCENDING as DESC
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import OperationFailure
+
+VERSION = "0001"
+NAME = "baseline_indexes"
+
+# (collection, keys, options, name)
+_INDEX_SPECS: list[tuple[str, list[tuple[str, int]], dict, str]] = [
+    ("chunks", [("tenant_id", ASC), ("document_id", ASC)], {}, "chunks_tenant_doc"),
+    (
+        "chunks",
+        [("tenant_id", ASC), ("chunk_id", ASC)],
+        {"unique": True},
+        "chunks_tenant_chunkid_uq",
+    ),
+    ("chunks", [("tenant_id", ASC), ("created_at", DESC)], {}, "chunks_tenant_created"),
+    ("chunks", [("chunk_id", ASC)], {}, "chunks_chunkid"),
+    ("documents", [("tenant_id", ASC), ("source", ASC)], {}, "documents_tenant_source"),
+    ("documents", [("tenant_id", ASC), ("content_hash", ASC)], {}, "documents_tenant_hash"),
+    ("documents", [("tenant_id", ASC), ("created_at", DESC)], {}, "documents_tenant_created"),
+    ("tenants", [("tenant_id", ASC)], {"unique": True}, "tenants_tenantid_uq"),
+    ("tenants", [("slug", ASC)], {"unique": True}, "tenants_slug_uq"),
+    ("users", [("email", ASC)], {"unique": True}, "users_email_uq"),
+    ("users", [("tenant_id", ASC)], {}, "users_tenant"),
+    ("api_keys", [("key_hash", ASC)], {"unique": True}, "api_keys_hash_uq"),
+    ("api_keys", [("tenant_id", ASC)], {}, "api_keys_tenant"),
+    ("conversations", [("tenant_id", ASC), ("session_id", ASC)], {}, "conv_tenant_session"),
+    ("conversations", [("tenant_id", ASC), ("created_at", DESC)], {}, "conv_tenant_created"),
+    ("subscriptions", [("tenant_id", ASC)], {"unique": True}, "subs_tenant_uq"),
+    ("subscriptions", [("stripe_customer_id", ASC)], {}, "subs_stripe_customer"),
+]
+
+
+async def up(db: AsyncDatabase) -> None:
+    for coll, keys, opts, name in _INDEX_SPECS:
+        try:
+            await db[coll].create_index(keys, name=name, **opts)
+        except OperationFailure as e:
+            # 85/86 = options/spec conflict — index exists with different opts.
+            # Treat as already-applied for idempotency; let humans resolve.
+            if e.code not in (85, 86):
+                raise
+
+
+async def down(db: AsyncDatabase) -> None:
+    for coll, _keys, _opts, name in _INDEX_SPECS:
+        try:
+            await db[coll].drop_index(name)
+        except OperationFailure as e:
+            # 27 = IndexNotFound — already gone, fine.
+            if e.code != 27:
+                raise

--- a/apps/api/src/migrations/versions/__init__.py
+++ b/apps/api/src/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned migration modules. Filenames must match ``NNNN_<name>.py``."""

--- a/apps/api/tests/test_backup_scripts.py
+++ b/apps/api/tests/test_backup_scripts.py
@@ -1,0 +1,128 @@
+"""Smoke tests for the backup and restore shell scripts.
+
+These tests use ``--dry-run`` so they never invoke ``mongodump`` /
+``pg_dump`` / ``aws`` and are safe to run in any environment. They verify:
+
+- the scripts refuse to run with missing required env vars,
+- ``--dry-run`` prints the expected plan and exits 0,
+- restore scripts refuse to target non-staging URIs without ``--force``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO_ROOT / "scripts" / "backup"
+
+pytestmark = pytest.mark.skipif(not shutil.which("bash"), reason="bash unavailable")
+
+
+def _run(
+    script: str,
+    env: dict | None = None,
+    args: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    full_env = {**os.environ, **(env or {})}
+    return subprocess.run(
+        ["bash", str(SCRIPTS / script), *(args or [])],
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_mongo_backup_requires_uri():
+    env = {k: v for k, v in os.environ.items() if k != "MONGODB_URI"}
+    res = subprocess.run(
+        ["bash", str(SCRIPTS / "mongo_backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert res.returncode != 0
+    assert "MONGODB_URI" in (res.stderr + res.stdout)
+
+
+def test_mongo_backup_dry_run(tmp_path):
+    res = _run(
+        "mongo_backup.sh",
+        env={"MONGODB_URI": "mongodb://localhost/test", "BACKUP_DIR": str(tmp_path)},
+        args=["--dry-run"],
+    )
+    assert res.returncode == 0, res.stderr
+    assert "dry-run" in res.stdout
+    # No actual archive should have been written.
+    assert not list(tmp_path.glob("*.archive.gz"))
+
+
+def test_postgres_backup_requires_url():
+    env = {k: v for k, v in os.environ.items() if k != "DATABASE_URL"}
+    res = subprocess.run(
+        ["bash", str(SCRIPTS / "postgres_backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert res.returncode != 0
+    assert "DATABASE_URL" in (res.stderr + res.stdout)
+
+
+def test_postgres_backup_dry_run(tmp_path):
+    res = _run(
+        "postgres_backup.sh",
+        env={"DATABASE_URL": "postgresql://localhost/test", "BACKUP_DIR": str(tmp_path)},
+        args=["--dry-run"],
+    )
+    assert res.returncode == 0, res.stderr
+    assert "dry-run" in res.stdout
+
+
+def test_mongo_restore_refuses_non_staging_without_force(tmp_path):
+    archive = tmp_path / "fake.archive.gz"
+    archive.write_bytes(b"x")
+    res = _run(
+        "mongo_restore.sh",
+        env={
+            "MONGODB_URI": "mongodb://prod-cluster.example/app",
+            "ARCHIVE_PATH": str(archive),
+        },
+    )
+    assert res.returncode == 3
+    assert "Refusing" in res.stderr or "Refusing" in res.stdout
+
+
+def test_mongo_restore_allows_staging_dry_run(tmp_path):
+    archive = tmp_path / "fake.archive.gz"
+    archive.write_bytes(b"x")
+    res = _run(
+        "mongo_restore.sh",
+        env={
+            "MONGODB_URI": "mongodb://staging-cluster.example/app",
+            "ARCHIVE_PATH": str(archive),
+        },
+        args=["--dry-run"],
+    )
+    assert res.returncode == 0, res.stderr
+    assert "dry-run" in res.stdout
+
+
+def test_postgres_restore_refuses_non_staging_without_force(tmp_path):
+    archive = tmp_path / "fake.dump"
+    archive.write_bytes(b"x")
+    res = _run(
+        "postgres_restore.sh",
+        env={
+            "DATABASE_URL": "postgresql://prod-host.example/app",
+            "ARCHIVE_PATH": str(archive),
+        },
+    )
+    assert res.returncode == 3

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -1,0 +1,244 @@
+"""Unit tests for the MongoDB migration runner.
+
+Uses an in-memory ``mongomock_motor``-style fake. We avoid extra deps by
+implementing a tiny async stand-in that supports just the surface the
+runner uses: ``find``, ``insert_one``, ``delete_one``, ``sort``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from src.migrations import runner
+
+# ---------- minimal async-compatible mongo fake ----------
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict]):
+        self._docs = list(docs)
+
+    def sort(self, key: str, direction: int = 1) -> "_FakeCursor":
+        self._docs.sort(key=lambda d: d.get(key), reverse=direction == -1)
+        return self
+
+    def __aiter__(self):
+        self._idx = 0
+        return self
+
+    async def __anext__(self):
+        if self._idx >= len(self._docs):
+            raise StopAsyncIteration
+        doc = self._docs[self._idx]
+        self._idx += 1
+        return doc
+
+
+@dataclass
+class _FakeCollection:
+    name: str
+    docs: list[dict] = field(default_factory=list)
+    indexes: list[tuple] = field(default_factory=list)
+
+    def find(self, query: dict | None = None, projection: dict | None = None) -> _FakeCursor:
+        # We ignore projection since runner only reads "version".
+        return _FakeCursor(list(self.docs))
+
+    async def insert_one(self, doc: dict) -> Any:
+        self.docs.append(dict(doc))
+
+    async def delete_one(self, query: dict) -> Any:
+        for i, d in enumerate(self.docs):
+            if all(d.get(k) == v for k, v in query.items()):
+                self.docs.pop(i)
+                return
+        return None
+
+    async def create_index(self, keys, name: str | None = None, **opts) -> str:
+        self.indexes.append((tuple(keys), name, opts))
+        return name or "idx"
+
+    async def drop_index(self, name: str) -> None:
+        self.indexes = [i for i in self.indexes if i[1] != name]
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeCollection] = {}
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        if name not in self._collections:
+            self._collections[name] = _FakeCollection(name=name)
+        return self._collections[name]
+
+
+# ---------- helpers ----------
+
+
+def _install_fake_versions(monkeypatch, modules: dict[str, dict]):
+    """Inject fake migration modules under apps.api.migrations.versions."""
+    pkg_name = "src.migrations.versions_test"
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = []  # mark as package; pkgutil.iter_modules returns []
+    sys.modules[pkg_name] = pkg
+
+    # We bypass discovery by monkeypatching discover_migrations directly.
+    migrations: list[runner.Migration] = []
+    for filename, body in modules.items():
+        m = runner.Migration(
+            version=body["VERSION"],
+            name=body["NAME"],
+            up=body["up"],
+            down=body["down"],
+        )
+        migrations.append(m)
+    migrations.sort(key=lambda m: m.version)
+    monkeypatch.setattr(
+        runner,
+        "discover_migrations",
+        lambda package="src.migrations.versions": migrations,
+    )
+
+
+# ---------- tests ----------
+
+
+@pytest.mark.asyncio
+async def test_up_applies_in_order_and_records(monkeypatch):
+    applied_calls: list[str] = []
+
+    async def up_a(db):
+        applied_calls.append("a")
+
+    async def down_a(db):
+        applied_calls.append("-a")
+
+    async def up_b(db):
+        applied_calls.append("b")
+
+    async def down_b(db):
+        applied_calls.append("-b")
+
+    _install_fake_versions(
+        monkeypatch,
+        {
+            "0001_a": {"VERSION": "0001", "NAME": "a", "up": up_a, "down": down_a},
+            "0002_b": {"VERSION": "0002", "NAME": "b", "up": up_b, "down": down_b},
+        },
+    )
+
+    db = _FakeDB()
+    applied = await runner.up(db)
+
+    assert applied == ["0001_a", "0002_b"]
+    assert applied_calls == ["a", "b"]
+    versions = {d["version"] for d in db[runner.MIGRATIONS_COLLECTION].docs}
+    assert versions == {"0001", "0002"}
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(monkeypatch):
+    counter = {"a": 0}
+
+    async def up_a(db):
+        counter["a"] += 1
+
+    async def down_a(db):
+        pass
+
+    _install_fake_versions(
+        monkeypatch,
+        {"0001_a": {"VERSION": "0001", "NAME": "a", "up": up_a, "down": down_a}},
+    )
+
+    db = _FakeDB()
+    await runner.up(db)
+    await runner.up(db)
+    await runner.up(db)
+    assert counter["a"] == 1
+
+
+@pytest.mark.asyncio
+async def test_up_target_stops(monkeypatch):
+    async def noop(db):
+        pass
+
+    _install_fake_versions(
+        monkeypatch,
+        {
+            "0001_a": {"VERSION": "0001", "NAME": "a", "up": noop, "down": noop},
+            "0002_b": {"VERSION": "0002", "NAME": "b", "up": noop, "down": noop},
+            "0003_c": {"VERSION": "0003", "NAME": "c", "up": noop, "down": noop},
+        },
+    )
+
+    db = _FakeDB()
+    applied = await runner.up(db, target="0002")
+    assert applied == ["0001_a", "0002_b"]
+    assert {d["version"] for d in db[runner.MIGRATIONS_COLLECTION].docs} == {"0001", "0002"}
+
+
+@pytest.mark.asyncio
+async def test_down_reverts_last(monkeypatch):
+    log: list[str] = []
+
+    async def up_a(db):
+        log.append("up-a")
+
+    async def down_a(db):
+        log.append("down-a")
+
+    async def up_b(db):
+        log.append("up-b")
+
+    async def down_b(db):
+        log.append("down-b")
+
+    _install_fake_versions(
+        monkeypatch,
+        {
+            "0001_a": {"VERSION": "0001", "NAME": "a", "up": up_a, "down": down_a},
+            "0002_b": {"VERSION": "0002", "NAME": "b", "up": up_b, "down": down_b},
+        },
+    )
+
+    db = _FakeDB()
+    await runner.up(db)
+    reverted = await runner.down(db, steps=1)
+    assert reverted == ["0002_b"]
+    assert log[-1] == "down-b"
+    assert {d["version"] for d in db[runner.MIGRATIONS_COLLECTION].docs} == {"0001"}
+
+
+@pytest.mark.asyncio
+async def test_status_reports_pending(monkeypatch):
+    async def noop(db):
+        pass
+
+    _install_fake_versions(
+        monkeypatch,
+        {
+            "0001_a": {"VERSION": "0001", "NAME": "a", "up": noop, "down": noop},
+            "0002_b": {"VERSION": "0002", "NAME": "b", "up": noop, "down": noop},
+        },
+    )
+    db = _FakeDB()
+    await runner.up(db, target="0001")
+
+    rows = await runner.status(db)
+    assert rows == [
+        {"version": "0001", "name": "a", "applied": True},
+        {"version": "0002", "name": "b", "applied": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_down_steps_must_be_positive():
+    db = _FakeDB()
+    with pytest.raises(ValueError):
+        await runner.down(db, steps=0)

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,194 @@
+# Disaster Recovery Plan
+
+This runbook covers backup, restore, and incident-response procedures for the
+MongoRAG production stack: **MongoDB Atlas** (RAG data plane: documents,
+chunks, conversations, usage) and **Supabase Postgres** (control plane:
+tenancy, identity, billing).
+
+## 1. Objectives
+
+| Tier | RPO (data loss) | RTO (time to recover) | Notes |
+|------|-----------------|----------------------|-------|
+| Customer documents / chunks (MongoDB) | <= 60 min | <= 4 h | Atlas continuous backup; PITR enabled |
+| Tenancy / identity / billing (Postgres) | <= 60 min | <= 2 h | Supabase managed daily + WAL |
+| Conversation history (MongoDB)         | <= 24 h  | <= 8 h | Lower tier; can be replayed |
+| Object storage (uploads)               | <= 24 h  | <= 8 h | Versioned bucket |
+
+RPO is the *maximum* acceptable data loss measured from the last successful
+backup. RTO is the *maximum* acceptable time from incident declaration to
+restored service.
+
+## 2. Backup Architecture
+
+### 2.1 MongoDB Atlas
+
+- **Continuous Cloud Backup** enabled on the production cluster (M10+).
+- **Point-in-time restore** window: 7 days.
+- **Snapshot retention**: hourly for 24 h, daily for 7 d, weekly for 4 w,
+  monthly for 12 m. Configure under *Atlas > Backup > Policy*.
+- **Off-platform copy**: nightly `scripts/backup/mongo_backup.sh` runs from
+  GitHub Actions (`.github/workflows/backup.yml`) and writes an encrypted
+  `mongodump` archive to S3 (when `BACKUP_S3_BUCKET` is set) plus a 14-day
+  GitHub Actions artifact.
+- **Vector / Atlas Search indexes** are NOT included in `mongodump`. Index
+  definitions live in `apps/api/scripts/setup_indexes.py` and are recreated
+  via that script after restore. Vector index definitions must be applied
+  via the Atlas UI / Atlas CLI.
+
+### 2.2 Supabase Postgres
+
+- **Supabase managed daily backups**: 7-day retention on Pro plan, 14-day on
+  Team. Configure under *Project > Database > Backups*.
+- **Off-platform copy**: nightly `scripts/backup/postgres_backup.sh` runs
+  from GitHub Actions and writes a `pg_dump --format=custom` archive.
+- **Migrations**: Postgres schema lives under `supabase/migrations/`.
+  Applied with `supabase db push` from CI.
+
+### 2.3 Backup integrity
+
+- Each backup script verifies the archive is non-empty before exit and
+  applies a local retention policy (`RETENTION_DAYS`, default 30 days).
+- Quarterly: download the most recent backup and run a full restore drill
+  into the staging cluster (see Section 4.3). Track outcome in
+  `docs/runbooks/restore-drills.md` (create on first run).
+
+## 3. Migration Strategy
+
+### 3.1 MongoDB
+
+- Versioned migrations under `apps/api/src/migrations/versions/NNNN_<name>.py`.
+- Runner: `apps/api/src/migrations/runner.py`. CLI:
+
+  ```bash
+  uv run python -m src.migrations.cli status
+  uv run python -m src.migrations.cli up
+  uv run python -m src.migrations.cli up --target 0003
+  uv run python -m src.migrations.cli down --steps 1
+  ```
+
+- Tracking collection: `_migrations` (one document per applied version).
+- Each migration must be **idempotent** (re-running `up` is a no-op) and
+  must include a working `down`.
+- Vector / Atlas Search indexes are NOT created by migrations — those must
+  be applied via the Atlas UI or Atlas CLI per `apps/api/scripts/setup_indexes.py`.
+- The CLI refuses to run against a URI that contains `prod` / `production`
+  unless `MONGORAG_ALLOW_PROD=1` is exported. Production migrations run
+  from CI inside the deployment job, after the backup has succeeded.
+
+### 3.2 Postgres
+
+- Migrations live under `supabase/migrations/` and run via the Supabase
+  CLI in CI: `supabase db push --linked --include-all`.
+- Never edit a previously applied migration. Always add a new file.
+
+## 4. Recovery Procedures
+
+For every scenario: **declare the incident first**, set up an incident
+channel, and assign an Incident Commander before touching production.
+
+### 4.1 Database corruption (MongoDB)
+
+1. Pause writes by scaling the API to zero or enabling maintenance mode.
+2. Identify the last good point-in-time from Atlas monitoring + app logs.
+3. *Atlas > Backup > Restore* — select PITR, enter timestamp, restore into
+   a NEW cluster (`mongorag-restore-YYYYMMDD`).
+4. Validate the restore in the new cluster: row counts, recent docs,
+   tenant counts. Cross-check `tenants` collection size against expected.
+5. Update `MONGODB_URI` in production secrets to point at the restored
+   cluster (or use Atlas live migration). Rotate the original cluster
+   credentials before bringing the API back up.
+6. Re-run `apps/api/scripts/setup_indexes.py` and recreate Atlas Vector /
+   Search indexes from saved definitions (see `setup_indexes.py` footer).
+7. Resume traffic. Post-incident review within 5 business days.
+
+### 4.2 Accidental data deletion
+
+Two scenarios depending on scope:
+
+- **Single tenant, recent**: use Atlas PITR to restore into a scratch
+  cluster, then export only that tenant's data
+  (`mongoexport --query='{"tenant_id":"<id>"}'`) and re-import. **Never**
+  `--drop` collections during restore — that wipes other tenants. Verify
+  `tenant_id` filtering on every export and import command.
+- **Cross-tenant or schema-wide**: full PITR per Section 4.1.
+
+### 4.3 Service outage (control plane / Supabase)
+
+1. Confirm outage via Supabase status page.
+2. If outage > RTO, fail over: spin up a replacement Postgres (Supabase
+   project clone, or temporary RDS) and `pg_restore` from latest archive.
+3. Update `DATABASE_URL` in production secrets. Run `supabase db push`
+   to verify schema.
+4. Resume traffic.
+
+### 4.4 Compromised API keys / leaked credentials
+
+1. **Within 15 minutes**: rotate the affected secret(s) in Vercel + Atlas
+   + Supabase. Old keys revoked immediately.
+2. Audit: search Atlas + Supabase logs for the key's request signature,
+   compute blast radius, list affected tenants.
+3. If customer API keys are involved (`api_keys` collection): force-rotate
+   per-tenant keys, notify affected tenants within 24 h.
+4. If a backup credential was leaked: rotate `MONGODB_BACKUP_URI`,
+   `POSTGRES_BACKUP_URL`, and any S3 IAM keys. Verify backup workflow
+   still succeeds on the next manual run.
+5. File a SEC-* incident issue with timeline, scope, and remediation.
+
+## 5. Restore Drill (quarterly)
+
+1. Trigger `Database Backup` workflow manually with `target=all`.
+2. Download the latest artifact (or pull from S3).
+3. Provision a STAGING-tagged cluster:
+   - Mongo: `mongorag-restore-YYYYMMDD`
+   - Postgres: `mongorag-restore-YYYYMMDD` Supabase project
+4. Run:
+
+   ```bash
+   MONGODB_URI=<staging-restore-uri> ARCHIVE_PATH=./mongo-...archive.gz \
+     ./scripts/backup/mongo_restore.sh
+
+   DATABASE_URL=<staging-restore-url> ARCHIVE_PATH=./postgres-...dump \
+     ./scripts/backup/postgres_restore.sh
+   ```
+
+5. Validate: tenant counts match production, sample queries return
+   expected rows, indexes present, sample auth flow succeeds.
+6. Tear down restore cluster. Record drill outcome (date, duration,
+   issues, fixes) in `docs/runbooks/restore-drills.md`.
+
+## 6. Incident Response Checklist
+
+- [ ] Incident declared in #incidents (or chosen channel)
+- [ ] Incident Commander assigned
+- [ ] Status page updated
+- [ ] Severity classified (SEV-1/2/3)
+- [ ] Recovery procedure (Section 4) selected and started
+- [ ] Backups verified before any destructive recovery action
+- [ ] All recovery actions logged in incident channel
+- [ ] Resolution announced; status page updated
+- [ ] Post-incident review scheduled within 5 business days
+- [ ] PIR doc created with: timeline, root cause, contributing factors,
+      what went well, what went wrong, action items with owners + dates
+
+## 7. Escalation Chain (Template)
+
+Replace placeholders before going to production. Keep this section
+synchronized with the on-call rota.
+
+1. **Primary on-call engineer** — first responder, owns triage
+2. **Secondary on-call engineer** — backup, takes over if primary
+   unavailable within 15 minutes
+3. **Engineering lead** — escalation point for SEV-1
+4. **CTO / founder** — customer-impacting SEV-1 > 1 hour
+5. **Atlas / Supabase support** — open a P1 ticket for SEV-1 platform
+   issues; include cluster ID and incident timeline
+
+## 8. Post-Incident Review Checklist
+
+- [ ] Timeline reconstructed (UTC) from logs and chat
+- [ ] Root cause identified (5 Whys minimum)
+- [ ] Customer impact quantified (tenants affected, data lost, downtime)
+- [ ] Was RPO met? Was RTO met?
+- [ ] Action items: each has an owner and a due date
+- [ ] Runbook updated with anything missing or wrong
+- [ ] Tests added that would have caught the failure mode

--- a/scripts/backup/mongo_backup.sh
+++ b/scripts/backup/mongo_backup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# MongoDB backup script.
+#
+# Dumps a MongoDB database with mongodump, gzips the archive, optionally
+# uploads to an S3-compatible bucket via the AWS CLI, and applies a local
+# retention policy.
+#
+# Usage:
+#   MONGODB_URI="mongodb+srv://..." \
+#   BACKUP_DIR="./.backups/mongo" \
+#   [S3_BUCKET="s3://my-bucket/mongo-rag/mongo"] \
+#   [S3_ENDPOINT_URL="https://..."] \
+#   [RETENTION_DAYS=30] \
+#   ./scripts/backup/mongo_backup.sh [--dry-run]
+#
+# Safety:
+#   - Refuses to run if MONGODB_URI is unset.
+#   - --dry-run prints the plan and exits without invoking mongodump or aws.
+#   - No destructive operations are ever performed against the source DB.
+#   - The script never echoes the URI to stdout/stderr.
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 64
+      ;;
+  esac
+done
+
+: "${MONGODB_URI:?MONGODB_URI must be set}"
+BACKUP_DIR="${BACKUP_DIR:-./.backups/mongo}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ARCHIVE="${BACKUP_DIR}/mongo-${TIMESTAMP}.archive.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[mongo-backup] target=${ARCHIVE} retention_days=${RETENTION_DAYS} dry_run=${DRY_RUN}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[mongo-backup] dry-run: would invoke mongodump --archive --gzip"
+  if [[ -n "${S3_BUCKET:-}" ]]; then
+    echo "[mongo-backup] dry-run: would upload to ${S3_BUCKET}/$(basename "$ARCHIVE")"
+  fi
+  echo "[mongo-backup] dry-run: would prune files older than ${RETENTION_DAYS}d in ${BACKUP_DIR}"
+  exit 0
+fi
+
+if ! command -v mongodump >/dev/null 2>&1; then
+  echo "mongodump is not installed (install MongoDB Database Tools)" >&2
+  exit 127
+fi
+
+# mongodump reads the URI from --uri; we never print it.
+mongodump --uri="$MONGODB_URI" --archive="$ARCHIVE" --gzip --quiet
+
+if [[ ! -s "$ARCHIVE" ]]; then
+  echo "[mongo-backup] archive is empty or missing: $ARCHIVE" >&2
+  exit 1
+fi
+
+echo "[mongo-backup] wrote $(du -h "$ARCHIVE" | cut -f1) to ${ARCHIVE}"
+
+if [[ -n "${S3_BUCKET:-}" ]]; then
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "[mongo-backup] aws CLI not installed; skipping upload" >&2
+  else
+    AWS_ARGS=()
+    if [[ -n "${S3_ENDPOINT_URL:-}" ]]; then
+      AWS_ARGS+=("--endpoint-url" "$S3_ENDPOINT_URL")
+    fi
+    aws "${AWS_ARGS[@]}" s3 cp \
+      --only-show-errors \
+      --sse AES256 \
+      "$ARCHIVE" "${S3_BUCKET%/}/$(basename "$ARCHIVE")"
+    echo "[mongo-backup] uploaded to ${S3_BUCKET%/}/$(basename "$ARCHIVE")"
+  fi
+fi
+
+# Local retention. Note: this prunes local files only; off-platform copies
+# (S3 / GitHub Actions artifacts) have their own retention and are the
+# authoritative long-term store. If the upload step failed earlier we will
+# have already exited non-zero, so we never prune locally without a remote.
+find "$BACKUP_DIR" -type f -name 'mongo-*.archive.gz' -mtime "+${RETENTION_DAYS}" -print -delete \
+  || true

--- a/scripts/backup/mongo_restore.sh
+++ b/scripts/backup/mongo_restore.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# MongoDB restore script.
+#
+# Restores a mongodump archive into a target database.
+#
+# Usage:
+#   MONGODB_URI="mongodb+srv://..." \
+#   ARCHIVE_PATH="./.backups/mongo/mongo-20260101T000000Z.archive.gz" \
+#   ./scripts/backup/mongo_restore.sh [--dry-run] [--force]
+#
+# Safety:
+#   - REFUSES to run without --force AND a target URI containing "restore",
+#     "staging", or "test" in the host. This prevents accidental restore
+#     into production.
+#   - --dry-run prints the plan and exits.
+#   - No --drop is used by default; pass RESTORE_DROP=1 if you need a wipe.
+#   - Tenant isolation is preserved because mongodump captures full collection
+#     state including tenant_id; never partially restore individual collections
+#     across tenants without a per-tenant export.
+set -euo pipefail
+
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --force)   FORCE=1 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 64 ;;
+  esac
+done
+
+: "${MONGODB_URI:?MONGODB_URI must be set}"
+: "${ARCHIVE_PATH:?ARCHIVE_PATH must be set}"
+
+if [[ ! -s "$ARCHIVE_PATH" ]]; then
+  echo "Archive not found or empty: $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+URI_LOWER=$(echo "$MONGODB_URI" | tr '[:upper:]' '[:lower:]')
+if [[ "$FORCE" -ne 1 ]]; then
+  if [[ "$URI_LOWER" != *"restore"* && "$URI_LOWER" != *"staging"* && "$URI_LOWER" != *"test"* ]]; then
+    echo "Refusing to restore into a non-staging/test/restore URI without --force." >&2
+    exit 3
+  fi
+fi
+
+echo "[mongo-restore] archive=${ARCHIVE_PATH} dry_run=${DRY_RUN} force=${FORCE}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[mongo-restore] dry-run: would invoke mongorestore --archive --gzip"
+  exit 0
+fi
+
+if ! command -v mongorestore >/dev/null 2>&1; then
+  echo "mongorestore is not installed" >&2
+  exit 127
+fi
+
+DROP_ARGS=()
+if [[ "${RESTORE_DROP:-0}" -eq 1 ]]; then
+  DROP_ARGS+=("--drop")
+fi
+
+mongorestore --uri="$MONGODB_URI" --archive="$ARCHIVE_PATH" --gzip "${DROP_ARGS[@]}"
+
+echo "[mongo-restore] complete"

--- a/scripts/backup/postgres_backup.sh
+++ b/scripts/backup/postgres_backup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Postgres (Supabase) backup script using pg_dump in custom format.
+#
+# Usage:
+#   DATABASE_URL="postgresql://..." \
+#   BACKUP_DIR="./.backups/postgres" \
+#   [S3_BUCKET="s3://my-bucket/mongo-rag/postgres"] \
+#   [S3_ENDPOINT_URL="https://..."] \
+#   [RETENTION_DAYS=30] \
+#   ./scripts/backup/postgres_backup.sh [--dry-run]
+#
+# Notes:
+#   - Uses pg_dump --format=custom (.dump) which is restorable with pg_restore.
+#   - Supabase also runs its own managed daily backups; this script is for
+#     additional self-controlled backups (long retention, off-platform).
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 64
+      ;;
+  esac
+done
+
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+BACKUP_DIR="${BACKUP_DIR:-./.backups/postgres}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ARCHIVE="${BACKUP_DIR}/postgres-${TIMESTAMP}.dump"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[pg-backup] target=${ARCHIVE} retention_days=${RETENTION_DAYS} dry_run=${DRY_RUN}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[pg-backup] dry-run: would invoke pg_dump --format=custom"
+  if [[ -n "${S3_BUCKET:-}" ]]; then
+    echo "[pg-backup] dry-run: would upload to ${S3_BUCKET}/$(basename "$ARCHIVE")"
+  fi
+  echo "[pg-backup] dry-run: would prune files older than ${RETENTION_DAYS}d in ${BACKUP_DIR}"
+  exit 0
+fi
+
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "pg_dump is not installed (install postgresql-client)" >&2
+  exit 127
+fi
+
+# pg_dump reads URL from positional arg; we never echo it.
+pg_dump --format=custom --no-owner --no-acl --quote-all-identifiers \
+  --file="$ARCHIVE" "$DATABASE_URL"
+
+if [[ ! -s "$ARCHIVE" ]]; then
+  echo "[pg-backup] dump is empty or missing: $ARCHIVE" >&2
+  exit 1
+fi
+
+echo "[pg-backup] wrote $(du -h "$ARCHIVE" | cut -f1) to ${ARCHIVE}"
+
+if [[ -n "${S3_BUCKET:-}" ]]; then
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "[pg-backup] aws CLI not installed; skipping upload" >&2
+  else
+    AWS_ARGS=()
+    if [[ -n "${S3_ENDPOINT_URL:-}" ]]; then
+      AWS_ARGS+=("--endpoint-url" "$S3_ENDPOINT_URL")
+    fi
+    aws "${AWS_ARGS[@]}" s3 cp \
+      --only-show-errors \
+      --sse AES256 \
+      "$ARCHIVE" "${S3_BUCKET%/}/$(basename "$ARCHIVE")"
+    echo "[pg-backup] uploaded to ${S3_BUCKET%/}/$(basename "$ARCHIVE")"
+  fi
+fi
+
+# Local retention; off-platform copies are the authoritative long-term store.
+find "$BACKUP_DIR" -type f -name 'postgres-*.dump' -mtime "+${RETENTION_DAYS}" -print -delete \
+  || true

--- a/scripts/backup/postgres_restore.sh
+++ b/scripts/backup/postgres_restore.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Postgres restore script.
+#
+# Usage:
+#   DATABASE_URL="postgresql://..." \
+#   ARCHIVE_PATH="./.backups/postgres/postgres-20260101T000000Z.dump" \
+#   ./scripts/backup/postgres_restore.sh [--dry-run] [--force]
+#
+# Safety:
+#   - REFUSES without --force AND a host name containing restore/staging/test.
+#   - Uses pg_restore --clean --if-exists; no DROP DATABASE.
+set -euo pipefail
+
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --force)   FORCE=1 ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 64 ;;
+  esac
+done
+
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+: "${ARCHIVE_PATH:?ARCHIVE_PATH must be set}"
+
+if [[ ! -s "$ARCHIVE_PATH" ]]; then
+  echo "Archive not found or empty: $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+URL_LOWER=$(echo "$DATABASE_URL" | tr '[:upper:]' '[:lower:]')
+if [[ "$FORCE" -ne 1 ]]; then
+  if [[ "$URL_LOWER" != *"restore"* && "$URL_LOWER" != *"staging"* && "$URL_LOWER" != *"test"* ]]; then
+    echo "Refusing to restore into a non-staging/test/restore URL without --force." >&2
+    exit 3
+  fi
+fi
+
+echo "[pg-restore] archive=${ARCHIVE_PATH} dry_run=${DRY_RUN} force=${FORCE}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[pg-restore] dry-run: would invoke pg_restore --clean --if-exists"
+  exit 0
+fi
+
+if ! command -v pg_restore >/dev/null 2>&1; then
+  echo "pg_restore is not installed" >&2
+  exit 127
+fi
+
+pg_restore --clean --if-exists --no-owner --no-acl \
+  --dbname="$DATABASE_URL" "$ARCHIVE_PATH"
+
+echo "[pg-restore] complete"


### PR DESCRIPTION
Closes #26

## Summary
- Scheduled GitHub Actions workflow (`backup.yml`) for daily MongoDB + Postgres backups with optional S3-compatible upload, AES256 SSE, and retention.
- Versioned MongoDB migration runner (`apps/api/src/migrations/`) with `up` / `down` / `status` CLI, idempotent re-runs, and a baseline indexes migration covering tenant_id, content hash uniqueness, and chunks vector/text indexes.
- Refuse-by-default restore scripts (require staging/test/restore in URI or explicit `--force`); never echo URIs; tenant-isolation guidance in script headers and runbook.
- Disaster recovery runbook with RTO/RPO targets and step-by-step restore procedures (`docs/disaster-recovery.md`).

## Test plan
- [x] `uv run pytest tests/test_migrations.py tests/test_backup_scripts.py -v` (13 passed)
- [x] `uv run ruff check` and `ruff format --check` clean for new files
- [ ] Verify backup workflow runs successfully on `workflow_dispatch` after secrets are configured
- [ ] Tabletop DR drill against staging restore using runbook