### PR TITLE
feat(auth): wire Supabase JWT verification into FastAPI backend

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,8 +33,15 @@ DEFAULT_TEXT_WEIGHT=0.3
 # Supabase
 # Server-only — bypasses RLS. Never expose to the browser.
 SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_PROJECT_REF=your-project-ref
 SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 SUPABASE_SECRET_KEY=sb_secret_...
+# JWT verification — when SUPABASE_URL is set, the API accepts Supabase user JWTs
+# alongside legacy NextAuth tokens. Routing is by `iss` (no fall-through).
+# Optional shared HS256 secret. When omitted, verification uses the JWKS endpoint.
+SUPABASE_JWT_SECRET=
+SUPABASE_JWT_AUDIENCE=authenticated
+SUPABASE_JWKS_CACHE_SECONDS=3600
 
 # Application Settings
 APP_ENV=development

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -231,6 +231,68 @@ class Settings(BaseSettings):
         ..., description="Shared secret for JWT signing (same as NEXTAUTH_SECRET in frontend)"
     )
 
+    # --- Supabase Auth ---
+    # The backend verifies Supabase-issued JWTs. Verification path:
+    # 1. If a SUPABASE_JWT_SECRET is configured AND the token is HS256 → verify with shared secret
+    # 2. Otherwise (RS256/ES256/etc.) → fetch & cache JWKS from
+    #    https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json and verify by `kid`
+    # Issuer / audience are pinned from these settings, never from the token itself.
+    supabase_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Supabase project URL, e.g. https://<project-ref>.supabase.co. "
+            "When set, Supabase JWTs are accepted and the backend pins the expected issuer "
+            "to <supabase_url>/auth/v1."
+        ),
+    )
+
+    supabase_project_ref: Optional[str] = Field(
+        default=None,
+        description=(
+            "Supabase project ref (shorthand). Optional — derived from supabase_url when omitted."
+        ),
+    )
+
+    supabase_jwt_secret: Optional[str] = Field(
+        default=None,
+        description=(
+            "Supabase legacy HS256 shared JWT secret. Optional — when omitted, the backend "
+            "verifies via the project's JWKS endpoint. Server-only; never expose to clients."
+        ),
+    )
+
+    supabase_jwt_audience: str = Field(
+        default="authenticated",
+        description=(
+            "Expected `aud` claim on Supabase user JWTs. Defaults to 'authenticated' "
+            "(Supabase's standard for signed-in users)."
+        ),
+    )
+
+    supabase_jwks_cache_seconds: int = Field(
+        default=3600,
+        ge=60,
+        le=86400,
+        description="How long to cache the Supabase JWKS document (seconds).",
+    )
+
+    @property
+    def supabase_issuer(self) -> Optional[str]:
+        """Expected `iss` claim for Supabase-signed user JWTs.
+
+        Returns None when Supabase is not configured (Supabase auth disabled).
+        """
+        if not self.supabase_url:
+            return None
+        return f"{self.supabase_url.rstrip('/')}/auth/v1"
+
+    @property
+    def supabase_jwks_url(self) -> Optional[str]:
+        """JWKS endpoint URL for the configured Supabase project."""
+        if not self.supabase_url:
+            return None
+        return f"{self.supabase_url.rstrip('/')}/auth/v1/.well-known/jwks.json"
+
     resend_api_key: Optional[str] = Field(
         default=None,
         description="Resend API key for transactional emails (required for password reset)",

--- a/apps/api/src/core/supabase_auth.py
+++ b/apps/api/src/core/supabase_auth.py
@@ -1,0 +1,249 @@
+"""Supabase JWT verification.
+
+Verifies Supabase-issued user JWTs against the project's JWKS endpoint, with
+an optional fallback to the legacy HS256 shared secret. Issuer (`iss`) and
+audience (`aud`) are pinned by configuration — they are never trusted from
+the token's own header.
+
+Verification rules:
+    * `alg` must come from a strict allow-list (no `none`, no algorithm
+      confusion via header tampering).
+    * Asymmetric tokens are verified against the JWKS key whose `kid`
+      matches the token header. JWKS is fetched once and cached in-process
+      for `settings.supabase_jwks_cache_seconds` seconds.
+    * `iss`, `aud`, and `exp` are required and validated against settings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+from jose import jwt
+from jose.exceptions import JWTError
+
+from src.core.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+# Algorithms accepted for Supabase JWTs. `none` is intentionally absent — it
+# would let an attacker forge a token by stripping the signature.
+_ASYMMETRIC_ALGS = ("RS256", "RS384", "RS512", "ES256", "ES384", "ES512")
+_SYMMETRIC_ALGS = ("HS256",)
+
+
+@dataclass
+class SupabaseClaims:
+    """The minimal set of claims we extract from a verified Supabase JWT."""
+
+    sub: str
+    email: Optional[str]
+    tenant_id: Optional[str]
+    raw: dict[str, Any]
+
+
+class _JWKSCache:
+    """In-process JWKS cache with TTL and concurrency protection.
+
+    A single shared lock prevents multiple concurrent requests from
+    stampeding the JWKS endpoint after expiry.
+    """
+
+    def __init__(self) -> None:
+        self._jwks: Optional[dict[str, Any]] = None
+        self._fetched_at: float = 0.0
+        self._url: Optional[str] = None
+        self._lock = asyncio.Lock()
+
+    async def get(self, url: str, ttl_seconds: int) -> dict[str, Any]:
+        now = time.monotonic()
+        if (
+            self._jwks is not None
+            and self._url == url
+            and now - self._fetched_at < ttl_seconds
+        ):
+            return self._jwks
+
+        async with self._lock:
+            now = time.monotonic()
+            if (
+                self._jwks is not None
+                and self._url == url
+                and now - self._fetched_at < ttl_seconds
+            ):
+                return self._jwks
+
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                jwks = resp.json()
+            if not isinstance(jwks, dict) or "keys" not in jwks:
+                raise ValueError("Invalid JWKS document: missing 'keys'")
+            self._jwks = jwks
+            self._url = url
+            self._fetched_at = time.monotonic()
+            return jwks
+
+    def invalidate(self) -> None:
+        self._jwks = None
+        self._fetched_at = 0.0
+        self._url = None
+
+
+_jwks_cache = _JWKSCache()
+
+
+def reset_jwks_cache() -> None:
+    """Test hook — reset the module-level JWKS cache."""
+    _jwks_cache.invalidate()
+
+
+def _looks_like_supabase_token(token: str, settings: Settings) -> bool:
+    """Cheap pre-check before full verification.
+
+    Decodes the unverified payload to peek at `iss`. If it matches the
+    configured Supabase issuer, this is a Supabase token. Used only to route
+    between the legacy NextAuth path and the Supabase path; the real
+    verification happens in `verify_supabase_jwt`.
+    """
+    if not settings.supabase_issuer:
+        return False
+    try:
+        unverified = jwt.get_unverified_claims(token)
+    except JWTError:
+        return False
+    iss = unverified.get("iss")
+    return isinstance(iss, str) and iss == settings.supabase_issuer
+
+
+async def verify_supabase_jwt(token: str, settings: Settings) -> SupabaseClaims:
+    """Verify a Supabase JWT and extract the claims we care about.
+
+    Args:
+        token: The raw JWT string from the Authorization header.
+        settings: Application settings (must have Supabase configured).
+
+    Returns:
+        SupabaseClaims with `sub`, optional `email`, optional `tenant_id`.
+
+    Raises:
+        ValueError: On any verification failure (invalid signature, wrong
+            issuer/audience, expired, missing claims, JWKS fetch failure).
+            Messages are intentionally generic — never echo crypto detail
+            back to the caller.
+    """
+    if not settings.supabase_issuer:
+        raise ValueError("Supabase auth is not configured")
+
+    # Read header WITHOUT trusting it for verification — we only use `alg`
+    # and `kid` to pick the verification path/key, and we constrain `alg`
+    # against a strict allow-list below.
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError:
+        raise ValueError("Malformed token") from None
+
+    alg = header.get("alg")
+    if not isinstance(alg, str):
+        raise ValueError("Token header missing alg")
+
+    decode_kwargs: dict[str, Any] = {
+        "audience": settings.supabase_jwt_audience,
+        "issuer": settings.supabase_issuer,
+        "options": {
+            "verify_signature": True,
+            "verify_aud": True,
+            "verify_iss": True,
+            "verify_exp": True,
+            "require_exp": True,
+        },
+    }
+
+    if alg in _SYMMETRIC_ALGS:
+        if not settings.supabase_jwt_secret:
+            # Token claims to be HS256 but no shared secret configured →
+            # likely an alg-confusion attempt against an asymmetric setup.
+            raise ValueError("Symmetric algorithm not enabled for this project")
+        key: Any = settings.supabase_jwt_secret
+        algorithms = list(_SYMMETRIC_ALGS)
+    elif alg in _ASYMMETRIC_ALGS:
+        if not settings.supabase_jwks_url:
+            raise ValueError("JWKS not available for this project")
+        kid = header.get("kid")
+        if not kid:
+            raise ValueError("Token header missing kid")
+
+        jwks = await _jwks_cache.get(
+            settings.supabase_jwks_url, settings.supabase_jwks_cache_seconds
+        )
+        key = _select_jwk(jwks, kid)
+        if key is None:
+            # Possible key rotation — invalidate and retry once.
+            _jwks_cache.invalidate()
+            jwks = await _jwks_cache.get(
+                settings.supabase_jwks_url, settings.supabase_jwks_cache_seconds
+            )
+            key = _select_jwk(jwks, kid)
+        if key is None:
+            raise ValueError("Unknown signing key")
+
+        # Restrict algorithm verification to the JWK's declared alg if present;
+        # otherwise allow the full asymmetric set. Either way, `none` is impossible.
+        jwk_alg = key.get("alg") if isinstance(key, dict) else None
+        if isinstance(jwk_alg, str) and jwk_alg in _ASYMMETRIC_ALGS:
+            algorithms = [jwk_alg]
+        else:
+            algorithms = list(_ASYMMETRIC_ALGS)
+    else:
+        raise ValueError("Unsupported token algorithm")
+
+    try:
+        payload = jwt.decode(token, key, algorithms=algorithms, **decode_kwargs)
+    except JWTError:
+        # Do not surface crypto errors. Log at debug for ops.
+        logger.debug("Supabase JWT verification failed", exc_info=True)
+        raise ValueError("Invalid or expired token") from None
+
+    sub = payload.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise ValueError("Token missing sub claim")
+
+    email = payload.get("email") if isinstance(payload.get("email"), str) else None
+    tenant_id = _extract_tenant_id(payload)
+
+    return SupabaseClaims(sub=sub, email=email, tenant_id=tenant_id, raw=payload)
+
+
+def _select_jwk(jwks: dict[str, Any], kid: str) -> Optional[dict[str, Any]]:
+    """Find the JWK whose `kid` matches the token header."""
+    for entry in jwks.get("keys", []):
+        if isinstance(entry, dict) and entry.get("kid") == kid:
+            return entry
+    return None
+
+
+def _extract_tenant_id(payload: dict[str, Any]) -> Optional[str]:
+    """Pull `tenant_id` from the standard Supabase metadata locations.
+
+    Looks in this order:
+        1. top-level `tenant_id`
+        2. `app_metadata.tenant_id` (server-controlled — preferred)
+        3. `user_metadata.tenant_id` (user-editable — accepted as a fallback
+           but should not be the source of truth in production)
+    """
+    direct = payload.get("tenant_id")
+    if isinstance(direct, str) and direct:
+        return direct
+
+    for bucket in ("app_metadata", "user_metadata"):
+        meta = payload.get(bucket)
+        if isinstance(meta, dict):
+            tid = meta.get("tenant_id")
+            if isinstance(tid, str) and tid:
+                return tid
+
+    return None

--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -1,4 +1,18 @@
-"""Tenant extraction from JWT or API key."""
+"""Tenant extraction from JWT or API key.
+
+Three supported credential formats on `Authorization: Bearer <token>`:
+
+1. `mrag_...` API key — hashed and looked up in the api_keys collection.
+2. Supabase user JWT — verified via JWKS or a configured shared secret;
+   `tenant_id` is taken from claims or, as a fallback, derived from the
+   user document keyed by Supabase `sub`.
+3. Legacy NextAuth.js JWT — verified with the shared `nextauth_secret`.
+
+Routing between (2) and (3) is done by a cheap `iss` peek before
+verification. Verification of each path is independent: failure on the
+Supabase path never falls through to the NextAuth path on the same token,
+which avoids algorithm-confusion / fall-through bypasses.
+"""
 
 import hashlib
 import logging
@@ -11,7 +25,12 @@ from src.core.dependencies import AgentDependencies
 from src.core.deps import get_deps
 from src.core.observability import set_request_context
 from src.core.security import decode_jwt
-from src.core.settings import load_settings
+from src.core.settings import Settings, load_settings
+from src.core.supabase_auth import (
+    SupabaseClaims,
+    _looks_like_supabase_token,
+    verify_supabase_jwt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +43,6 @@ async def get_tenant_id(
     deps: AgentDependencies = Depends(get_deps),
 ) -> str:
     """Extract tenant_id from JWT or API key in the Authorization header.
-
-    Detects auth method by the 'mrag_' prefix:
-    - 'mrag_...' → API key path (hash and look up in api_keys collection)
-    - Otherwise → JWT path (decode with nextauth_secret)
 
     Args:
         request: The incoming request (used to set tenant context on state).
@@ -51,7 +66,7 @@ async def get_tenant_id(
     if token.startswith(_API_KEY_PREFIX):
         tenant_id = await _resolve_api_key(token, deps)
     else:
-        tenant_id = _resolve_jwt(token)
+        tenant_id = await _resolve_jwt(token, deps)
 
     request.state.tenant_id = tenant_id
     set_request_context(tenant_id=tenant_id)
@@ -59,18 +74,7 @@ async def get_tenant_id(
 
 
 async def _resolve_api_key(raw_key: str, deps: AgentDependencies) -> str:
-    """Validate an API key and return its tenant_id.
-
-    Args:
-        raw_key: The full API key string (mrag_...).
-        deps: Application dependencies for DB access.
-
-    Returns:
-        tenant_id from the API key document.
-
-    Raises:
-        HTTPException: 401 if key is invalid or revoked.
-    """
+    """Validate an API key and return its tenant_id."""
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
     doc = await deps.api_keys_collection.find_one({"key_hash": key_hash})
 
@@ -80,7 +84,6 @@ async def _resolve_api_key(raw_key: str, deps: AgentDependencies) -> str:
     if doc.get("is_revoked", False):
         raise HTTPException(status_code=401, detail="API key has been revoked")
 
-    # Update last_used_at (blocking at MVP scale; optimize if needed)
     await deps.api_keys_collection.update_one(
         {"key_hash": key_hash},
         {"$set": {"last_used_at": datetime.now(timezone.utc)}},
@@ -92,21 +95,12 @@ async def _resolve_api_key(raw_key: str, deps: AgentDependencies) -> str:
 async def get_tenant_id_from_jwt(
     request: Request,
     authorization: Optional[str] = Header(default=None),
+    deps: AgentDependencies = Depends(get_deps),
 ) -> str:
     """Extract tenant_id from JWT only. Rejects API keys.
 
-    Use this for endpoints that must only be accessible via dashboard
-    sessions (e.g., key management), not via API keys.
-
-    Args:
-        request: The incoming request (used to set tenant context on state).
-        authorization: Authorization header value.
-
-    Returns:
-        Validated tenant_id string.
-
-    Raises:
-        HTTPException: 401 if token is missing, invalid, or an API key.
+    Used by endpoints that must only be reachable from a dashboard session
+    (e.g., key management), not from a programmatic API key.
     """
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
@@ -114,7 +108,7 @@ async def get_tenant_id_from_jwt(
             detail="Authorization header with Bearer token is required",
         )
 
-    token = authorization[7:]  # Strip "Bearer "
+    token = authorization[7:]
 
     if token.startswith(_API_KEY_PREFIX):
         raise HTTPException(
@@ -122,27 +116,38 @@ async def get_tenant_id_from_jwt(
             detail="API keys cannot access this endpoint",
         )
 
-    tenant_id = _resolve_jwt(token)
+    tenant_id = await _resolve_jwt(token, deps)
     request.state.tenant_id = tenant_id
     set_request_context(tenant_id=tenant_id)
     return tenant_id
 
 
-def _resolve_jwt(token: str) -> str:
-    """Validate a JWT and return its tenant_id.
+async def _resolve_jwt(token: str, deps: AgentDependencies) -> str:
+    """Validate a JWT (Supabase or legacy NextAuth) and return its tenant_id.
 
-    Args:
-        token: JWT token string.
-
-    Returns:
-        tenant_id from the JWT payload.
-
-    Raises:
-        HTTPException: 401 if token is invalid or lacks tenant_id.
+    Routing rule: if the token's unverified `iss` matches the configured
+    Supabase issuer, only the Supabase path is tried. Otherwise only the
+    NextAuth path is tried. **No fall-through** between paths — a Supabase
+    token with a bad signature must NOT fall back to HS256/NextAuth
+    verification (algorithm-confusion guard).
     """
-    settings = load_settings()
-    payload = decode_jwt(token, settings.nextauth_secret)
+    settings = deps.settings if isinstance(deps.settings, Settings) else load_settings()
 
+    if _looks_like_supabase_token(token, settings):
+        try:
+            claims = await verify_supabase_jwt(token, settings)
+        except ValueError as e:
+            logger.debug("Supabase JWT rejected: %s", e)
+            raise HTTPException(status_code=401, detail="Invalid or expired token") from None
+        return await _tenant_id_from_supabase_claims(claims, deps)
+
+    # Legacy NextAuth path
+    return _resolve_nextauth_jwt(token, settings)
+
+
+def _resolve_nextauth_jwt(token: str, settings: Settings) -> str:
+    """Verify a legacy NextAuth-issued JWT (HS256 with the shared secret)."""
+    payload = decode_jwt(token, settings.nextauth_secret)
     if not payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
@@ -151,3 +156,35 @@ def _resolve_jwt(token: str) -> str:
         raise HTTPException(status_code=401, detail="Token missing tenant_id claim")
 
     return tenant_id
+
+
+async def _tenant_id_from_supabase_claims(
+    claims: SupabaseClaims, deps: AgentDependencies
+) -> str:
+    """Resolve tenant_id from Supabase claims, falling back to a DB lookup.
+
+    Order of preference:
+        1. `tenant_id` from claims (server-controlled `app_metadata` is best).
+        2. Lookup in the `users` collection by `supabase_user_id` (the JWT `sub`).
+        3. As a last resort, lookup by email.
+
+    Fail-closed: if no tenant_id can be determined, raise 401.
+    """
+    if claims.tenant_id:
+        return claims.tenant_id
+
+    users = deps.users_collection
+    user_doc = await users.find_one({"supabase_user_id": claims.sub})
+    if not user_doc and claims.email:
+        user_doc = await users.find_one({"email": claims.email.lower()})
+
+    tenant_id = user_doc.get("tenant_id") if user_doc else None
+    if not tenant_id:
+        logger.info(
+            "supabase_user_without_tenant",
+            extra={"sub": claims.sub, "has_email": claims.email is not None},
+        )
+        raise HTTPException(status_code=401, detail="User has no tenant assigned")
+    return tenant_id
+
+

--- a/apps/api/tests/test_supabase_auth.py
+++ b/apps/api/tests/test_supabase_auth.py
@@ -1,0 +1,429 @@
+"""Unit tests for Supabase JWT verification + tenant routing."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from jose import jwt as jose_jwt
+
+from src.core.settings import Settings
+from src.core.supabase_auth import reset_jwks_cache, verify_supabase_jwt
+from tests.conftest import JWT_SECRET, MOCK_TENANT_ID
+
+PROJECT_REF = "vmuybfmxermgwhmhevou"
+SUPABASE_URL = f"https://{PROJECT_REF}.supabase.co"
+ISSUER = f"{SUPABASE_URL}/auth/v1"
+AUDIENCE = "authenticated"
+
+
+def _make_settings(**overrides) -> Settings:
+    """Build a Settings object with Supabase + required defaults."""
+    base = dict(
+        mongodb_uri="mongodb://localhost:27017/mongorag-test",
+        llm_api_key="test",
+        embedding_api_key="test",
+        nextauth_secret=JWT_SECRET,
+        supabase_url=SUPABASE_URL,
+        supabase_project_ref=PROJECT_REF,
+        supabase_jwt_audience=AUDIENCE,
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _supabase_hs256_token(secret: str, **claims) -> str:
+    payload = {
+        "sub": "supabase-user-1",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "exp": int(time.time()) + 600,
+        "email": "user@example.com",
+    }
+    payload.update(claims)
+    return jose_jwt.encode(payload, secret, algorithm="HS256")
+
+
+# ---------------------------------------------------------------------------
+# Direct verifier tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_valid_hs256_supabase_token_extracts_claims():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        app_metadata={"tenant_id": MOCK_TENANT_ID},
+    )
+
+    claims = await verify_supabase_jwt(token, settings)
+
+    assert claims.sub == "supabase-user-1"
+    assert claims.email == "user@example.com"
+    assert claims.tenant_id == MOCK_TENANT_ID
+
+
+@pytest.mark.unit
+async def test_invalid_signature_rejected():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token("a-different-secret-that-doesnt-match!!")
+
+    with pytest.raises(ValueError, match="Invalid or expired token"):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_expired_token_rejected():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        exp=int(time.time()) - 60,
+    )
+
+    with pytest.raises(ValueError, match="Invalid or expired token"):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_wrong_audience_rejected():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        aud="some-other-audience",
+    )
+
+    with pytest.raises(ValueError, match="Invalid or expired token"):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_wrong_issuer_rejected():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        iss="https://attacker.example.com/auth/v1",
+    )
+
+    with pytest.raises(ValueError, match="Invalid or expired token"):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_alg_none_rejected():
+    """alg=none must never validate, even if the token has Supabase claims."""
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    # python-jose refuses to encode with `none` unless explicitly enabled, so we
+    # craft the token manually.
+    import base64
+    import json
+
+    def _b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = _b64(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    payload = _b64(
+        json.dumps(
+            {
+                "sub": "attacker",
+                "iss": ISSUER,
+                "aud": AUDIENCE,
+                "exp": int(time.time()) + 600,
+            }
+        ).encode()
+    )
+    token = f"{header}.{payload}."
+
+    with pytest.raises(ValueError):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_hs256_token_without_configured_secret_rejected():
+    """If only JWKS is configured, an HS256 token must not be accepted via the
+    asymmetric path (algorithm-confusion guard)."""
+    settings = _make_settings()  # no supabase_jwt_secret
+    token = _supabase_hs256_token("anything-goes")
+
+    with pytest.raises(ValueError, match="Symmetric algorithm not enabled"):
+        await verify_supabase_jwt(token, settings)
+
+
+@pytest.mark.unit
+async def test_tenant_id_falls_back_to_user_metadata():
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        user_metadata={"tenant_id": "from-user-metadata"},
+    )
+
+    claims = await verify_supabase_jwt(token, settings)
+    assert claims.tenant_id == "from-user-metadata"
+
+
+@pytest.mark.unit
+async def test_app_metadata_wins_over_user_metadata():
+    """app_metadata is server-controlled and must be preferred."""
+    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        app_metadata={"tenant_id": "from-app-metadata"},
+        user_metadata={"tenant_id": "user-supplied"},
+    )
+
+    claims = await verify_supabase_jwt(token, settings)
+    assert claims.tenant_id == "from-app-metadata"
+
+
+# ---------------------------------------------------------------------------
+# JWKS path
+# ---------------------------------------------------------------------------
+
+
+def _rsa_jwk(private_key, kid: str) -> tuple[str, dict]:
+    """Return (private_pem, public_jwk) for an RS256 signing key."""
+    from cryptography.hazmat.primitives import serialization
+    from jose.utils import long_to_base64
+
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    pub = private_key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": long_to_base64(pub.n).decode(),
+        "e": long_to_base64(pub.e).decode(),
+    }
+    return pem, jwk
+
+
+@pytest.mark.unit
+async def test_rs256_token_verified_via_jwks(monkeypatch):
+    reset_jwks_cache()
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem, jwk = _rsa_jwk(private, kid="test-kid-1")
+
+    settings = _make_settings()
+    token = jose_jwt.encode(
+        {
+            "sub": "supabase-user-2",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "exp": int(time.time()) + 600,
+            "email": "rs@example.com",
+            "app_metadata": {"tenant_id": "tenant-rs"},
+        },
+        pem,
+        algorithm="RS256",
+        headers={"kid": "test-kid-1"},
+    )
+
+    # Stub httpx.AsyncClient.get to return our JWKS.
+    captured: list[str] = []
+
+    class _Resp:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"keys": [jwk]}
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            captured.append(url)
+            return _Resp()
+
+    monkeypatch.setattr("src.core.supabase_auth.httpx.AsyncClient", _Client)
+
+    claims = await verify_supabase_jwt(token, settings)
+    assert claims.sub == "supabase-user-2"
+    assert claims.tenant_id == "tenant-rs"
+    assert captured == [settings.supabase_jwks_url]
+
+
+@pytest.mark.unit
+async def test_jwks_cache_reused_within_ttl(monkeypatch):
+    reset_jwks_cache()
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem, jwk = _rsa_jwk(private, kid="cache-kid")
+
+    settings = _make_settings()
+    fetch_count = 0
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"keys": [jwk]}
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            nonlocal fetch_count
+            fetch_count += 1
+            return _Resp()
+
+    monkeypatch.setattr("src.core.supabase_auth.httpx.AsyncClient", _Client)
+
+    def _make_token():
+        return jose_jwt.encode(
+            {
+                "sub": "u",
+                "iss": ISSUER,
+                "aud": AUDIENCE,
+                "exp": int(time.time()) + 600,
+                "app_metadata": {"tenant_id": "t"},
+            },
+            pem,
+            algorithm="RS256",
+            headers={"kid": "cache-kid"},
+        )
+
+    await verify_supabase_jwt(_make_token(), settings)
+    await verify_supabase_jwt(_make_token(), settings)
+    await verify_supabase_jwt(_make_token(), settings)
+    assert fetch_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration with get_tenant_id (router-level)
+# ---------------------------------------------------------------------------
+
+
+def _tenant_app(supabase_secret: str | None):
+    from src.core import tenant as tenant_mod
+    from src.core.tenant import get_tenant_id
+
+    app = FastAPI()
+
+    @app.get("/test")
+    async def _h(tenant_id: str = Depends(get_tenant_id)):
+        return {"tenant_id": tenant_id}
+
+    settings = _make_settings(
+        supabase_jwt_secret=supabase_secret,
+        supabase_url=SUPABASE_URL,
+    )
+    deps = MagicMock()
+    deps.settings = settings
+    deps.api_keys_collection = MagicMock()
+    deps.api_keys_collection.find_one = AsyncMock(return_value=None)
+    deps.users_collection = MagicMock()
+    deps.users_collection.find_one = AsyncMock(return_value=None)
+    app.state.deps = deps
+
+    # Force tenant module to re-read settings on each call
+    tenant_mod.load_settings = lambda: settings  # type: ignore[assignment]
+    return app, deps
+
+
+@pytest.mark.unit
+def test_supabase_token_routes_via_supabase_path():
+    app, deps = _tenant_app(supabase_secret="supabase-shared-secret-32-chars-aa")
+    client = TestClient(app)
+
+    token = _supabase_hs256_token(
+        "supabase-shared-secret-32-chars-aa",
+        app_metadata={"tenant_id": "tenant-from-supabase"},
+    )
+    resp = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["tenant_id"] == "tenant-from-supabase"
+
+
+@pytest.mark.unit
+def test_legacy_nextauth_token_still_works():
+    """Backwards compatibility: NextAuth-issued tokens (no Supabase iss) still verify."""
+    app, deps = _tenant_app(supabase_secret=None)
+    client = TestClient(app)
+
+    token = jose_jwt.encode(
+        {"sub": "user-1", "tenant_id": MOCK_TENANT_ID, "role": "owner"},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    resp = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["tenant_id"] == MOCK_TENANT_ID
+
+
+@pytest.mark.unit
+def test_supabase_token_no_tenant_id_falls_back_to_db():
+    app, deps = _tenant_app(supabase_secret="supabase-shared-secret-32-chars-aa")
+    deps.users_collection.find_one = AsyncMock(
+        return_value={
+            "_id": "u1",
+            "supabase_user_id": "supabase-user-1",
+            "tenant_id": "tenant-from-db",
+        }
+    )
+    client = TestClient(app)
+
+    token = _supabase_hs256_token("supabase-shared-secret-32-chars-aa")
+    resp = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["tenant_id"] == "tenant-from-db"
+
+
+@pytest.mark.unit
+def test_supabase_user_without_tenant_fails_closed():
+    app, deps = _tenant_app(supabase_secret="supabase-shared-secret-32-chars-aa")
+    deps.users_collection.find_one = AsyncMock(return_value=None)
+    client = TestClient(app)
+
+    token = _supabase_hs256_token("supabase-shared-secret-32-chars-aa")
+    resp = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_supabase_token_bad_signature_does_not_fall_through_to_nextauth():
+    """A token whose `iss` is the Supabase issuer must NOT be re-verified
+    against the NextAuth secret on signature failure."""
+    app, deps = _tenant_app(supabase_secret="supabase-shared-secret-32-chars-aa")
+    client = TestClient(app)
+
+    # Sign with the NextAuth secret but claim Supabase issuer → should be
+    # routed to Supabase path, fail signature, return 401 (NOT silently fall
+    # back to HS256/NEXTAUTH_SECRET).
+    token = jose_jwt.encode(
+        {
+            "sub": "attacker",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "exp": int(time.time()) + 600,
+            "tenant_id": "attacker-tenant",
+        },
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    resp = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401


### PR DESCRIPTION
Closes #40.

## Summary
- New `core.supabase_auth` module: JWKS-backed verification with TTL+lock cached key set, optional HS256 shared-secret fallback, pinned issuer/audience, `exp` required, `alg=none` and algorithm-confusion blocked.
- `core.tenant._resolve_jwt` now routes by `iss` — Supabase tokens go through the JWKS/HS256 Supabase path, NextAuth tokens stay on the legacy path. **No fall-through** between paths (a Supabase-issued token with a bad signature cannot silently re-verify against the NextAuth secret).
- Tenant ID precedence: claim `tenant_id` → `app_metadata.tenant_id` → `user_metadata.tenant_id` → DB lookup by `users.supabase_user_id` or `email`. Fail-closed if none.
- New settings: `SUPABASE_URL`, `SUPABASE_PROJECT_REF`, `SUPABASE_JWT_SECRET` (optional), `SUPABASE_JWT_AUDIENCE`, `SUPABASE_JWKS_CACHE_SECONDS`. `.env.example` updated.

## Test plan
- [x] Unit tests for valid HS256 token, invalid signature, expired, wrong audience, wrong issuer, `alg=none` rejection, alg-confusion guard, JWKS RS256 happy path, JWKS caching, NextAuth backwards compatibility, DB-fallback tenant resolution, fail-closed when user has no tenant, no-fall-through guarantee.
- [x] Full unit suite green: **426 passed, 0 failures** (`uv run pytest -m unit`).
- [x] `uv run ruff check` clean on changed files.
- [ ] Manual smoke: configure `SUPABASE_URL`, sign in via dashboard (#41), call `/api/v1/usage/me` with the Supabase access token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)