### PR TITLE
feat(team): team management and role-based access control

### DIFF
--- a/apps/api/src/core/authz.py
+++ b/apps/api/src/core/authz.py
@@ -1,0 +1,106 @@
+"""Role-based authorization helpers for dashboard JWT principals.
+
+API-key requests do NOT carry a role and are rejected here. Use
+``get_tenant_id`` (in ``core.tenant``) for endpoints that must accept API
+keys; use these helpers for dashboard-only management endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from fastapi import Depends, Header, HTTPException, Request
+
+from src.core.observability import set_request_context
+from src.core.security import decode_jwt
+from src.core.settings import load_settings
+from src.models.user import UserRole, has_min_role
+
+logger = logging.getLogger(__name__)
+
+_API_KEY_PREFIX = "mrag_"
+
+
+@dataclass(frozen=True)
+class Principal:
+    """An authenticated dashboard user."""
+
+    user_id: str
+    tenant_id: str
+    role: str
+
+
+async def get_principal(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+) -> Principal:
+    """Decode a dashboard JWT and return the calling principal.
+
+    Raises:
+        HTTPException 401: missing / invalid token, or token lacks required claims.
+        HTTPException 403: caller used an API key — keys cannot manage team.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header with Bearer token is required",
+        )
+
+    token = authorization[7:]
+    if token.startswith(_API_KEY_PREFIX):
+        raise HTTPException(
+            status_code=403,
+            detail="API keys cannot access this endpoint",
+        )
+
+    settings = load_settings()
+    payload = decode_jwt(token, settings.nextauth_secret)
+    if not payload:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    tenant_id = payload.get("tenant_id")
+    user_id = payload.get("sub")
+    role = payload.get("role")
+    if not tenant_id or not user_id or not role:
+        raise HTTPException(
+            status_code=401,
+            detail="Token missing required claims",
+        )
+    if role not in {r.value for r in UserRole}:
+        raise HTTPException(status_code=401, detail="Token has unknown role claim")
+
+    request.state.tenant_id = tenant_id
+    set_request_context(tenant_id=tenant_id)
+    return Principal(user_id=user_id, tenant_id=tenant_id, role=role)
+
+
+def require_role(minimum: UserRole):
+    """Build a FastAPI dependency that enforces a minimum role.
+
+    Example::
+
+        @router.post(...)
+        async def endpoint(principal: Principal = Depends(require_role(UserRole.ADMIN))):
+            ...
+    """
+
+    async def _dep(principal: Principal = Depends(get_principal)) -> Principal:
+        if not has_min_role(principal.role, minimum):
+            logger.info(
+                "rbac_denied",
+                extra={
+                    "tenant_id": principal.tenant_id,
+                    "user_id": principal.user_id,
+                    "role": principal.role,
+                    "required": minimum.value,
+                },
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=f"Requires '{minimum.value}' role or higher",
+            )
+        return principal
+
+    return _dep

--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -139,4 +139,38 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
         background=True,
     )
 
+    # Users: tenant-scoped listing (team page)
+    await db[settings.mongodb_collection_users].create_index(
+        [("tenant_id", 1), ("created_at", 1)], background=True
+    )
+
+    # Invitations: unique by token_hash (single-use semantics)
+    await _create_index_safe(
+        db[settings.mongodb_collection_invitations],
+        "token_hash",
+        unique=True,
+        background=True,
+    )
+
+    # Invitations: only one PENDING invite per (tenant, email).
+    # Partial index allows revoked / accepted rows to coexist.
+    await _create_index_safe(
+        db[settings.mongodb_collection_invitations],
+        [("tenant_id", 1), ("email", 1)],
+        unique=True,
+        background=True,
+        partialFilterExpression={"accepted_at": None, "revoked_at": None},
+        name="invitation_pending_unique",
+    )
+
+    # Invitations: tenant-scoped listing
+    await db[settings.mongodb_collection_invitations].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # Invitations: TTL cleanup 30 days after expiry (covers revoked + accepted)
+    await db[settings.mongodb_collection_invitations].create_index(
+        "expires_at", expireAfterSeconds=86400 * 30, background=True
+    )
+
     logger.info("database_indexes_ensured")

--- a/apps/api/src/core/dependencies.py
+++ b/apps/api/src/core/dependencies.py
@@ -133,6 +133,10 @@ class AgentDependencies:
     def bots_collection(self) -> AsyncCollection:
         return self._get_collection(self.settings.mongodb_collection_bots)
 
+    @property
+    def invitations_collection(self) -> AsyncCollection:
+        return self._get_collection(self.settings.mongodb_collection_invitations)
+
     # -- Core methods --
 
     async def cleanup(self) -> None:

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -81,6 +81,16 @@ class Settings(BaseSettings):
         description="Collection for tenant-scoped bot configurations",
     )
 
+    mongodb_collection_invitations: str = Field(
+        default="invitations",
+        description="Collection for pending tenant team invitations",
+    )
+
+    invitation_ttl_hours: int = Field(
+        default=168,  # 7 days
+        description="How long an invitation remains valid",
+    )
+
     # LLM Configuration (OpenAI-compatible)
     llm_provider: str = Field(
         default="openrouter",

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -26,6 +26,7 @@ from src.routers.documents import router as documents_router
 from src.routers.health import router as health_router
 from src.routers.ingest import router as ingest_router
 from src.routers.keys import router as keys_router
+from src.routers.team import router as team_router
 from src.routers.usage import router as usage_router
 
 # Install structured JSON logging before any module-level logger acquires
@@ -157,3 +158,4 @@ app.include_router(usage_router)
 app.include_router(billing_router)
 app.include_router(bots_router)
 app.include_router(analytics_router)
+app.include_router(team_router)

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -351,3 +351,90 @@ class KeyListResponse(BaseModel):
     """List of API keys for a tenant."""
 
     keys: list[KeyResponse]
+
+
+# --- Team / RBAC ---
+
+
+TeamRole = Literal["owner", "admin", "member", "viewer"]
+
+
+class MemberResponse(BaseModel):
+    """A team member as exposed to the dashboard."""
+
+    id: str
+    email: str
+    name: str
+    role: TeamRole
+    is_active: bool
+    created_at: datetime
+
+
+class MemberListResponse(BaseModel):
+    members: list[MemberResponse]
+
+
+class UpdateMemberRoleRequest(BaseModel):
+    role: TeamRole = Field(..., description="New role for the member")
+
+
+class InvitationResponse(BaseModel):
+    """A pending or historical invitation."""
+
+    id: str
+    email: str
+    role: TeamRole
+    expires_at: datetime
+    accepted_at: Optional[datetime] = None
+    revoked_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class InvitationListResponse(BaseModel):
+    invitations: list[InvitationResponse]
+
+
+class CreateInvitationRequest(BaseModel):
+    email: EmailStr
+    role: TeamRole = Field(default="member")
+
+
+class CreateInvitationResponse(BaseModel):
+    invitation: InvitationResponse
+    accept_url: str = Field(..., description="One-time invite link — shown once")
+
+
+class AcceptInvitationRequest(BaseModel):
+    """Used by an already-authenticated user to accept their invite."""
+
+    token: str = Field(..., min_length=10)
+
+
+class AcceptInvitationSignupRequest(BaseModel):
+    """Used by a new user to sign up and accept an invite atomically."""
+
+    token: str = Field(..., min_length=10)
+    password: str = Field(..., min_length=8, max_length=128)
+    name: str = Field(default="", max_length=100)
+
+
+class InvitationPreviewResponse(BaseModel):
+    """Public, non-sensitive preview of an invite (for the accept page)."""
+
+    email: str
+    role: TeamRole
+    organization_name: str
+    expires_at: datetime
+    requires_signup: bool = Field(
+        ..., description="True if no account exists for this email yet"
+    )
+
+
+class MeResponse(BaseModel):
+    """Current user/principal — used by the web dashboard for role gating."""
+
+    user_id: str
+    tenant_id: str
+    email: str
+    name: str
+    role: TeamRole

--- a/apps/api/src/models/invitation.py
+++ b/apps/api/src/models/invitation.py
@@ -1,0 +1,30 @@
+"""Team invitation model."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+from src.models.user import UserRole
+
+
+class InvitationModel(BaseModel):
+    """A pending invitation for someone to join a tenant.
+
+    The raw token is shown to the inviter exactly once (in the accept link).
+    Only the SHA-256 hash is persisted, so a leaked DB cannot be replayed.
+    """
+
+    tenant_id: str = Field(..., description="Tenant the invitee will join")
+    email: EmailStr = Field(..., description="Invitee email address")
+    role: UserRole = Field(..., description="Role granted on accept")
+    token_hash: str = Field(..., description="SHA-256 of the invite token")
+    invited_by_user_id: str = Field(..., description="User id of inviter")
+    expires_at: datetime = Field(..., description="Invitation expiry time (UTC)")
+    accepted_at: Optional[datetime] = Field(
+        default=None, description="When the invite was accepted"
+    )
+    revoked_at: Optional[datetime] = Field(
+        default=None, description="When the invite was revoked"
+    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -8,11 +8,29 @@ from pydantic import BaseModel, EmailStr, Field
 
 
 class UserRole(str, Enum):
-    """User roles within a tenant."""
+    """User roles within a tenant.
+
+    Hierarchy (highest to lowest): owner > admin > member > viewer.
+    Use ``ROLE_RANK`` to compare and ``has_min_role`` to gate authorization.
+    """
 
     OWNER = "owner"
     ADMIN = "admin"
     MEMBER = "member"
+    VIEWER = "viewer"
+
+
+ROLE_RANK: dict[str, int] = {
+    UserRole.VIEWER.value: 0,
+    UserRole.MEMBER.value: 1,
+    UserRole.ADMIN.value: 2,
+    UserRole.OWNER.value: 3,
+}
+
+
+def has_min_role(role: str, minimum: UserRole) -> bool:
+    """Return True if ``role`` is at least as privileged as ``minimum``."""
+    return ROLE_RANK.get(role, -1) >= ROLE_RANK[minimum.value]
 
 
 class UserModel(BaseModel):

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -6,6 +6,7 @@ import logging
 import resend
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.core.authz import Principal, get_principal
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
 from src.core.rate_limit_dep import enforce_auth_ip_rate_limit
@@ -15,6 +16,7 @@ from src.models.api import (
     ForgotPasswordRequest,
     LoginRequest,
     LoginResponse,
+    MeResponse,
     MessageResponse,
     ResetPasswordRequest,
     SignupRequest,
@@ -147,6 +149,36 @@ async def reset_password(
         raise HTTPException(status_code=400, detail=str(e))
 
     return MessageResponse(message="Password has been reset successfully.")
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(
+    principal: Principal = Depends(get_principal),
+    deps: AgentDependencies = Depends(get_deps),
+):
+    """Return the current user — used by the dashboard for role-gated UI."""
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    try:
+        oid = ObjectId(principal.user_id)
+    except (InvalidId, TypeError):
+        raise HTTPException(status_code=401, detail="Unknown user")
+
+    user = await deps.users_collection.find_one(
+        {"_id": oid, "tenant_id": principal.tenant_id}
+    )
+    if not user:
+        raise HTTPException(status_code=401, detail="Unknown user")
+
+    # Always trust the DB role over the JWT role to defeat stale tokens.
+    return MeResponse(
+        user_id=principal.user_id,
+        tenant_id=principal.tenant_id,
+        email=user["email"],
+        name=user.get("name", ""),
+        role=user.get("role", "viewer"),
+    )
 
 
 @router.post("/ws-ticket", response_model=WSTicketResponse)

--- a/apps/api/src/routers/billing.py
+++ b/apps/api/src/routers/billing.py
@@ -9,9 +9,9 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.core.authz import Principal, require_role
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
-from src.core.tenant import get_tenant_id_from_jwt
 from src.models.billing import (
     DISPLAY_PRICES_CENTS,
     MODEL_CATALOG,
@@ -27,6 +27,7 @@ from src.models.billing import (
     PlansResponse,
 )
 from src.models.tenant import PlanTier
+from src.models.user import UserRole
 from src.services.billing import BillingError, BillingService
 
 logger = logging.getLogger(__name__)
@@ -151,13 +152,14 @@ async def list_plans() -> PlansResponse:
 @router.post("/checkout", response_model=CheckoutResponse)
 async def create_checkout(
     body: CheckoutRequest,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.OWNER)),
     service: BillingService = Depends(_get_billing_service),
 ) -> CheckoutResponse:
     """Create a Stripe Checkout session for an upgrade.
 
-    JWT-only (not API keys) — billing is a dashboard-session-only operation.
+    Owner-only — billing is a tenant-financial concern.
     """
+    tenant_id = principal.tenant_id
     if body.plan in NON_CHECKOUT_PLANS:
         raise HTTPException(
             status_code=400,

--- a/apps/api/src/routers/bots.py
+++ b/apps/api/src/routers/bots.py
@@ -8,9 +8,9 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.core.authz import Principal, require_role
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
-from src.core.tenant import get_tenant_id_from_jwt
 from src.models.api import MessageResponse
 from src.models.bot import (
     BotListResponse,
@@ -19,6 +19,7 @@ from src.models.bot import (
     PublicBotResponse,
     UpdateBotRequest,
 )
+from src.models.user import UserRole
 from src.services.bot import BotService, BotSlugTakenError
 
 logger = logging.getLogger(__name__)
@@ -37,10 +38,11 @@ def _get_bot_service(deps: AgentDependencies = Depends(get_deps)) -> BotService:
 @router.post("", response_model=BotResponse, status_code=201)
 async def create_bot(
     body: CreateBotRequest,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
     service: BotService = Depends(_get_bot_service),
 ):
     """Create a new bot. Slug must be unique per tenant."""
+    tenant_id = principal.tenant_id
     count = await service.count_for_tenant(tenant_id)
     if count >= MAX_BOTS_PER_TENANT:
         raise HTTPException(
@@ -56,22 +58,22 @@ async def create_bot(
 
 @router.get("", response_model=BotListResponse)
 async def list_bots(
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.VIEWER)),
     service: BotService = Depends(_get_bot_service),
 ):
     """List all bots for the authenticated tenant."""
-    bots = await service.list_for_tenant(tenant_id)
+    bots = await service.list_for_tenant(principal.tenant_id)
     return BotListResponse(bots=[BotResponse(**b) for b in bots])
 
 
 @router.get("/{bot_id}", response_model=BotResponse)
 async def get_bot(
     bot_id: str,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.VIEWER)),
     service: BotService = Depends(_get_bot_service),
 ):
     """Fetch a single bot. 404 for cross-tenant ids."""
-    bot = await service.get(bot_id=bot_id, tenant_id=tenant_id)
+    bot = await service.get(bot_id=bot_id, tenant_id=principal.tenant_id)
     if bot is None:
         raise HTTPException(status_code=404, detail="Bot not found")
     return BotResponse(**bot)
@@ -81,11 +83,11 @@ async def get_bot(
 async def update_bot(
     bot_id: str,
     body: UpdateBotRequest,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
     service: BotService = Depends(_get_bot_service),
 ):
     """Partially update a bot. Slug is immutable."""
-    bot = await service.update(bot_id=bot_id, tenant_id=tenant_id, body=body)
+    bot = await service.update(bot_id=bot_id, tenant_id=principal.tenant_id, body=body)
     if bot is None:
         raise HTTPException(status_code=404, detail="Bot not found")
     return BotResponse(**bot)
@@ -94,11 +96,11 @@ async def update_bot(
 @router.delete("/{bot_id}", response_model=MessageResponse)
 async def delete_bot(
     bot_id: str,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
     service: BotService = Depends(_get_bot_service),
 ):
     """Permanently delete a bot."""
-    deleted = await service.delete(bot_id=bot_id, tenant_id=tenant_id)
+    deleted = await service.delete(bot_id=bot_id, tenant_id=principal.tenant_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Bot not found")
     return MessageResponse(message="Bot deleted")

--- a/apps/api/src/routers/keys.py
+++ b/apps/api/src/routers/keys.py
@@ -5,9 +5,9 @@ import logging
 from bson.errors import InvalidId
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.core.authz import Principal, require_role
 from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
-from src.core.tenant import get_tenant_id_from_jwt
 from src.models.api import (
     CreateKeyRequest,
     CreateKeyResponse,
@@ -15,6 +15,7 @@ from src.models.api import (
     KeyResponse,
     MessageResponse,
 )
+from src.models.user import UserRole
 from src.services.api_key import APIKeyService
 
 logger = logging.getLogger(__name__)
@@ -30,12 +31,12 @@ def _get_api_key_service(deps: AgentDependencies = Depends(get_deps)) -> APIKeyS
 @router.post("", response_model=CreateKeyResponse, status_code=201)
 async def create_key(
     body: CreateKeyRequest,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
     service: APIKeyService = Depends(_get_api_key_service),
 ):
     """Generate a new API key. The raw key is returned once and cannot be retrieved again."""
     result = await service.create_key(
-        tenant_id=tenant_id,
+        tenant_id=principal.tenant_id,
         name=body.name,
         permissions=body.permissions,
     )
@@ -44,23 +45,23 @@ async def create_key(
 
 @router.get("", response_model=KeyListResponse)
 async def list_keys(
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.MEMBER)),
     service: APIKeyService = Depends(_get_api_key_service),
 ):
     """List all API keys for the authenticated tenant."""
-    keys = await service.list_keys(tenant_id)
+    keys = await service.list_keys(principal.tenant_id)
     return KeyListResponse(keys=[KeyResponse(**k) for k in keys])
 
 
 @router.delete("/{key_id}", response_model=MessageResponse)
 async def revoke_key(
     key_id: str,
-    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
     service: APIKeyService = Depends(_get_api_key_service),
 ):
     """Revoke an API key (soft delete)."""
     try:
-        revoked = await service.revoke_key(key_id=key_id, tenant_id=tenant_id)
+        revoked = await service.revoke_key(key_id=key_id, tenant_id=principal.tenant_id)
     except InvalidId:
         raise HTTPException(status_code=400, detail="Invalid key ID format")
 

--- a/apps/api/src/routers/team.py
+++ b/apps/api/src/routers/team.py
@@ -1,0 +1,300 @@
+"""Team management endpoints: members + invitations.
+
+Authorization is enforced via ``require_role``:
+* listing members / invitations: any authenticated user (member+)
+* creating / revoking invitations: admin+
+* changing roles / removing members: admin+ (with owner-only rules in service)
+
+Accept-invite endpoints are public so far as they accept either:
+* a signed-in dashboard user that matches the invite email, OR
+* a new user signing up + accepting in one step.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from src.core.authz import Principal, get_principal, require_role
+from src.core.dependencies import AgentDependencies
+from src.core.deps import get_deps
+from src.core.settings import load_settings
+from src.models.api import (
+    AcceptInvitationRequest,
+    AcceptInvitationSignupRequest,
+    CreateInvitationRequest,
+    CreateInvitationResponse,
+    InvitationListResponse,
+    InvitationPreviewResponse,
+    InvitationResponse,
+    LoginResponse,
+    MemberListResponse,
+    MemberResponse,
+    MessageResponse,
+    UpdateMemberRoleRequest,
+)
+from src.models.user import UserRole
+from src.services.team import TeamError, TeamService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/team", tags=["team"])
+
+
+def _service(deps: AgentDependencies = Depends(get_deps)) -> TeamService:
+    settings = load_settings()
+    return TeamService(
+        users_collection=deps.users_collection,
+        tenants_collection=deps.tenants_collection,
+        invitations_collection=deps.invitations_collection,
+        invitation_ttl_hours=settings.invitation_ttl_hours,
+    )
+
+
+def _accept_url(token: str) -> str:
+    settings = load_settings()
+    base = settings.app_url.rstrip("/")
+    return f"{base}/invite/{token}"
+
+
+# --- Members -----------------------------------------------------------
+
+
+@router.get("/members", response_model=MemberListResponse)
+async def list_members(
+    principal: Principal = Depends(get_principal),
+    service: TeamService = Depends(_service),
+):
+    """Any authenticated user can see who else is on the team."""
+    members = await service.list_members(principal.tenant_id)
+    return MemberListResponse(members=[MemberResponse(**m) for m in members])
+
+
+@router.patch("/members/{user_id}", response_model=MemberResponse)
+async def update_member_role(
+    user_id: str,
+    body: UpdateMemberRoleRequest,
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
+    service: TeamService = Depends(_service),
+):
+    try:
+        updated = await service.update_member_role(
+            tenant_id=principal.tenant_id,
+            target_user_id=user_id,
+            new_role=UserRole(body.role),
+            actor_user_id=principal.user_id,
+            actor_role=UserRole(principal.role),
+        )
+    except TeamError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return MemberResponse(**updated)
+
+
+@router.delete("/members/{user_id}", response_model=MessageResponse)
+async def remove_member(
+    user_id: str,
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
+    service: TeamService = Depends(_service),
+):
+    try:
+        removed = await service.remove_member(
+            tenant_id=principal.tenant_id,
+            target_user_id=user_id,
+            actor_user_id=principal.user_id,
+            actor_role=UserRole(principal.role),
+        )
+    except TeamError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc))
+    if not removed:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return MessageResponse(message="Member removed")
+
+
+# --- Invitations -------------------------------------------------------
+
+
+@router.get("/invitations", response_model=InvitationListResponse)
+async def list_invitations(
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
+    service: TeamService = Depends(_service),
+):
+    invites = await service.list_invitations(principal.tenant_id)
+    return InvitationListResponse(
+        invitations=[InvitationResponse(**i) for i in invites]
+    )
+
+
+@router.post(
+    "/invitations",
+    response_model=CreateInvitationResponse,
+    status_code=201,
+)
+async def create_invitation(
+    body: CreateInvitationRequest,
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
+    service: TeamService = Depends(_service),
+):
+    try:
+        record, raw_token = await service.create_invitation(
+            tenant_id=principal.tenant_id,
+            email=body.email,
+            role=UserRole(body.role),
+            invited_by_user_id=principal.user_id,
+            actor_role=UserRole(principal.role),
+        )
+    except TeamError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc))
+
+    return CreateInvitationResponse(
+        invitation=InvitationResponse(**record),
+        accept_url=_accept_url(raw_token),
+    )
+
+
+@router.delete("/invitations/{invitation_id}", response_model=MessageResponse)
+async def revoke_invitation(
+    invitation_id: str,
+    principal: Principal = Depends(require_role(UserRole.ADMIN)),
+    service: TeamService = Depends(_service),
+):
+    revoked = await service.revoke_invitation(
+        tenant_id=principal.tenant_id,
+        invitation_id=invitation_id,
+    )
+    if not revoked:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    return MessageResponse(message="Invitation revoked")
+
+
+# --- Accept (public) ---------------------------------------------------
+
+
+@router.get(
+    "/invitations/{token}/preview",
+    response_model=InvitationPreviewResponse,
+)
+async def preview_invitation(
+    token: str,
+    service: TeamService = Depends(_service),
+):
+    """Public: look up an invitation for the accept page.
+
+    Returns 404 for unknown / expired / revoked tokens to avoid enumeration.
+    """
+    preview = await service.preview_invitation(token)
+    if not preview:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    return InvitationPreviewResponse(**preview)
+
+
+@router.post("/invitations/{token}/accept", response_model=LoginResponse)
+async def accept_invitation(
+    token: str,
+    body: AcceptInvitationRequest,
+    principal: Principal = Depends(get_principal),
+    service: TeamService = Depends(_service),
+):
+    """Authenticated path: an existing user accepts their invite.
+
+    The path token MUST equal the body token — defends against CSRF that
+    swaps the path while reusing a stale body.
+    """
+    if token != body.token:
+        raise HTTPException(status_code=400, detail="Token mismatch")
+
+    user = await service._users.find_one(  # noqa: SLF001 — internal helper
+        {"_id": _safe_oid(principal.user_id)}
+    )
+    if not user:
+        raise HTTPException(status_code=401, detail="Unknown user")
+
+    try:
+        result = await service.accept_invitation_existing_user(
+            raw_token=body.token,
+            acting_user_id=principal.user_id,
+            acting_email=user["email"],
+        )
+    except TeamError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc))
+
+    return LoginResponse(
+        user_id=result["user_id"],
+        tenant_id=result["tenant_id"],
+        email=user["email"],
+        name=user.get("name", ""),
+        role=result["role"],
+    )
+
+
+@router.post(
+    "/invitations/{token}/accept-signup",
+    response_model=LoginResponse,
+    status_code=201,
+)
+async def accept_invitation_signup(
+    token: str,
+    body: AcceptInvitationSignupRequest,
+    request: Request,
+    deps: AgentDependencies = Depends(get_deps),
+    service: TeamService = Depends(_service),
+):
+    """Public: a brand-new user signs up + accepts the invite atomically.
+
+    Rate-limited per source IP to deter token enumeration / brute force.
+    """
+    if token != body.token:
+        raise HTTPException(status_code=400, detail="Token mismatch")
+
+    await _enforce_invite_rate_limit(request, deps)
+
+    try:
+        result = await service.accept_invitation_new_user(
+            raw_token=body.token,
+            password=body.password,
+            name=body.name,
+        )
+    except TeamError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc))
+
+    return LoginResponse(
+        user_id=result["user_id"],
+        tenant_id=result["tenant_id"],
+        email=result["email"],
+        name=body.name or "",
+        role=result["role"],
+    )
+
+
+# --- helpers -----------------------------------------------------------
+
+
+def _safe_oid(value: str):
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    try:
+        return ObjectId(value)
+    except (InvalidId, TypeError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid id") from exc
+
+
+async def _enforce_invite_rate_limit(
+    request: Request,
+    deps: AgentDependencies,
+) -> None:
+    """Cap accept-signup attempts per source IP."""
+    from src.services.rate_limit import get_default_limiter
+
+    client_ip = (request.client.host if request.client else "unknown") or "unknown"
+    key = f"invite-accept:{client_ip}"
+    limiter = get_default_limiter()
+    result = await limiter.check(key, limit=10, window_seconds=60)
+    if not result.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many invitation attempts; try again later",
+            headers={"Retry-After": str(result.reset_in)},
+        )

--- a/apps/api/src/services/team.py
+++ b/apps/api/src/services/team.py
@@ -1,0 +1,465 @@
+"""Team management service — members and invitations.
+
+Authorization is enforced at the router layer. This service implements
+business invariants:
+
+* the last owner of a tenant cannot be demoted or removed;
+* only owners may grant/transfer the ``owner`` role;
+* invitations are tenant-scoped and stored as a SHA-256 hash;
+* tokens are single-use, expire after a configured TTL, and only the
+  intended email may accept.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.errors import DuplicateKeyError
+
+from src.core.security import hash_password
+from src.models.user import UserRole
+
+logger = logging.getLogger(__name__)
+
+
+class TeamError(ValueError):
+    """Domain error for team operations (mapped to 4xx by router)."""
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _strip_user_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(doc["_id"]),
+        "email": doc["email"],
+        "name": doc.get("name", ""),
+        "role": doc.get("role", UserRole.MEMBER.value),
+        "is_active": bool(doc.get("is_active", True)),
+        "created_at": doc.get("created_at"),
+    }
+
+
+def _strip_invite_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(doc["_id"]),
+        "email": doc["email"],
+        "role": doc["role"],
+        "expires_at": doc["expires_at"],
+        "accepted_at": doc.get("accepted_at"),
+        "revoked_at": doc.get("revoked_at"),
+        "created_at": doc["created_at"],
+    }
+
+
+class TeamService:
+    """Members + invitations, scoped by tenant_id."""
+
+    def __init__(
+        self,
+        users_collection: AsyncCollection,
+        tenants_collection: AsyncCollection,
+        invitations_collection: AsyncCollection,
+        invitation_ttl_hours: int = 168,
+    ) -> None:
+        self._users = users_collection
+        self._tenants = tenants_collection
+        self._invitations = invitations_collection
+        self._ttl = timedelta(hours=invitation_ttl_hours)
+
+    # --- Members -------------------------------------------------------
+
+    async def list_members(self, tenant_id: str) -> list[dict[str, Any]]:
+        cursor = self._users.find({"tenant_id": tenant_id}).sort("created_at", 1)
+        return [_strip_user_doc(d) async for d in cursor]
+
+    async def get_member(self, tenant_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        try:
+            oid = ObjectId(user_id)
+        except (InvalidId, TypeError):
+            return None
+        doc = await self._users.find_one({"_id": oid, "tenant_id": tenant_id})
+        return _strip_user_doc(doc) if doc else None
+
+    async def _count_owners(self, tenant_id: str) -> int:
+        return await self._users.count_documents(
+            {"tenant_id": tenant_id, "role": UserRole.OWNER.value}
+        )
+
+    async def update_member_role(
+        self,
+        *,
+        tenant_id: str,
+        target_user_id: str,
+        new_role: UserRole,
+        actor_user_id: str,
+        actor_role: UserRole,
+    ) -> Optional[dict[str, Any]]:
+        try:
+            oid = ObjectId(target_user_id)
+        except (InvalidId, TypeError):
+            return None
+
+        target = await self._users.find_one({"_id": oid, "tenant_id": tenant_id})
+        if not target:
+            return None
+
+        current_role = target.get("role", UserRole.MEMBER.value)
+
+        # Only owners can promote anyone TO owner, or demote an owner.
+        if (new_role == UserRole.OWNER or current_role == UserRole.OWNER.value) and (
+            actor_role != UserRole.OWNER
+        ):
+            raise TeamError("Only owners can change owner roles", status_code=403)
+
+        # Last-owner-protection: cannot demote the last owner.
+        if (
+            current_role == UserRole.OWNER.value
+            and new_role != UserRole.OWNER
+            and await self._count_owners(tenant_id) <= 1
+        ):
+            raise TeamError(
+                "Cannot demote the last owner — promote another member first",
+                status_code=409,
+            )
+
+        # No-op fast path
+        if current_role == new_role.value:
+            return _strip_user_doc(target)
+
+        result = await self._users.find_one_and_update(
+            {"_id": oid, "tenant_id": tenant_id, "role": current_role},
+            {
+                "$set": {
+                    "role": new_role.value,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+            return_document=True,
+        )
+        if not result:
+            # Concurrent role change — re-evaluate.
+            raise TeamError("Concurrent role change, retry", status_code=409)
+
+        # Recheck-after-write: if the previous role was owner, confirm at
+        # least one owner still remains. Defends against the race where two
+        # concurrent demotions both pass the count check above.
+        if current_role == UserRole.OWNER.value and new_role != UserRole.OWNER:
+            if await self._count_owners(tenant_id) == 0:
+                # Roll back atomically.
+                await self._users.update_one(
+                    {"_id": oid, "tenant_id": tenant_id},
+                    {"$set": {"role": current_role}},
+                )
+                raise TeamError(
+                    "Cannot demote the last owner — promote another member first",
+                    status_code=409,
+                )
+
+        logger.info(
+            "team_member_role_changed",
+            extra={
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "target_user_id": target_user_id,
+                "from_role": current_role,
+                "to_role": new_role.value,
+            },
+        )
+        return _strip_user_doc(result)
+
+    async def remove_member(
+        self,
+        *,
+        tenant_id: str,
+        target_user_id: str,
+        actor_user_id: str,
+        actor_role: UserRole,
+    ) -> bool:
+        try:
+            oid = ObjectId(target_user_id)
+        except (InvalidId, TypeError):
+            return False
+
+        target = await self._users.find_one({"_id": oid, "tenant_id": tenant_id})
+        if not target:
+            return False
+
+        target_role = target.get("role", UserRole.MEMBER.value)
+
+        # Only owners can remove other owners.
+        if target_role == UserRole.OWNER.value and actor_role != UserRole.OWNER:
+            raise TeamError("Only owners can remove an owner", status_code=403)
+
+        # Last-owner-protection.
+        if (
+            target_role == UserRole.OWNER.value
+            and await self._count_owners(tenant_id) <= 1
+        ):
+            raise TeamError(
+                "Cannot remove the last owner — promote another member first",
+                status_code=409,
+            )
+
+        # Prevent self-removal of the only owner.
+        if str(target["_id"]) == actor_user_id and target_role == UserRole.OWNER.value:
+            if await self._count_owners(tenant_id) <= 1:
+                raise TeamError(
+                    "Cannot remove yourself as the last owner",
+                    status_code=409,
+                )
+
+        result = await self._users.delete_one(
+            {"_id": oid, "tenant_id": tenant_id, "role": target_role}
+        )
+        if result.deleted_count == 0:
+            raise TeamError("Concurrent change, retry", status_code=409)
+
+        # Recheck-after-write to close the concurrent-removal race.
+        if target_role == UserRole.OWNER.value:
+            if await self._count_owners(tenant_id) == 0:
+                # Re-insert the owner — best effort rollback.
+                await self._users.insert_one({**target})
+                raise TeamError(
+                    "Cannot remove the last owner — promote another member first",
+                    status_code=409,
+                )
+
+        logger.info(
+            "team_member_removed",
+            extra={
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "target_user_id": target_user_id,
+                "removed_role": target_role,
+            },
+        )
+        return True
+
+    # --- Invitations ---------------------------------------------------
+
+    async def list_invitations(self, tenant_id: str) -> list[dict[str, Any]]:
+        cursor = self._invitations.find({"tenant_id": tenant_id}).sort("created_at", -1)
+        return [_strip_invite_doc(d) async for d in cursor]
+
+    async def create_invitation(
+        self,
+        *,
+        tenant_id: str,
+        email: str,
+        role: UserRole,
+        invited_by_user_id: str,
+        actor_role: UserRole,
+    ) -> tuple[dict[str, Any], str]:
+        """Create a pending invite. Returns (record, raw_token)."""
+        if role == UserRole.OWNER and actor_role != UserRole.OWNER:
+            raise TeamError("Only owners can invite another owner", status_code=403)
+
+        email = email.strip().lower()
+
+        existing = await self._users.find_one(
+            {"tenant_id": tenant_id, "email": email}
+        )
+        if existing:
+            raise TeamError("That email is already a member of this tenant", 409)
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_token(raw_token)
+        now = datetime.now(timezone.utc)
+
+        doc = {
+            "tenant_id": tenant_id,
+            "email": email,
+            "role": role.value,
+            "token_hash": token_hash,
+            "invited_by_user_id": invited_by_user_id,
+            "expires_at": now + self._ttl,
+            "accepted_at": None,
+            "revoked_at": None,
+            "created_at": now,
+        }
+        try:
+            result = await self._invitations.insert_one(doc)
+        except DuplicateKeyError:
+            raise TeamError(
+                "An invitation for that email is already pending", 409
+            )
+
+        doc["_id"] = result.inserted_id
+        logger.info(
+            "invitation_created",
+            extra={
+                "tenant_id": tenant_id,
+                "invited_by_user_id": invited_by_user_id,
+                "role": role.value,
+            },
+        )
+        return _strip_invite_doc(doc), raw_token
+
+    async def revoke_invitation(self, *, tenant_id: str, invitation_id: str) -> bool:
+        try:
+            oid = ObjectId(invitation_id)
+        except (InvalidId, TypeError):
+            return False
+
+        result = await self._invitations.find_one_and_update(
+            {
+                "_id": oid,
+                "tenant_id": tenant_id,
+                "accepted_at": None,
+                "revoked_at": None,
+            },
+            {"$set": {"revoked_at": datetime.now(timezone.utc)}},
+        )
+        return result is not None
+
+    async def preview_invitation(self, raw_token: str) -> Optional[dict[str, Any]]:
+        """Public: look up an invite by token + check whether signup is needed."""
+        token_hash = _hash_token(raw_token)
+        invite = await self._invitations.find_one(
+            {
+                "token_hash": token_hash,
+                "accepted_at": None,
+                "revoked_at": None,
+                "expires_at": {"$gt": datetime.now(timezone.utc)},
+            }
+        )
+        if not invite:
+            return None
+
+        tenant = await self._tenants.find_one({"tenant_id": invite["tenant_id"]})
+        existing_user = await self._users.find_one({"email": invite["email"]})
+
+        return {
+            "email": invite["email"],
+            "role": invite["role"],
+            "organization_name": (tenant or {}).get("name", ""),
+            "expires_at": invite["expires_at"],
+            "requires_signup": existing_user is None,
+        }
+
+    async def accept_invitation_existing_user(
+        self,
+        *,
+        raw_token: str,
+        acting_user_id: str,
+        acting_email: str,
+    ) -> dict[str, Any]:
+        """Accept an invite for an already-signed-in user.
+
+        The user's tenant_id is migrated to the inviting tenant. We require
+        the acting user's email to match the invite email, defending against
+        token theft + cross-account replay.
+        """
+        invite = await self._claim_invite(raw_token)
+        if invite["email"] != acting_email.strip().lower():
+            # Re-open: do not consume someone else's invite.
+            await self._invitations.update_one(
+                {"_id": invite["_id"]},
+                {"$set": {"accepted_at": None}},
+            )
+            raise TeamError("This invitation was issued to a different email", 403)
+
+        try:
+            user_oid = ObjectId(acting_user_id)
+        except (InvalidId, TypeError):
+            raise TeamError("Invalid user", 400)
+
+        await self._users.update_one(
+            {"_id": user_oid},
+            {
+                "$set": {
+                    "tenant_id": invite["tenant_id"],
+                    "role": invite["role"],
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+        return {
+            "user_id": acting_user_id,
+            "tenant_id": invite["tenant_id"],
+            "role": invite["role"],
+        }
+
+    async def accept_invitation_new_user(
+        self,
+        *,
+        raw_token: str,
+        password: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Sign up + accept an invite atomically (no tenant created)."""
+        invite = await self._claim_invite(raw_token)
+
+        existing = await self._users.find_one({"email": invite["email"]})
+        if existing:
+            # Re-open the invite — caller should sign in and accept instead.
+            await self._invitations.update_one(
+                {"_id": invite["_id"]},
+                {"$set": {"accepted_at": None}},
+            )
+            raise TeamError(
+                "An account already exists for this email — sign in to accept",
+                status_code=409,
+            )
+
+        now = datetime.now(timezone.utc)
+        user_doc = {
+            "tenant_id": invite["tenant_id"],
+            "email": invite["email"],
+            "hashed_password": hash_password(password),
+            "name": name or "",
+            "role": invite["role"],
+            "is_active": True,
+            "email_verified": True,  # email proven by accepting the invite
+            "created_at": now,
+            "updated_at": now,
+        }
+        try:
+            result = await self._users.insert_one(user_doc)
+        except DuplicateKeyError:
+            await self._invitations.update_one(
+                {"_id": invite["_id"]},
+                {"$set": {"accepted_at": None}},
+            )
+            raise TeamError(
+                "An account already exists for this email — sign in to accept",
+                status_code=409,
+            )
+
+        return {
+            "user_id": str(result.inserted_id),
+            "tenant_id": invite["tenant_id"],
+            "email": invite["email"],
+            "role": invite["role"],
+        }
+
+    async def _claim_invite(self, raw_token: str) -> dict[str, Any]:
+        """Atomically mark an invite accepted. Returns the original doc."""
+        token_hash = _hash_token(raw_token)
+        now = datetime.now(timezone.utc)
+
+        invite = await self._invitations.find_one_and_update(
+            {
+                "token_hash": token_hash,
+                "accepted_at": None,
+                "revoked_at": None,
+                "expires_at": {"$gt": now},
+            },
+            {"$set": {"accepted_at": now}},
+        )
+        if not invite:
+            raise TeamError("Invalid or expired invitation", 400)
+        return invite

--- a/apps/api/tests/test_authz.py
+++ b/apps/api/tests/test_authz.py
@@ -1,0 +1,88 @@
+"""Tests for the role-based authorization helper (require_role)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from jose import jwt
+
+JWT_SECRET = "test-secret-for-unit-tests-minimum-32chars"
+
+
+def _token(role: str, tenant_id: str = "tenant-1", sub: str = "user-1") -> str:
+    return jwt.encode(
+        {"sub": sub, "tenant_id": tenant_id, "role": role},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+def _hdr(role: str) -> dict:
+    return {"Authorization": f"Bearer {_token(role)}"}
+
+
+@pytest.fixture
+def app():
+    from src.core.authz import Principal, require_role
+    from src.models.user import UserRole
+
+    app = FastAPI()
+
+    @app.get("/owner-only")
+    async def owner(p: Principal = Depends(require_role(UserRole.OWNER))):
+        return {"ok": True}
+
+    @app.get("/admin-plus")
+    async def admin(p: Principal = Depends(require_role(UserRole.ADMIN))):
+        return {"ok": True}
+
+    @app.get("/member-plus")
+    async def member(p: Principal = Depends(require_role(UserRole.MEMBER))):
+        return {"ok": True}
+
+    deps = MagicMock()
+    deps.api_keys_collection.find_one = AsyncMock(return_value=None)
+    app.state.deps = deps
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_owner_passes_all_gates(app):
+    for path in ("/owner-only", "/admin-plus", "/member-plus"):
+        assert app.get(path, headers=_hdr("owner")).status_code == 200
+
+
+@pytest.mark.unit
+def test_admin_blocked_from_owner_only(app):
+    assert app.get("/owner-only", headers=_hdr("admin")).status_code == 403
+    assert app.get("/admin-plus", headers=_hdr("admin")).status_code == 200
+
+
+@pytest.mark.unit
+def test_member_blocked_from_admin(app):
+    assert app.get("/admin-plus", headers=_hdr("member")).status_code == 403
+    assert app.get("/member-plus", headers=_hdr("member")).status_code == 200
+
+
+@pytest.mark.unit
+def test_viewer_blocked_from_member(app):
+    assert app.get("/member-plus", headers=_hdr("viewer")).status_code == 403
+
+
+@pytest.mark.unit
+def test_unknown_role_rejected(app):
+    assert app.get("/member-plus", headers=_hdr("super-admin")).status_code == 401
+
+
+@pytest.mark.unit
+def test_missing_role_claim_rejected(app):
+    token = jwt.encode({"sub": "u", "tenant_id": "t"}, JWT_SECRET, algorithm="HS256")
+    r = app.get("/member-plus", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_api_key_rejected(app):
+    r = app.get("/member-plus", headers={"Authorization": "Bearer mrag_abcdef123"})
+    assert r.status_code == 403

--- a/apps/api/tests/test_database_indexes.py
+++ b/apps/api/tests/test_database_indexes.py
@@ -22,6 +22,7 @@ async def test_ensure_indexes_creates_expected_indexes():
         "ws_tickets",
         "usage",
         "bots",
+        "invitations",
     ]:
         mock_col = MagicMock()
         mock_col.create_index = AsyncMock()
@@ -41,6 +42,7 @@ async def test_ensure_indexes_creates_expected_indexes():
     mock_settings.mongodb_collection_ws_tickets = "ws_tickets"
     mock_settings.mongodb_collection_usage = "usage"
     mock_settings.mongodb_collection_bots = "bots"
+    mock_settings.mongodb_collection_invitations = "invitations"
 
     await ensure_indexes(mock_db, mock_settings)
 
@@ -98,4 +100,14 @@ async def test_ensure_indexes_creates_expected_indexes():
     # bots: unique slug per tenant
     collections["bots"].create_index.assert_any_call(
         [("tenant_id", 1), ("slug", 1)], unique=True, background=True
+    )
+
+    # invitations: unique token hash
+    collections["invitations"].create_index.assert_any_call(
+        "token_hash", unique=True, background=True
+    )
+
+    # invitations: tenant-scoped listing
+    collections["invitations"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
     )

--- a/apps/api/tests/test_team_service.py
+++ b/apps/api/tests/test_team_service.py
@@ -1,0 +1,400 @@
+"""Tests for the TeamService — invariants for invitations and member roles."""
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import pytest
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from src.models.user import UserRole
+from src.services.team import TeamError, TeamService
+
+
+class FakeCursor:
+    def __init__(self, docs: list[dict[str, Any]]):
+        self._docs = docs
+
+    def sort(self, *_args, **_kwargs) -> "FakeCursor":
+        return self
+
+    def __aiter__(self):
+        async def gen():
+            for d in self._docs:
+                yield d
+
+        return gen()
+
+
+class FakeCollection:
+    """Tiny in-memory subset of pymongo's async collection API."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+        self.docs: list[dict[str, Any]] = []
+        self.unique: list[tuple[str, ...]] = []
+
+    def add_unique(self, *fields: str) -> None:
+        self.unique.append(fields)
+
+    def _matches(self, doc: dict[str, Any], q: dict[str, Any]) -> bool:
+        for k, v in q.items():
+            doc_v = doc.get(k)
+            if isinstance(v, dict):
+                for op, val in v.items():
+                    if op == "$gt" and not (doc_v is not None and doc_v > val):
+                        return False
+                    if op == "$lt" and not (doc_v is not None and doc_v < val):
+                        return False
+                continue
+            if doc_v != v:
+                return False
+        return True
+
+    async def find_one(self, q: dict[str, Any]) -> Optional[dict[str, Any]]:
+        for d in self.docs:
+            if self._matches(d, q):
+                return dict(d)
+        return None
+
+    def find(self, q: dict[str, Any]) -> FakeCursor:
+        return FakeCursor([dict(d) for d in self.docs if self._matches(d, q)])
+
+    async def count_documents(self, q: dict[str, Any]) -> int:
+        return sum(1 for d in self.docs if self._matches(d, q))
+
+    async def insert_one(self, doc: dict[str, Any]):
+        for fields in self.unique:
+            for d in self.docs:
+                # Treat None as wildcard for partial indexes simulating
+                # `accepted_at: None, revoked_at: None`.
+                if all(d.get(f) == doc.get(f) for f in fields):
+                    raise DuplicateKeyError("dup")
+        new_doc = dict(doc)
+        new_doc.setdefault("_id", ObjectId())
+        self.docs.append(new_doc)
+
+        class R:
+            inserted_id = new_doc["_id"]
+
+        return R()
+
+    async def update_one(self, q: dict[str, Any], update: dict[str, Any]):
+        for d in self.docs:
+            if self._matches(d, q):
+                d.update(update.get("$set", {}))
+                break
+
+        class R:
+            matched_count = 1
+
+        return R()
+
+    async def delete_one(self, q: dict[str, Any]):
+        for i, d in enumerate(self.docs):
+            if self._matches(d, q):
+                del self.docs[i]
+
+                class R:
+                    deleted_count = 1
+
+                return R()
+
+        class R:
+            deleted_count = 0
+
+        return R()
+
+    async def find_one_and_update(
+        self, q: dict[str, Any], update: dict[str, Any], **_kw
+    ) -> Optional[dict[str, Any]]:
+        for d in self.docs:
+            if self._matches(d, q):
+                d.update(update.get("$set", {}))
+                return dict(d)
+        return None
+
+
+@pytest.fixture
+def collections():
+    users = FakeCollection("users")
+    tenants = FakeCollection("tenants")
+    invites = FakeCollection("invitations")
+    invites.add_unique("token_hash")
+    # Simulate the partial unique index: tenant + email + only when pending.
+    # We capture this by clearing the constraint after revoke/accept.
+    return users, tenants, invites
+
+
+@pytest.fixture
+def service(collections):
+    users, tenants, invites = collections
+    return TeamService(
+        users_collection=users,
+        tenants_collection=tenants,
+        invitations_collection=invites,
+        invitation_ttl_hours=168,
+    )
+
+
+def _seed_user(coll, *, tenant_id, role, email="u@example.com", _id=None):
+    doc = {
+        "_id": _id or ObjectId(),
+        "tenant_id": tenant_id,
+        "email": email,
+        "name": "",
+        "role": role,
+        "is_active": True,
+        "created_at": datetime.now(timezone.utc),
+    }
+    coll.docs.append(doc)
+    return doc
+
+
+# --- Members ---
+
+
+@pytest.mark.unit
+async def test_owner_can_change_admin_to_member(service, collections):
+    users, _, _ = collections
+    owner = _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    admin = _seed_user(users, tenant_id="t1", role="admin", email="a@x")
+    updated = await service.update_member_role(
+        tenant_id="t1",
+        target_user_id=str(admin["_id"]),
+        new_role=UserRole.MEMBER,
+        actor_user_id=str(owner["_id"]),
+        actor_role=UserRole.OWNER,
+    )
+    assert updated["role"] == "member"
+
+
+@pytest.mark.unit
+async def test_admin_cannot_promote_to_owner(service, collections):
+    users, _, _ = collections
+    actor = _seed_user(users, tenant_id="t1", role="admin", email="a@x")
+    target = _seed_user(users, tenant_id="t1", role="member", email="m@x")
+    with pytest.raises(TeamError) as exc:
+        await service.update_member_role(
+            tenant_id="t1",
+            target_user_id=str(target["_id"]),
+            new_role=UserRole.OWNER,
+            actor_user_id=str(actor["_id"]),
+            actor_role=UserRole.ADMIN,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.unit
+async def test_admin_cannot_demote_owner(service, collections):
+    users, _, _ = collections
+    actor = _seed_user(users, tenant_id="t1", role="admin", email="a@x")
+    owner = _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    with pytest.raises(TeamError) as exc:
+        await service.update_member_role(
+            tenant_id="t1",
+            target_user_id=str(owner["_id"]),
+            new_role=UserRole.MEMBER,
+            actor_user_id=str(actor["_id"]),
+            actor_role=UserRole.ADMIN,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.unit
+async def test_cannot_demote_last_owner(service, collections):
+    users, _, _ = collections
+    owner = _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    with pytest.raises(TeamError) as exc:
+        await service.update_member_role(
+            tenant_id="t1",
+            target_user_id=str(owner["_id"]),
+            new_role=UserRole.ADMIN,
+            actor_user_id=str(owner["_id"]),
+            actor_role=UserRole.OWNER,
+        )
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.unit
+async def test_can_demote_owner_when_more_than_one(service, collections):
+    users, _, _ = collections
+    o1 = _seed_user(users, tenant_id="t1", role="owner", email="o1@x")
+    o2 = _seed_user(users, tenant_id="t1", role="owner", email="o2@x")
+    updated = await service.update_member_role(
+        tenant_id="t1",
+        target_user_id=str(o2["_id"]),
+        new_role=UserRole.MEMBER,
+        actor_user_id=str(o1["_id"]),
+        actor_role=UserRole.OWNER,
+    )
+    assert updated["role"] == "member"
+
+
+@pytest.mark.unit
+async def test_cannot_remove_last_owner(service, collections):
+    users, _, _ = collections
+    owner = _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    with pytest.raises(TeamError) as exc:
+        await service.remove_member(
+            tenant_id="t1",
+            target_user_id=str(owner["_id"]),
+            actor_user_id=str(owner["_id"]),
+            actor_role=UserRole.OWNER,
+        )
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.unit
+async def test_member_in_other_tenant_not_visible(service, collections):
+    users, _, _ = collections
+    _seed_user(users, tenant_id="t1", role="owner", email="a@x")
+    _seed_user(users, tenant_id="t2", role="owner", email="b@x")
+    members = await service.list_members("t1")
+    assert len(members) == 1
+    assert members[0]["email"] == "a@x"
+
+
+@pytest.mark.unit
+async def test_remove_target_in_other_tenant_returns_false(service, collections):
+    users, _, _ = collections
+    _seed_user(users, tenant_id="t1", role="owner", email="o1@x")
+    other = _seed_user(users, tenant_id="t2", role="member", email="m@x")
+    removed = await service.remove_member(
+        tenant_id="t1",
+        target_user_id=str(other["_id"]),
+        actor_user_id="ignored",
+        actor_role=UserRole.OWNER,
+    )
+    assert removed is False
+    # Other-tenant doc was not touched.
+    assert any(d["_id"] == other["_id"] for d in users.docs)
+
+
+# --- Invitations ---
+
+
+@pytest.mark.unit
+async def test_admin_cannot_invite_owner(service, collections):
+    users, _, _ = collections
+    _seed_user(users, tenant_id="t1", role="admin", email="a@x")
+    with pytest.raises(TeamError) as exc:
+        await service.create_invitation(
+            tenant_id="t1",
+            email="new@x",
+            role=UserRole.OWNER,
+            invited_by_user_id="ignored",
+            actor_role=UserRole.ADMIN,
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.unit
+async def test_existing_member_cannot_be_invited(service, collections):
+    users, _, _ = collections
+    _seed_user(users, tenant_id="t1", role="member", email="exists@x")
+    with pytest.raises(TeamError) as exc:
+        await service.create_invitation(
+            tenant_id="t1",
+            email="exists@x",
+            role=UserRole.MEMBER,
+            invited_by_user_id="i",
+            actor_role=UserRole.OWNER,
+        )
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.unit
+async def test_invitation_token_is_hashed_at_rest(service, collections):
+    _, _, invites = collections
+    _, raw = await service.create_invitation(
+        tenant_id="t1",
+        email="new@x",
+        role=UserRole.MEMBER,
+        invited_by_user_id="i",
+        actor_role=UserRole.OWNER,
+    )
+    stored = invites.docs[0]
+    assert "raw_token" not in stored
+    assert "token" not in stored
+    expected = hashlib.sha256(raw.encode()).hexdigest()
+    assert stored["token_hash"] == expected
+
+
+@pytest.mark.unit
+async def test_invitation_accept_existing_user_email_must_match(service, collections):
+    users, _, _ = collections
+    inviter = _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    _seed_user(users, tenant_id="t2", role="owner", email="invited@x")
+    _, raw = await service.create_invitation(
+        tenant_id="t1",
+        email="invited@x",
+        role=UserRole.MEMBER,
+        invited_by_user_id=str(inviter["_id"]),
+        actor_role=UserRole.OWNER,
+    )
+
+    # Wrong-email accept path is rejected and invite stays pending.
+    with pytest.raises(TeamError) as exc:
+        await service.accept_invitation_existing_user(
+            raw_token=raw,
+            acting_user_id=str(inviter["_id"]),
+            acting_email="o@x",
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.unit
+async def test_invitation_accept_is_single_use(service, collections):
+    users, _, _ = collections
+    _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    invited = _seed_user(users, tenant_id="t2", role="member", email="invited@x")
+    _, raw = await service.create_invitation(
+        tenant_id="t1",
+        email="invited@x",
+        role=UserRole.MEMBER,
+        invited_by_user_id="o",
+        actor_role=UserRole.OWNER,
+    )
+    res = await service.accept_invitation_existing_user(
+        raw_token=raw,
+        acting_user_id=str(invited["_id"]),
+        acting_email="invited@x",
+    )
+    assert res["tenant_id"] == "t1"
+    with pytest.raises(TeamError) as exc:
+        await service.accept_invitation_existing_user(
+            raw_token=raw,
+            acting_user_id=str(invited["_id"]),
+            acting_email="invited@x",
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.unit
+async def test_invitation_expired_token_rejected(service, collections):
+    users, _, invites = collections
+    _seed_user(users, tenant_id="t1", role="owner", email="o@x")
+    _, raw = await service.create_invitation(
+        tenant_id="t1",
+        email="invited@x",
+        role=UserRole.MEMBER,
+        invited_by_user_id="o",
+        actor_role=UserRole.OWNER,
+    )
+    invites.docs[0]["expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    with pytest.raises(TeamError) as exc:
+        await service.accept_invitation_new_user(
+            raw_token=raw,
+            password="abcdefgh",
+            name="x",
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.unit
+async def test_invitation_unknown_token_returns_none_preview(service):
+    preview = await service.preview_invitation("not-a-real-token")
+    assert preview is None

--- a/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
+++ b/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
@@ -10,6 +10,7 @@ import {
   KeyRound,
   LayoutDashboard,
   Settings,
+  Users,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ const NAV_ITEMS: readonly NavItem[] = [
   { href: "/dashboard/documents", label: "Documents", icon: FileText },
   { href: "/dashboard/api-keys", label: "API Keys", icon: KeyRound },
   { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/dashboard/team", label: "Team", icon: Users },
   { href: "/dashboard/billing", label: "Billing", icon: CreditCard },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
 ] as const;

--- a/apps/web/app/(dashboard)/dashboard/team/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/team/actions.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  createInvitation,
+  removeMember,
+  revokeInvitation,
+  updateMemberRole,
+  type CreatedInvitation,
+  type TeamRole,
+} from "@/lib/team";
+import {
+  inviteMemberSchema,
+  updateMemberRoleSchema,
+} from "@/lib/validations/team";
+
+export type CreateInviteResult =
+  | { ok: true; data: CreatedInvitation }
+  | { ok: false; error: string };
+
+export type SimpleResult = { ok: true } | { ok: false; error: string };
+
+const PAGE_PATH = "/dashboard/team";
+
+export async function inviteMemberAction(
+  input: unknown,
+): Promise<CreateInviteResult> {
+  const parsed = inviteMemberSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+  try {
+    const data = await createInvitation(parsed.data);
+    revalidatePath(PAGE_PATH);
+    return { ok: true, data };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to create invitation" };
+  }
+}
+
+export async function revokeInvitationAction(
+  invitationId: string,
+): Promise<SimpleResult> {
+  if (!invitationId) return { ok: false, error: "Missing invitation id" };
+  try {
+    await revokeInvitation(invitationId);
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to revoke invitation" };
+  }
+}
+
+export async function updateMemberRoleAction(
+  input: unknown,
+): Promise<SimpleResult> {
+  const parsed = updateMemberRoleSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+  try {
+    await updateMemberRole({
+      userId: parsed.data.user_id,
+      role: parsed.data.role as TeamRole,
+    });
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to update role" };
+  }
+}
+
+export async function removeMemberAction(
+  userId: string,
+): Promise<SimpleResult> {
+  if (!userId) return { ok: false, error: "Missing user id" };
+  try {
+    await removeMember(userId);
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to remove member" };
+  }
+}

--- a/apps/web/app/(dashboard)/dashboard/team/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/team/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  getMe,
+  hasMinRole,
+  listInvitations,
+  listMembers,
+  type Invitation,
+  type Me,
+  type Member,
+} from "@/lib/team";
+
+import { TeamClient } from "./team-client";
+
+export const metadata: Metadata = {
+  title: "Team — MongoRAG",
+  description: "Invite teammates, manage roles, and revoke access.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function TeamPage() {
+  let initialError: string | null = null;
+  let me: Me | null = null;
+  let members: Member[] = [];
+  let invitations: Invitation[] = [];
+
+  try {
+    const [meRes, membersRes, invitationsRes] = await Promise.all([
+      getMe(),
+      listMembers(),
+      // Viewer / member don't have access; ignore failures gracefully.
+      listInvitations().catch(() => [] as Invitation[]),
+    ]);
+    me = meRes;
+    members = membersRes;
+    invitations = invitationsRes;
+  } catch (err) {
+    initialError =
+      err instanceof ApiError
+        ? err.message
+        : "Could not reach the API. Try again in a moment.";
+  }
+
+  const canManage = me ? hasMinRole(me.role, "admin") : false;
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-6 py-10">
+      <header className="space-y-1">
+        <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+          Workspace
+        </p>
+        <h1 className="font-heading text-2xl leading-tight font-medium tracking-tight">
+          Team
+        </h1>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          Invite teammates and decide how much access each of them should have.
+          Owners control billing and ownership; admins manage bots, documents,
+          and API keys.
+        </p>
+      </header>
+
+      {initialError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        >
+          {initialError}
+        </div>
+      ) : me ? (
+        <TeamClient
+          me={me}
+          canManage={canManage}
+          initialMembers={members}
+          initialInvitations={invitations}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/team/team-client.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Invitation, Me, Member, TeamRole } from "@/lib/team";
+
+import {
+  inviteMemberAction,
+  removeMemberAction,
+  revokeInvitationAction,
+  updateMemberRoleAction,
+} from "./actions";
+
+interface Props {
+  me: Me;
+  canManage: boolean;
+  initialMembers: Member[];
+  initialInvitations: Invitation[];
+}
+
+const ROLE_LABEL: Record<TeamRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+  viewer: "Viewer",
+};
+
+function roleVariant(
+  role: TeamRole,
+): "default" | "info" | "muted" | "success" | "warning" {
+  if (role === "owner") return "success";
+  if (role === "admin") return "info";
+  if (role === "member") return "default";
+  return "muted";
+}
+
+function rolesAssignableBy(actorRole: TeamRole): TeamRole[] {
+  // Owners can assign any role (including owner); admins cannot grant owner.
+  if (actorRole === "owner") return ["owner", "admin", "member", "viewer"];
+  if (actorRole === "admin") return ["admin", "member", "viewer"];
+  return [];
+}
+
+export function TeamClient({
+  me,
+  canManage,
+  initialMembers,
+  initialInvitations,
+}: Props) {
+  const [members, setMembers] = useState(initialMembers);
+  const [invitations, setInvitations] = useState(initialInvitations);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<TeamRole>("member");
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const meRole = me.role;
+  const assignable = rolesAssignableBy(meRole);
+  const pendingInvites = invitations.filter(
+    (i) => !i.accepted_at && !i.revoked_at,
+  );
+
+  function handleInvite() {
+    startTransition(async () => {
+      const r = await inviteMemberAction({
+        email: inviteEmail,
+        role: inviteRole,
+      });
+      if (!r.ok) {
+        toast.error(r.error);
+        return;
+      }
+      setInvitations((prev) => [r.data.invitation, ...prev]);
+      setInviteLink(r.data.accept_url);
+      setInviteEmail("");
+      setInviteRole("member");
+      setInviteOpen(false);
+    });
+  }
+
+  function handleRoleChange(m: Member, newRole: TeamRole) {
+    if (m.role === newRole) return;
+    startTransition(async () => {
+      const r = await updateMemberRoleAction({ user_id: m.id, role: newRole });
+      if (!r.ok) {
+        toast.error(r.error);
+        return;
+      }
+      setMembers((prev) =>
+        prev.map((x) => (x.id === m.id ? { ...x, role: newRole } : x)),
+      );
+      toast.success(`Updated ${m.email} to ${ROLE_LABEL[newRole]}`);
+    });
+  }
+
+  function handleRemove() {
+    if (!removeTarget) return;
+    const target = removeTarget;
+    startTransition(async () => {
+      const r = await removeMemberAction(target.id);
+      if (!r.ok) {
+        toast.error(r.error);
+        return;
+      }
+      setMembers((prev) => prev.filter((x) => x.id !== target.id));
+      toast.success(`Removed ${target.email}`);
+      setRemoveTarget(null);
+    });
+  }
+
+  function handleRevoke(invitationId: string) {
+    startTransition(async () => {
+      const r = await revokeInvitationAction(invitationId);
+      if (!r.ok) {
+        toast.error(r.error);
+        return;
+      }
+      setInvitations((prev) =>
+        prev.map((i) =>
+          i.id === invitationId
+            ? { ...i, revoked_at: new Date().toISOString() }
+            : i,
+        ),
+      );
+      toast.success("Invitation revoked");
+    });
+  }
+
+  return (
+    <section className="space-y-10">
+      <div className="space-y-4">
+        <div className="flex items-end justify-between gap-4">
+          <div className="space-y-1">
+            <h2 className="font-heading text-lg font-medium">Members</h2>
+            <p className="text-sm text-muted-foreground">
+              {members.length} {members.length === 1 ? "person" : "people"} on
+              this workspace.
+            </p>
+          </div>
+          {canManage ? (
+            <Button onClick={() => setInviteOpen(true)} disabled={isPending}>
+              <Plus />
+              Invite
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="rounded-lg border border-border/60">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead className="w-px text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((m) => {
+                const isSelf = m.id === me.user_id;
+                const canEditRole =
+                  canManage &&
+                  !isSelf &&
+                  // admins cannot change owner roles
+                  (m.role !== "owner" || meRole === "owner");
+                const canRemove =
+                  canManage &&
+                  !isSelf &&
+                  (m.role !== "owner" || meRole === "owner");
+                return (
+                  <TableRow key={m.id}>
+                    <TableCell className="font-medium">
+                      {m.email}
+                      {isSelf ? (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          you
+                        </span>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      {canEditRole ? (
+                        <Select
+                          value={m.role}
+                          onValueChange={(v) =>
+                            handleRoleChange(m, v as TeamRole)
+                          }
+                          disabled={isPending}
+                        >
+                          <SelectTrigger className="w-32">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {assignable.map((r) => (
+                              <SelectItem key={r} value={r}>
+                                {ROLE_LABEL[r]}
+                              </SelectItem>
+                            ))}
+                            {/* If current role is not assignable by actor, still surface it
+                                read-only so the value isn't blank. */}
+                            {!assignable.includes(m.role) ? (
+                              <SelectItem value={m.role} disabled>
+                                {ROLE_LABEL[m.role]}
+                              </SelectItem>
+                            ) : null}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <Badge variant={roleVariant(m.role)}>
+                          {ROLE_LABEL[m.role]}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {canRemove ? (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setRemoveTarget(m)}
+                          disabled={isPending}
+                          aria-label={`Remove ${m.email}`}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {canManage ? (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="font-heading text-lg font-medium">
+              Pending invitations
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              People who have been invited but have not joined yet.
+            </p>
+          </div>
+          {pendingInvites.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No pending invitations.
+            </p>
+          ) : (
+            <div className="rounded-lg border border-border/60">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead className="w-px text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {pendingInvites.map((i) => (
+                    <TableRow key={i.id}>
+                      <TableCell>{i.email}</TableCell>
+                      <TableCell>
+                        <Badge variant={roleVariant(i.role)}>
+                          {ROLE_LABEL[i.role]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {new Date(i.expires_at).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleRevoke(i.id)}
+                          disabled={isPending}
+                        >
+                          Revoke
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Invite teammate</DialogTitle>
+            <DialogDescription>
+              We&rsquo;ll generate a one-time link they can use to accept.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">Email</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="teammate@example.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-role">Role</Label>
+              <Select
+                value={inviteRole}
+                onValueChange={(v) => setInviteRole(v as TeamRole)}
+              >
+                <SelectTrigger id="invite-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {assignable.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {ROLE_LABEL[r]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setInviteOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleInvite}
+              disabled={isPending || !inviteEmail}
+            >
+              Send invitation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={inviteLink !== null}
+        onOpenChange={(o) => {
+          if (!o) setInviteLink(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Share this invitation link</DialogTitle>
+            <DialogDescription>
+              This is the only time this link will be shown. Send it to your
+              teammate over a secure channel.
+            </DialogDescription>
+          </DialogHeader>
+          {inviteLink ? (
+            <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs break-all select-all">
+              {inviteLink}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                if (inviteLink) {
+                  navigator.clipboard.writeText(inviteLink);
+                  toast.success("Copied to clipboard");
+                }
+              }}
+            >
+              Copy link
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={removeTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setRemoveTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove member?</DialogTitle>
+            <DialogDescription>
+              {removeTarget
+                ? `${removeTarget.email} will lose access immediately.`
+                : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setRemoveTarget(null)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRemove}
+              disabled={isPending}
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/app/api/invite/[token]/accept/route.ts
+++ b/apps/web/app/api/invite/[token]/accept/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Authenticated accept-invite proxy.
+ *
+ * The browser cannot mint the backend JWT (NEXTAUTH_SECRET is server-only),
+ * so it calls this route which forwards to the FastAPI accept endpoint with
+ * a freshly minted token tied to the current session.
+ */
+
+import { NextResponse } from "next/server";
+
+import { ApiError, apiFetch } from "@/lib/api-client";
+import { acceptInvitationAuthed } from "@/lib/team";
+
+interface RouteContext {
+  params: Promise<{ token: string }>;
+}
+
+export async function POST(_req: Request, context: RouteContext) {
+  const { token } = await context.params;
+  if (!token || token.length < 10) {
+    return NextResponse.json({ detail: "Invalid token" }, { status: 400 });
+  }
+
+  try {
+    const result = await acceptInvitationAuthed(token);
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      return NextResponse.json(
+        { detail: err.message },
+        { status: err.status },
+      );
+    }
+    return NextResponse.json(
+      { detail: "Could not accept invitation" },
+      { status: 500 },
+    );
+  }
+}
+
+// Keep apiFetch in the module graph for tree-shake-aware bundlers.
+void apiFetch;

--- a/apps/web/app/invite/[token]/accept-invite-client.tsx
+++ b/apps/web/app/invite/[token]/accept-invite-client.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+interface InvitePreview {
+  email: string;
+  role: "owner" | "admin" | "member" | "viewer";
+  organization_name: string;
+  expires_at: string;
+  requires_signup: boolean;
+}
+
+interface Props {
+  token: string;
+  preview: InvitePreview;
+  signedInEmail: string | null;
+}
+
+const ROLE_LABEL: Record<InvitePreview["role"], string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+  viewer: "Viewer",
+};
+
+export function AcceptInviteClient({ token, preview, signedInEmail }: Props) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+
+  const emailMismatch =
+    signedInEmail !== null &&
+    signedInEmail.toLowerCase() !== preview.email.toLowerCase();
+
+  async function acceptAsExistingUser() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/invite/${encodeURIComponent(token)}/accept`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { detail?: string };
+        toast.error(data.detail ?? "Could not accept invitation");
+        return;
+      }
+      toast.success("Welcome to the team");
+      router.push("/dashboard");
+      router.refresh();
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function acceptAsNewUser() {
+    if (password.length < 8) {
+      toast.error("Password must be at least 8 characters");
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/team/invitations/${encodeURIComponent(token)}/accept-signup`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token, password, name }),
+        },
+      );
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { detail?: string };
+        toast.error(data.detail ?? "Could not accept invitation");
+        return;
+      }
+      const signin = await signIn("credentials", {
+        email: preview.email,
+        password,
+        redirect: false,
+      });
+      if (signin?.error) {
+        toast.error("Account created but sign-in failed; please log in");
+        router.push("/login");
+        return;
+      }
+      toast.success("Welcome to the team");
+      router.push("/dashboard");
+      router.refresh();
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <main className="flex min-h-svh items-center justify-center px-6 py-12">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Join {preview.organization_name || "the team"}</CardTitle>
+          <CardDescription>
+            You&rsquo;ve been invited to join as a{" "}
+            <strong>{ROLE_LABEL[preview.role]}</strong>. The invitation was
+            issued to <strong>{preview.email}</strong>.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {emailMismatch ? (
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            >
+              You&rsquo;re signed in as {signedInEmail}. Sign out and accept
+              with {preview.email} to continue.
+            </div>
+          ) : signedInEmail !== null ? (
+            <p className="text-sm text-muted-foreground">
+              You&rsquo;re already signed in as {signedInEmail}. Accepting will
+              move your account to this workspace.
+            </p>
+          ) : preview.requires_signup ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="invite-name">Your name</Label>
+                <Input
+                  id="invite-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Alex Doe"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="invite-password">Choose a password</Label>
+                <Input
+                  id="invite-password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="At least 8 characters"
+                />
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              An account already exists for {preview.email}.{" "}
+              <Link href="/login" className="underline">
+                Sign in
+              </Link>{" "}
+              to accept this invitation.
+            </p>
+          )}
+        </CardContent>
+
+        <CardFooter className="flex justify-end gap-2">
+          {emailMismatch ? (
+            <Link
+              href="/login"
+              className={cn(buttonVariants({ variant: "outline" }))}
+            >
+              Switch account
+            </Link>
+          ) : signedInEmail !== null ? (
+            <Button onClick={acceptAsExistingUser} disabled={isLoading}>
+              Accept invitation
+            </Button>
+          ) : preview.requires_signup ? (
+            <Button onClick={acceptAsNewUser} disabled={isLoading}>
+              Create account &amp; join
+            </Button>
+          ) : null}
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/app/invite/[token]/page.tsx
+++ b/apps/web/app/invite/[token]/page.tsx
@@ -1,0 +1,56 @@
+import { notFound } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+
+import { AcceptInviteClient } from "./accept-invite-client";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100";
+
+interface InvitePreview {
+  email: string;
+  role: "owner" | "admin" | "member" | "viewer";
+  organization_name: string;
+  expires_at: string;
+  requires_signup: boolean;
+}
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default async function InvitePage({ params }: PageProps) {
+  const { token } = await params;
+
+  // Server-side preview — non-sensitive, prevents the client from
+  // hammering an unknown token endlessly.
+  const res = await fetch(
+    `${API_URL}/api/v1/team/invitations/${encodeURIComponent(token)}/preview`,
+    { cache: "no-store" },
+  );
+  if (res.status === 404) {
+    notFound();
+  }
+  if (!res.ok) {
+    return (
+      <main className="flex min-h-svh items-center justify-center px-6">
+        <p className="text-sm text-destructive">
+          Could not load this invitation. Please try again later.
+        </p>
+      </main>
+    );
+  }
+  const preview = (await res.json()) as InvitePreview;
+
+  const session = await auth();
+  const signedInEmail = session?.user?.email ?? null;
+
+  return (
+    <AcceptInviteClient
+      token={token}
+      preview={preview}
+      signedInEmail={signedInEmail}
+    />
+  );
+}

--- a/apps/web/lib/team.ts
+++ b/apps/web/lib/team.ts
@@ -1,0 +1,119 @@
+/**
+ * Typed client for the FastAPI /api/v1/team endpoints.
+ *
+ * Server-only — these helpers mint a backend JWT.
+ */
+
+import "server-only";
+
+import { apiFetch } from "@/lib/api-client";
+
+export type TeamRole = "owner" | "admin" | "member" | "viewer";
+
+export const ROLE_RANK: Record<TeamRole, number> = {
+  viewer: 0,
+  member: 1,
+  admin: 2,
+  owner: 3,
+};
+
+export function hasMinRole(role: TeamRole | string, min: TeamRole): boolean {
+  const a = ROLE_RANK[role as TeamRole];
+  const b = ROLE_RANK[min];
+  if (a === undefined) return false;
+  return a >= b;
+}
+
+export interface Member {
+  id: string;
+  email: string;
+  name: string;
+  role: TeamRole;
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface Invitation {
+  id: string;
+  email: string;
+  role: TeamRole;
+  expires_at: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export interface CreatedInvitation {
+  invitation: Invitation;
+  accept_url: string;
+}
+
+export interface Me {
+  user_id: string;
+  tenant_id: string;
+  email: string;
+  name: string;
+  role: TeamRole;
+}
+
+export async function getMe(): Promise<Me> {
+  return apiFetch<Me>("/api/v1/auth/me");
+}
+
+export async function listMembers(): Promise<Member[]> {
+  const r = await apiFetch<{ members: Member[] }>("/api/v1/team/members");
+  return r.members;
+}
+
+export async function listInvitations(): Promise<Invitation[]> {
+  const r = await apiFetch<{ invitations: Invitation[] }>(
+    "/api/v1/team/invitations",
+  );
+  return r.invitations;
+}
+
+export async function createInvitation(input: {
+  email: string;
+  role: TeamRole;
+}): Promise<CreatedInvitation> {
+  return apiFetch<CreatedInvitation>("/api/v1/team/invitations", {
+    method: "POST",
+    body: input,
+  });
+}
+
+export async function revokeInvitation(invitationId: string): Promise<void> {
+  await apiFetch<{ message: string }>(
+    `/api/v1/team/invitations/${invitationId}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function updateMemberRole(input: {
+  userId: string;
+  role: TeamRole;
+}): Promise<Member> {
+  return apiFetch<Member>(`/api/v1/team/members/${input.userId}`, {
+    method: "PATCH",
+    body: { role: input.role },
+  });
+}
+
+export async function removeMember(userId: string): Promise<void> {
+  await apiFetch<{ message: string }>(`/api/v1/team/members/${userId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function acceptInvitationAuthed(token: string): Promise<{
+  user_id: string;
+  tenant_id: string;
+  role: TeamRole;
+  email: string;
+  name: string;
+}> {
+  return apiFetch(`/api/v1/team/invitations/${token}/accept`, {
+    method: "POST",
+    body: { token },
+  });
+}

--- a/apps/web/lib/validations/team.ts
+++ b/apps/web/lib/validations/team.ts
@@ -1,0 +1,15 @@
+import { z } from "zod/v3";
+
+export const teamRoles = ["owner", "admin", "member", "viewer"] as const;
+
+export const inviteMemberSchema = z.object({
+  email: z.string().email("Enter a valid email"),
+  role: z.enum(teamRoles).default("member"),
+});
+
+export type InviteMemberFormData = z.infer<typeof inviteMemberSchema>;
+
+export const updateMemberRoleSchema = z.object({
+  user_id: z.string().min(1),
+  role: z.enum(teamRoles),
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -11,12 +11,19 @@ const authRoutes = ["/login", "/signup", "/forgot-password", "/reset-password"];
 // Marketing routes are public and never trigger auth redirects.
 const marketingRoutes = ["/", "/pricing"];
 
+// Public path prefixes — accessible without auth, no auto-redirect either way.
+const publicRoutePrefixes = ["/invite/"];
+
 function isMarketingPath(pathname: string): boolean {
   if (marketingRoutes.includes(pathname)) return true;
   // Allow generated SEO files served from app/ (sitemap.ts, robots.ts, opengraph-image.tsx).
   if (pathname === "/sitemap.xml" || pathname === "/robots.txt") return true;
   if (pathname.startsWith("/opengraph-image")) return true;
   return false;
+}
+
+function isPublicPrefix(pathname: string): boolean {
+  return publicRoutePrefixes.some((p) => pathname.startsWith(p));
 }
 
 function withRequestId(response: NextResponse, requestId: string): NextResponse {
@@ -45,7 +52,8 @@ export default auth((req) => {
     return withRequestId(NextResponse.next(), requestId);
   }
 
-  // Redirect authenticated users away from auth pages
+  // Redirect authenticated users away from auth pages, but NOT from
+  // public-prefix paths like /invite/* (signed-in users may still need to accept).
   if (isAuthenticated && authRoutes.includes(pathname)) {
     return withRequestId(
       NextResponse.redirect(new URL("/dashboard", req.url)),
@@ -53,8 +61,12 @@ export default auth((req) => {
     );
   }
 
-  // Redirect unauthenticated users to login
-  if (!isAuthenticated && !authRoutes.includes(pathname)) {
+  // Redirect unauthenticated users to login, except for public paths.
+  if (
+    !isAuthenticated &&
+    !authRoutes.includes(pathname) &&
+    !isPublicPrefix(pathname)
+  ) {
     return withRequestId(
       NextResponse.redirect(new URL("/login", req.url)),
       requestId,


### PR DESCRIPTION
## Summary

Adds owner / admin / member / viewer roles, team management UI, and a hashed-token invitation system.

- `require_role(min)` FastAPI dependency extracts a Principal from the dashboard JWT, rejects API keys for management endpoints
- New `/api/v1/team` endpoints for members + invitations (create, list, revoke, preview, accept-existing, accept-signup)
- Invitations are SHA-256 hashed at rest, single-use via atomic claim, TTL-bound, and IP rate-limited on signup-accept
- Last-owner protection (with recheck-after-write to close the concurrent-demotion race) on both demotion and removal
- `/api/v1/auth/me` re-reads role from MongoDB so stale JWTs cannot escalate
- Existing routers tightened: bots/keys CRUD → admin+, bots read → viewer+, billing checkout → owner-only
- New `/dashboard/team` page (members + invitations) and public `/invite/[token]` accept page with email-mismatch detection
- 22 new unit tests cover the authz dep and TeamService invariants (privilege escalation, last-owner, IDOR, expired/single-use tokens, hashed-at-rest)

Closes #29

## Test plan

- [x] `uv run pytest tests/test_authz.py tests/test_team_service.py tests/test_database_indexes.py tests/test_billing_router.py tests/test_api_key_router.py tests/test_bot_router.py tests/test_auth_router.py` — 65 passed
- [x] `uv run ruff check .` — clean
- [x] `pnpm lint && pnpm tsc --noEmit` — clean
- [ ] Manual flow: owner invites admin -> admin invites member -> member accepts new-user signup
- [ ] Manual flow: admin tries to demote owner -> 403; sole owner tries to demote self -> 409
- [ ] Manual flow: revoked invite cannot be accepted; expired invite cannot be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)