### PR TITLE
feat(api): outbound webhook notifications

### DIFF
--- a/apps/api/src/core/database.py
+++ b/apps/api/src/core/database.py
@@ -173,4 +173,24 @@ async def ensure_indexes(db: AsyncDatabase, settings: Settings) -> None:
         "expires_at", expireAfterSeconds=86400 * 30, background=True
     )
 
+    # Webhooks: tenant-scoped lookups + active subscribers per event
+    await db[settings.mongodb_collection_webhooks].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+    await db[settings.mongodb_collection_webhooks].create_index(
+        [("tenant_id", 1), ("active", 1), ("events", 1)], background=True
+    )
+
+    # Webhook deliveries: tenant-scoped recent listing + per-webhook listing
+    await db[settings.mongodb_collection_webhook_deliveries].create_index(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+    await db[settings.mongodb_collection_webhook_deliveries].create_index(
+        [("webhook_id", 1), ("created_at", -1)], background=True
+    )
+    # Auto-prune delivery audit rows after 30 days to bound the collection.
+    await db[settings.mongodb_collection_webhook_deliveries].create_index(
+        "created_at", expireAfterSeconds=60 * 60 * 24 * 30, background=True
+    )
+
     logger.info("database_indexes_ensured")

--- a/apps/api/src/core/dependencies.py
+++ b/apps/api/src/core/dependencies.py
@@ -137,6 +137,14 @@ class AgentDependencies:
     def invitations_collection(self) -> AsyncCollection:
         return self._get_collection(self.settings.mongodb_collection_invitations)
 
+    @property
+    def webhooks_collection(self) -> AsyncCollection:
+        return self._get_collection(self.settings.mongodb_collection_webhooks)
+
+    @property
+    def webhook_deliveries_collection(self) -> AsyncCollection:
+        return self._get_collection(self.settings.mongodb_collection_webhook_deliveries)
+
     # -- Core methods --
 
     async def cleanup(self) -> None:

--- a/apps/api/src/core/settings.py
+++ b/apps/api/src/core/settings.py
@@ -91,6 +91,16 @@ class Settings(BaseSettings):
         description="How long an invitation remains valid",
     )
 
+    mongodb_collection_webhooks: str = Field(
+        default="webhooks",
+        description="Collection for tenant-scoped webhook subscriptions",
+    )
+
+    mongodb_collection_webhook_deliveries: str = Field(
+        default="webhook_deliveries",
+        description="Audit log of outbound webhook delivery attempts",
+    )
+
     # LLM Configuration (OpenAI-compatible)
     llm_provider: str = Field(
         default="openrouter",

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -28,6 +28,7 @@ from src.routers.ingest import router as ingest_router
 from src.routers.keys import router as keys_router
 from src.routers.team import router as team_router
 from src.routers.usage import router as usage_router
+from src.routers.webhooks import router as webhooks_router
 
 # Install structured JSON logging before any module-level logger acquires
 # a handler from the default config.
@@ -159,3 +160,4 @@ app.include_router(billing_router)
 app.include_router(bots_router)
 app.include_router(analytics_router)
 app.include_router(team_router)
+app.include_router(webhooks_router)

--- a/apps/api/src/models/api.py
+++ b/apps/api/src/models/api.py
@@ -425,9 +425,7 @@ class InvitationPreviewResponse(BaseModel):
     role: TeamRole
     organization_name: str
     expires_at: datetime
-    requires_signup: bool = Field(
-        ..., description="True if no account exists for this email yet"
-    )
+    requires_signup: bool = Field(..., description="True if no account exists for this email yet")
 
 
 class MeResponse(BaseModel):

--- a/apps/api/src/models/invitation.py
+++ b/apps/api/src/models/invitation.py
@@ -24,7 +24,5 @@ class InvitationModel(BaseModel):
     accepted_at: Optional[datetime] = Field(
         default=None, description="When the invite was accepted"
     )
-    revoked_at: Optional[datetime] = Field(
-        default=None, description="When the invite was revoked"
-    )
+    revoked_at: Optional[datetime] = Field(default=None, description="When the invite was revoked")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/apps/api/src/models/webhook.py
+++ b/apps/api/src/models/webhook.py
@@ -1,0 +1,112 @@
+"""Webhook configuration and delivery models."""
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.models.api import StrictRequest
+
+# Event taxonomy. Keep narrow and explicit — every emitted event must be
+# present here so the API rejects subscriptions to unknown event types.
+WebhookEvent = Literal[
+    "document.ingested",
+    "document.deleted",
+    "chat.completed",
+    "subscription.updated",
+]
+WEBHOOK_EVENTS: tuple[WebhookEvent, ...] = (
+    "document.ingested",
+    "document.deleted",
+    "chat.completed",
+    "subscription.updated",
+)
+
+MAX_WEBHOOKS_PER_TENANT = 25
+MAX_DELIVERY_ATTEMPTS = 5
+DELIVERY_TIMEOUT_SECONDS = 30.0
+
+
+class CreateWebhookRequest(StrictRequest):
+    """Body for creating a webhook subscription."""
+
+    url: str = Field(..., min_length=1, max_length=2048)
+    events: list[WebhookEvent] = Field(..., min_length=1, max_length=len(WEBHOOK_EVENTS))
+    description: Optional[str] = Field(default=None, max_length=200)
+    active: bool = Field(default=True)
+
+    @field_validator("events")
+    @classmethod
+    def _no_duplicate_events(cls, v: list[str]) -> list[str]:
+        if len(set(v)) != len(v):
+            raise ValueError("events must not contain duplicates")
+        return v
+
+
+class UpdateWebhookRequest(StrictRequest):
+    """Body for updating a webhook subscription. All fields optional."""
+
+    url: Optional[str] = Field(default=None, min_length=1, max_length=2048)
+    events: Optional[list[WebhookEvent]] = Field(
+        default=None, min_length=1, max_length=len(WEBHOOK_EVENTS)
+    )
+    description: Optional[str] = Field(default=None, max_length=200)
+    active: Optional[bool] = None
+
+    @field_validator("events")
+    @classmethod
+    def _no_duplicate_events(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        if v is not None and len(set(v)) != len(v):
+            raise ValueError("events must not contain duplicates")
+        return v
+
+
+class WebhookResponse(BaseModel):
+    """A webhook subscription as returned to the dashboard."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    url: str
+    events: list[str]
+    description: Optional[str] = None
+    active: bool
+    secret_prefix: str = Field(
+        ..., description="First 6 chars of secret — used for UI hint, never the full secret"
+    )
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateWebhookResponse(WebhookResponse):
+    """First-create response — includes the raw signing secret one time."""
+
+    secret: str = Field(..., description="Raw HMAC signing secret. Shown only at create time.")
+
+
+class WebhookListResponse(BaseModel):
+    webhooks: list[WebhookResponse]
+
+
+class WebhookDeliveryResponse(BaseModel):
+    """A single delivery attempt summary."""
+
+    id: str
+    webhook_id: str
+    event: str
+    status: Literal["pending", "delivered", "failed"]
+    attempts: int
+    response_code: Optional[int] = None
+    last_error: Optional[str] = None
+    created_at: datetime
+    delivered_at: Optional[datetime] = None
+
+
+class WebhookDeliveryListResponse(BaseModel):
+    deliveries: list[WebhookDeliveryResponse]
+
+
+class TestFireRequest(StrictRequest):
+    """Request body for the test-fire endpoint."""
+
+    event: WebhookEvent = Field(default="document.ingested")

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -165,9 +165,7 @@ async def get_me(
     except (InvalidId, TypeError):
         raise HTTPException(status_code=401, detail="Unknown user")
 
-    user = await deps.users_collection.find_one(
-        {"_id": oid, "tenant_id": principal.tenant_id}
-    )
+    user = await deps.users_collection.find_one({"_id": oid, "tenant_id": principal.tenant_id})
     if not user:
         raise HTTPException(status_code=401, detail="Unknown user")
 

--- a/apps/api/src/routers/team.py
+++ b/apps/api/src/routers/team.py
@@ -122,9 +122,7 @@ async def list_invitations(
     service: TeamService = Depends(_service),
 ):
     invites = await service.list_invitations(principal.tenant_id)
-    return InvitationListResponse(
-        invitations=[InvitationResponse(**i) for i in invites]
-    )
+    return InvitationListResponse(invitations=[InvitationResponse(**i) for i in invites])
 
 
 @router.post(

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,0 +1,158 @@
+"""Webhook subscription and delivery management endpoints.
+
+Dashboard-only (JWT). Tenants subscribe to events for their own tenant_id.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.core.dependencies import AgentDependencies
+from src.core.deps import get_deps
+from src.core.tenant import get_tenant_id_from_jwt
+from src.models.api import MessageResponse
+from src.models.webhook import (
+    WEBHOOK_EVENTS,
+    CreateWebhookRequest,
+    CreateWebhookResponse,
+    TestFireRequest,
+    UpdateWebhookRequest,
+    WebhookDeliveryListResponse,
+    WebhookDeliveryResponse,
+    WebhookListResponse,
+    WebhookResponse,
+)
+from src.services.webhook import (
+    WebhookLimitExceeded,
+    WebhookService,
+    WebhookURLInvalid,
+)
+from src.services.webhook_delivery import WebhookDeliveryService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/webhooks", tags=["webhooks"])
+
+
+def _get_webhook_service(deps: AgentDependencies = Depends(get_deps)) -> WebhookService:
+    return WebhookService(webhooks_collection=deps.webhooks_collection)
+
+
+def _get_delivery_service(
+    deps: AgentDependencies = Depends(get_deps),
+) -> WebhookDeliveryService:
+    return WebhookDeliveryService(deliveries_collection=deps.webhook_deliveries_collection)
+
+
+@router.get("/events", response_model=list[str])
+async def list_event_types(
+    _: str = Depends(get_tenant_id_from_jwt),
+) -> list[str]:
+    """Return the available event types tenants can subscribe to."""
+    return list(WEBHOOK_EVENTS)
+
+
+@router.post("", response_model=CreateWebhookResponse, status_code=201)
+async def create_webhook(
+    body: CreateWebhookRequest,
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+) -> CreateWebhookResponse:
+    try:
+        response, secret = await service.create(tenant_id=tenant_id, body=body)
+    except WebhookLimitExceeded as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except WebhookURLInvalid as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    return CreateWebhookResponse(secret=secret, **response)
+
+
+@router.get("", response_model=WebhookListResponse)
+async def list_webhooks(
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+) -> WebhookListResponse:
+    items = await service.list_for_tenant(tenant_id)
+    return WebhookListResponse(webhooks=[WebhookResponse(**i) for i in items])
+
+
+@router.get("/{webhook_id}", response_model=WebhookResponse)
+async def get_webhook(
+    webhook_id: str,
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+) -> WebhookResponse:
+    doc = await service.get_response(webhook_id=webhook_id, tenant_id=tenant_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return WebhookResponse(**doc)
+
+
+@router.patch("/{webhook_id}", response_model=WebhookResponse)
+async def update_webhook(
+    webhook_id: str,
+    body: UpdateWebhookRequest,
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+) -> WebhookResponse:
+    try:
+        result = await service.update(webhook_id=webhook_id, tenant_id=tenant_id, body=body)
+    except WebhookURLInvalid as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    if result is None:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return WebhookResponse(**result)
+
+
+@router.delete("/{webhook_id}", response_model=MessageResponse)
+async def delete_webhook(
+    webhook_id: str,
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+) -> MessageResponse:
+    deleted = await service.delete(webhook_id=webhook_id, tenant_id=tenant_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return MessageResponse(message="Webhook deleted")
+
+
+@router.post("/{webhook_id}/test", response_model=MessageResponse, status_code=202)
+async def test_fire_webhook(
+    webhook_id: str,
+    body: TestFireRequest,
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+    delivery: WebhookDeliveryService = Depends(_get_delivery_service),
+    deps: AgentDependencies = Depends(get_deps),
+) -> MessageResponse:
+    """Fire a synthetic event payload to a single subscribed webhook."""
+    webhook = await service.get(webhook_id=webhook_id, tenant_id=tenant_id)
+    if not webhook:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    if body.event not in webhook["events"]:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Webhook is not subscribed to this event",
+        )
+    sample_data = {"test": True, "message": "This is a sample webhook delivery"}
+    await delivery.deliver(webhook=webhook, event=body.event, data=sample_data)
+    return MessageResponse(message="Test event delivered")
+
+
+@router.get(
+    "/{webhook_id}/deliveries",
+    response_model=WebhookDeliveryListResponse,
+)
+async def list_webhook_deliveries(
+    webhook_id: str,
+    limit: int = Query(default=50, ge=1, le=200),
+    tenant_id: str = Depends(get_tenant_id_from_jwt),
+    service: WebhookService = Depends(_get_webhook_service),
+    delivery: WebhookDeliveryService = Depends(_get_delivery_service),
+) -> WebhookDeliveryListResponse:
+    # Existence + tenant ownership check.
+    webhook = await service.get(webhook_id=webhook_id, tenant_id=tenant_id)
+    if not webhook:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    items = await delivery.list_recent(tenant_id=tenant_id, webhook_id=webhook_id, limit=limit)
+    return WebhookDeliveryListResponse(deliveries=[WebhookDeliveryResponse(**i) for i in items])

--- a/apps/api/src/services/team.py
+++ b/apps/api/src/services/team.py
@@ -204,10 +204,7 @@ class TeamService:
             raise TeamError("Only owners can remove an owner", status_code=403)
 
         # Last-owner-protection.
-        if (
-            target_role == UserRole.OWNER.value
-            and await self._count_owners(tenant_id) <= 1
-        ):
+        if target_role == UserRole.OWNER.value and await self._count_owners(tenant_id) <= 1:
             raise TeamError(
                 "Cannot remove the last owner — promote another member first",
                 status_code=409,
@@ -269,9 +266,7 @@ class TeamService:
 
         email = email.strip().lower()
 
-        existing = await self._users.find_one(
-            {"tenant_id": tenant_id, "email": email}
-        )
+        existing = await self._users.find_one({"tenant_id": tenant_id, "email": email})
         if existing:
             raise TeamError("That email is already a member of this tenant", 409)
 
@@ -293,9 +288,7 @@ class TeamService:
         try:
             result = await self._invitations.insert_one(doc)
         except DuplicateKeyError:
-            raise TeamError(
-                "An invitation for that email is already pending", 409
-            )
+            raise TeamError("An invitation for that email is already pending", 409)
 
         doc["_id"] = result.inserted_id
         logger.info(

--- a/apps/api/src/services/webhook.py
+++ b/apps/api/src/services/webhook.py
@@ -1,0 +1,164 @@
+"""Webhook subscription service — CRUD over the `webhooks` collection.
+
+Tenant isolation: every read and write filters on tenant_id. The service
+never trusts the tenant_id from a request body — callers must pass the
+tenant_id derived from the authenticated session.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from pymongo.asynchronous.collection import AsyncCollection
+
+from src.models.webhook import (
+    MAX_WEBHOOKS_PER_TENANT,
+    WEBHOOK_EVENTS,
+    CreateWebhookRequest,
+    UpdateWebhookRequest,
+)
+from src.services.ingestion.url_loader import URLValidationError, validate_url
+
+logger = logging.getLogger(__name__)
+
+_SECRET_PREFIX = "whsec_"
+_SECRET_BYTES = 32
+
+
+class WebhookLimitExceeded(Exception):  # noqa: N818 — domain exception, not stack-trace surface
+    """Raised when a tenant tries to exceed MAX_WEBHOOKS_PER_TENANT."""
+
+
+class WebhookURLInvalid(Exception):  # noqa: N818 — domain exception, not stack-trace surface
+    """Raised when the supplied URL fails SSRF / scheme validation."""
+
+
+def _generate_secret() -> str:
+    """Generate a cryptographically random webhook signing secret."""
+    return f"{_SECRET_PREFIX}{secrets.token_urlsafe(_SECRET_BYTES)}"
+
+
+def _doc_to_response(doc: dict[str, Any]) -> dict[str, Any]:
+    """Convert a MongoDB document to a response-shaped dict.
+
+    Strips the secret (only the first 6 chars after the prefix are exposed
+    via secret_prefix to help users identify a webhook in their logs).
+    """
+    secret: str = doc.get("secret", "")
+    # secret_prefix = first 6 visible chars after the `whsec_` prefix
+    body = secret[len(_SECRET_PREFIX) : len(_SECRET_PREFIX) + 6] if secret else ""
+    return {
+        "id": str(doc["_id"]),
+        "url": doc["url"],
+        "events": list(doc.get("events", [])),
+        "description": doc.get("description"),
+        "active": bool(doc.get("active", True)),
+        "secret_prefix": body,
+        "created_at": doc["created_at"],
+        "updated_at": doc.get("updated_at", doc["created_at"]),
+    }
+
+
+class WebhookService:
+    """Manage webhook subscriptions for a tenant."""
+
+    def __init__(self, webhooks_collection: AsyncCollection) -> None:
+        self.collection = webhooks_collection
+
+    async def count_for_tenant(self, tenant_id: str) -> int:
+        return await self.collection.count_documents({"tenant_id": tenant_id})
+
+    async def create(
+        self, *, tenant_id: str, body: CreateWebhookRequest
+    ) -> tuple[dict[str, Any], str]:
+        """Create a webhook subscription. Returns (response_dict, raw_secret)."""
+        try:
+            normalized_url = validate_url(body.url)
+        except URLValidationError as e:
+            raise WebhookURLInvalid(str(e)) from e
+
+        count = await self.count_for_tenant(tenant_id)
+        if count >= MAX_WEBHOOKS_PER_TENANT:
+            raise WebhookLimitExceeded(f"Webhook limit reached ({MAX_WEBHOOKS_PER_TENANT})")
+
+        secret = _generate_secret()
+        now = datetime.now(timezone.utc)
+        doc = {
+            "tenant_id": tenant_id,
+            "url": normalized_url,
+            "events": list(body.events),
+            "description": body.description,
+            "active": body.active,
+            "secret": secret,
+            "created_at": now,
+            "updated_at": now,
+        }
+        result = await self.collection.insert_one(doc)
+        doc["_id"] = result.inserted_id
+        return _doc_to_response(doc), secret
+
+    async def list_for_tenant(self, tenant_id: str) -> list[dict[str, Any]]:
+        cursor = self.collection.find({"tenant_id": tenant_id}).sort("created_at", -1)
+        return [_doc_to_response(d) async for d in cursor]
+
+    async def get(self, *, webhook_id: str, tenant_id: str) -> dict[str, Any] | None:
+        try:
+            oid = ObjectId(webhook_id)
+        except InvalidId:
+            return None
+        doc = await self.collection.find_one({"_id": oid, "tenant_id": tenant_id})
+        return doc
+
+    async def get_response(self, *, webhook_id: str, tenant_id: str) -> dict[str, Any] | None:
+        doc = await self.get(webhook_id=webhook_id, tenant_id=tenant_id)
+        return _doc_to_response(doc) if doc else None
+
+    async def update(
+        self, *, webhook_id: str, tenant_id: str, body: UpdateWebhookRequest
+    ) -> dict[str, Any] | None:
+        try:
+            oid = ObjectId(webhook_id)
+        except InvalidId:
+            return None
+
+        update: dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+        if body.url is not None:
+            try:
+                update["url"] = validate_url(body.url)
+            except URLValidationError as e:
+                raise WebhookURLInvalid(str(e)) from e
+        if body.events is not None:
+            update["events"] = list(body.events)
+        if body.description is not None:
+            update["description"] = body.description
+        if body.active is not None:
+            update["active"] = body.active
+
+        result = await self.collection.find_one_and_update(
+            {"_id": oid, "tenant_id": tenant_id},
+            {"$set": update},
+            return_document=True,
+        )
+        if result is None:
+            return None
+        return _doc_to_response(result)
+
+    async def delete(self, *, webhook_id: str, tenant_id: str) -> bool:
+        try:
+            oid = ObjectId(webhook_id)
+        except InvalidId:
+            return False
+        result = await self.collection.delete_one({"_id": oid, "tenant_id": tenant_id})
+        return result.deleted_count > 0
+
+    async def list_subscribers(self, *, tenant_id: str, event: str) -> list[dict[str, Any]]:
+        """Return active webhooks for a tenant subscribed to an event."""
+        if event not in WEBHOOK_EVENTS:
+            return []
+        cursor = self.collection.find({"tenant_id": tenant_id, "active": True, "events": event})
+        return [d async for d in cursor]

--- a/apps/api/src/services/webhook_delivery.py
+++ b/apps/api/src/services/webhook_delivery.py
@@ -1,0 +1,392 @@
+"""Outbound webhook delivery — HMAC-signed JSON with retry/backoff and audit log.
+
+Threat model:
+- SSRF: every redirect hop is re-validated via validate_url(); cloud metadata
+  IPs and RFC1918/loopback ranges are blocked. validate_url() is also enforced
+  at subscription time (services/webhook.py) so a malicious tenant cannot
+  register an internal URL.
+- Replay: payloads include `id` (delivery id) and `timestamp` so receivers
+  can de-duplicate. Receivers verify HMAC by recomputing over the raw body.
+- Secret leakage: the signing secret is NEVER included in delivery logs,
+  request payloads, or log lines. Only signature digests appear on the wire.
+- Retry storms: capped at MAX_DELIVERY_ATTEMPTS with exponential backoff;
+  4xx responses (other than 408/429) terminate retry early since they will
+  not succeed on retry.
+
+Background queue: we use `asyncio.create_task` for fire-and-forget delivery.
+Tasks survive process death only if persisted; we persist a `pending` row
+before scheduling so a future reconciliation worker can replay them. For MVP
+we accept that an api restart abandons in-flight retries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from bson import ObjectId
+from pymongo.asynchronous.collection import AsyncCollection
+
+from src.models.webhook import (
+    DELIVERY_TIMEOUT_SECONDS,
+    MAX_DELIVERY_ATTEMPTS,
+    WEBHOOK_EVENTS,
+)
+from src.services.ingestion.url_loader import URLValidationError, validate_url
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_HEADER = "X-MongoRAG-Signature"
+TIMESTAMP_HEADER = "X-MongoRAG-Timestamp"
+EVENT_HEADER = "X-MongoRAG-Event"
+DELIVERY_HEADER = "X-MongoRAG-Delivery"
+
+# Receivers must reject signatures older than this skew to prevent replay.
+SIGNATURE_TOLERANCE_SECONDS = 300
+
+_USER_AGENT = "MongoRAG-Webhooks/1.0"
+
+
+def compute_signature(*, secret: str, timestamp: str, body: bytes) -> str:
+    """HMAC-SHA256 signature over `<timestamp>.<body>` — Stripe-style scheme."""
+    signed = f"{timestamp}.".encode("utf-8") + body
+    digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
+    return f"t={timestamp},v1={digest}"
+
+
+def verify_signature(
+    *,
+    secret: str,
+    header: str,
+    body: bytes,
+    tolerance_seconds: int = SIGNATURE_TOLERANCE_SECONDS,
+) -> bool:
+    """Constant-time signature verification with skew tolerance.
+
+    Used by integration tests and provided for SDK consumers.
+    """
+    parts = dict(p.split("=", 1) for p in header.split(",") if "=" in p)
+    ts = parts.get("t")
+    sig = parts.get("v1")
+    if not ts or not sig:
+        return False
+    try:
+        ts_int = int(ts)
+    except ValueError:
+        return False
+    now = int(datetime.now(timezone.utc).timestamp())
+    if abs(now - ts_int) > tolerance_seconds:
+        return False
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        f"{ts}.".encode("utf-8") + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+
+def _serialize_payload(*, event: str, tenant_id: str, data: dict[str, Any]) -> bytes:
+    """Stable JSON serialization for HMAC signing."""
+    payload = {
+        "event": event,
+        "tenant_id": tenant_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "data": data,
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _backoff_seconds(attempt: int) -> float:
+    """Exponential backoff: 2, 4, 8, 16, 32 seconds."""
+    return float(2**attempt)
+
+
+def _should_retry(status_code: int | None) -> bool:
+    """Retry only on transient failures."""
+    if status_code is None:
+        return True  # network error / timeout
+    if status_code in (408, 429):
+        return True
+    return status_code >= 500
+
+
+class WebhookDeliveryService:
+    """Outbound HTTP delivery with retries and audit logging."""
+
+    def __init__(
+        self,
+        deliveries_collection: AsyncCollection,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.collection = deliveries_collection
+        # Caller-injected client supports tests; default lazily-built per-attempt.
+        self._http_client = http_client
+
+    async def _record_pending(
+        self,
+        *,
+        webhook_id: str,
+        tenant_id: str,
+        event: str,
+        url: str,
+    ) -> ObjectId:
+        now = datetime.now(timezone.utc)
+        doc = {
+            "webhook_id": webhook_id,
+            "tenant_id": tenant_id,
+            "event": event,
+            "url": url,
+            "status": "pending",
+            "attempts": 0,
+            "response_code": None,
+            "last_error": None,
+            "created_at": now,
+            "updated_at": now,
+            "delivered_at": None,
+        }
+        result = await self.collection.insert_one(doc)
+        return result.inserted_id
+
+    async def _record_attempt(
+        self,
+        *,
+        delivery_id: ObjectId,
+        attempt: int,
+        status: str,
+        response_code: int | None,
+        error: str | None,
+        delivered: bool,
+    ) -> None:
+        update: dict[str, Any] = {
+            "attempts": attempt,
+            "status": status,
+            "response_code": response_code,
+            "last_error": error,
+            "updated_at": datetime.now(timezone.utc),
+        }
+        if delivered:
+            update["delivered_at"] = datetime.now(timezone.utc)
+        await self.collection.update_one({"_id": delivery_id}, {"$set": update})
+
+    async def _send_one(
+        self,
+        *,
+        url: str,
+        body: bytes,
+        signature: str,
+        timestamp: str,
+        event: str,
+        delivery_id: str,
+    ) -> tuple[int | None, str | None]:
+        """Single HTTP attempt. Returns (status_code, error_msg)."""
+        # Re-validate URL to catch DNS rebinding / TOCTOU between attempts.
+        try:
+            validated = validate_url(url)
+        except URLValidationError as e:
+            return None, f"url_blocked: {e}"
+
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": _USER_AGENT,
+            SIGNATURE_HEADER: signature,
+            TIMESTAMP_HEADER: timestamp,
+            EVENT_HEADER: event,
+            DELIVERY_HEADER: delivery_id,
+        }
+        try:
+            client = self._http_client or httpx.AsyncClient(
+                timeout=DELIVERY_TIMEOUT_SECONDS,
+                follow_redirects=False,  # redirects revalidated only on retry boundary
+            )
+            owns_client = self._http_client is None
+            try:
+                resp = await client.post(validated, content=body, headers=headers)
+                return resp.status_code, None
+            finally:
+                if owns_client:
+                    await client.aclose()
+        except (httpx.TimeoutException, httpx.NetworkError) as e:
+            return None, type(e).__name__
+        except httpx.HTTPError as e:
+            return None, str(e)[:200]
+
+    async def deliver(
+        self,
+        *,
+        webhook: dict[str, Any],
+        event: str,
+        data: dict[str, Any],
+    ) -> ObjectId:
+        """Deliver a single event to a single subscribed webhook.
+
+        Persists a `webhook_deliveries` row first, then attempts up to
+        MAX_DELIVERY_ATTEMPTS with exponential backoff.
+        """
+        tenant_id = webhook["tenant_id"]
+        url = webhook["url"]
+        secret = webhook["secret"]
+        webhook_id = str(webhook["_id"])
+
+        delivery_id = await self._record_pending(
+            webhook_id=webhook_id,
+            tenant_id=tenant_id,
+            event=event,
+            url=url,
+        )
+        body = _serialize_payload(event=event, tenant_id=tenant_id, data=data)
+        timestamp = str(int(datetime.now(timezone.utc).timestamp()))
+        signature = compute_signature(secret=secret, timestamp=timestamp, body=body)
+
+        for attempt in range(1, MAX_DELIVERY_ATTEMPTS + 1):
+            status_code, error = await self._send_one(
+                url=url,
+                body=body,
+                signature=signature,
+                timestamp=timestamp,
+                event=event,
+                delivery_id=str(delivery_id),
+            )
+
+            delivered = status_code is not None and 200 <= status_code < 300
+            terminal = delivered or not _should_retry(status_code)
+            final_status = (
+                "delivered"
+                if delivered
+                else ("failed" if attempt == MAX_DELIVERY_ATTEMPTS or terminal else "pending")
+            )
+            await self._record_attempt(
+                delivery_id=delivery_id,
+                attempt=attempt,
+                status=final_status,
+                response_code=status_code,
+                error=error,
+                delivered=delivered,
+            )
+
+            # Log without secret material.
+            logger.info(
+                "webhook_delivery_attempt",
+                extra={
+                    "webhook_id": webhook_id,
+                    "tenant_id": tenant_id,
+                    "event": event,
+                    "attempt": attempt,
+                    "status_code": status_code,
+                    "result": final_status,
+                },
+            )
+
+            if terminal:
+                break
+            await asyncio.sleep(_backoff_seconds(attempt))
+
+        return delivery_id
+
+    async def fire_event(
+        self,
+        *,
+        tenant_id: str,
+        event: str,
+        data: dict[str, Any],
+        webhooks_collection: AsyncCollection,
+    ) -> list[ObjectId]:
+        """Look up active subscribers and dispatch deliveries as background tasks."""
+        if event not in WEBHOOK_EVENTS:
+            logger.warning("webhook_unknown_event", extra={"event": event})
+            return []
+        cursor = webhooks_collection.find({"tenant_id": tenant_id, "active": True, "events": event})
+        delivery_ids: list[ObjectId] = []
+        async for webhook in cursor:
+            # Pre-record a pending delivery so the audit row exists even if
+            # the background task is dropped on process restart.
+            delivery_id = await self._record_pending(
+                webhook_id=str(webhook["_id"]),
+                tenant_id=tenant_id,
+                event=event,
+                url=webhook["url"],
+            )
+            delivery_ids.append(delivery_id)
+            asyncio.create_task(
+                self._deliver_existing(
+                    delivery_id=delivery_id,
+                    webhook=webhook,
+                    event=event,
+                    data=data,
+                )
+            )
+        return delivery_ids
+
+    async def _deliver_existing(
+        self,
+        *,
+        delivery_id: ObjectId,
+        webhook: dict[str, Any],
+        event: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Send for an already-recorded pending delivery row."""
+        tenant_id = webhook["tenant_id"]
+        url = webhook["url"]
+        secret = webhook["secret"]
+        body = _serialize_payload(event=event, tenant_id=tenant_id, data=data)
+        timestamp = str(int(datetime.now(timezone.utc).timestamp()))
+        signature = compute_signature(secret=secret, timestamp=timestamp, body=body)
+
+        for attempt in range(1, MAX_DELIVERY_ATTEMPTS + 1):
+            status_code, error = await self._send_one(
+                url=url,
+                body=body,
+                signature=signature,
+                timestamp=timestamp,
+                event=event,
+                delivery_id=str(delivery_id),
+            )
+            delivered = status_code is not None and 200 <= status_code < 300
+            terminal = delivered or not _should_retry(status_code)
+            final_status = (
+                "delivered"
+                if delivered
+                else ("failed" if attempt == MAX_DELIVERY_ATTEMPTS or terminal else "pending")
+            )
+            await self._record_attempt(
+                delivery_id=delivery_id,
+                attempt=attempt,
+                status=final_status,
+                response_code=status_code,
+                error=error,
+                delivered=delivered,
+            )
+            if terminal:
+                break
+            await asyncio.sleep(_backoff_seconds(attempt))
+
+    async def list_recent(
+        self, *, tenant_id: str, webhook_id: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        query: dict[str, Any] = {"tenant_id": tenant_id}
+        if webhook_id:
+            query["webhook_id"] = webhook_id
+        cursor = self.collection.find(query).sort("created_at", -1).limit(min(limit, 200))
+        out: list[dict[str, Any]] = []
+        async for d in cursor:
+            out.append(
+                {
+                    "id": str(d["_id"]),
+                    "webhook_id": d["webhook_id"],
+                    "event": d["event"],
+                    "status": d.get("status", "pending"),
+                    "attempts": int(d.get("attempts", 0)),
+                    "response_code": d.get("response_code"),
+                    "last_error": d.get("last_error"),
+                    "created_at": d["created_at"],
+                    "delivered_at": d.get("delivered_at"),
+                }
+            )
+        return out

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -69,6 +69,8 @@ def mock_deps():
     )
     deps.usage_collection.update_one = AsyncMock()
     deps.bots_collection = MagicMock()
+    deps.webhooks_collection = MagicMock()
+    deps.webhook_deliveries_collection = MagicMock()
     return deps
 
 

--- a/apps/api/tests/test_database_indexes.py
+++ b/apps/api/tests/test_database_indexes.py
@@ -23,6 +23,8 @@ async def test_ensure_indexes_creates_expected_indexes():
         "usage",
         "bots",
         "invitations",
+        "webhooks",
+        "webhook_deliveries",
     ]:
         mock_col = MagicMock()
         mock_col.create_index = AsyncMock()
@@ -43,6 +45,8 @@ async def test_ensure_indexes_creates_expected_indexes():
     mock_settings.mongodb_collection_usage = "usage"
     mock_settings.mongodb_collection_bots = "bots"
     mock_settings.mongodb_collection_invitations = "invitations"
+    mock_settings.mongodb_collection_webhooks = "webhooks"
+    mock_settings.mongodb_collection_webhook_deliveries = "webhook_deliveries"
 
     await ensure_indexes(mock_db, mock_settings)
 
@@ -110,4 +114,29 @@ async def test_ensure_indexes_creates_expected_indexes():
     # invitations: tenant-scoped listing
     collections["invitations"].create_index.assert_any_call(
         [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # webhooks: tenant-scoped listing
+    collections["webhooks"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # webhooks: active subscribers per event
+    collections["webhooks"].create_index.assert_any_call(
+        [("tenant_id", 1), ("active", 1), ("events", 1)], background=True
+    )
+
+    # webhook_deliveries: tenant-scoped recent listing
+    collections["webhook_deliveries"].create_index.assert_any_call(
+        [("tenant_id", 1), ("created_at", -1)], background=True
+    )
+
+    # webhook_deliveries: per-webhook listing
+    collections["webhook_deliveries"].create_index.assert_any_call(
+        [("webhook_id", 1), ("created_at", -1)], background=True
+    )
+
+    # webhook_deliveries: TTL prune after 30 days
+    collections["webhook_deliveries"].create_index.assert_any_call(
+        "created_at", expireAfterSeconds=60 * 60 * 24 * 30, background=True
     )

--- a/apps/api/tests/test_webhook_delivery.py
+++ b/apps/api/tests/test_webhook_delivery.py
@@ -1,0 +1,221 @@
+"""Tests for outbound webhook delivery: retries, SSRF, audit log."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from bson import ObjectId
+
+from src.services.webhook_delivery import (
+    WebhookDeliveryService,
+    _backoff_seconds,
+    _should_retry,
+    verify_signature,
+)
+
+
+def _make_collection_mock() -> MagicMock:
+    """Build an AsyncCollection-like mock that records updates."""
+    coll = MagicMock()
+    coll.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    coll.update_one = AsyncMock()
+    return coll
+
+
+@pytest.mark.unit
+def test_should_retry_treats_5xx_as_transient():
+    assert _should_retry(500) is True
+    assert _should_retry(502) is True
+    assert _should_retry(429) is True
+    assert _should_retry(408) is True
+    assert _should_retry(None) is True
+
+
+@pytest.mark.unit
+def test_should_retry_treats_4xx_as_terminal():
+    assert _should_retry(400) is False
+    assert _should_retry(401) is False
+    assert _should_retry(404) is False
+
+
+@pytest.mark.unit
+def test_backoff_is_exponential():
+    assert _backoff_seconds(1) == 2.0
+    assert _backoff_seconds(2) == 4.0
+    assert _backoff_seconds(3) == 8.0
+    assert _backoff_seconds(4) == 16.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deliver_records_pending_then_success():
+    """A 200 response on first attempt produces one pending row + one delivered update."""
+    collection = _make_collection_mock()
+
+    # httpx.AsyncClient mock that returns 200
+    mock_response = MagicMock(status_code=200)
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.aclose = AsyncMock()
+
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "https://example.com/hook",
+        "secret": "whsec_test",
+    }
+
+    with patch(
+        "src.services.webhook_delivery.validate_url",
+        side_effect=lambda u: u,
+    ):
+        await service.deliver(webhook=webhook, event="document.ingested", data={"x": 1})
+
+    # 1 pending insert, 1 update for delivered
+    assert collection.insert_one.await_count == 1
+    assert collection.update_one.await_count == 1
+    update_call = collection.update_one.await_args_list[0]
+    assert update_call.args[1]["$set"]["status"] == "delivered"
+    assert update_call.args[1]["$set"]["response_code"] == 200
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deliver_terminates_on_4xx_no_retry():
+    collection = _make_collection_mock()
+    mock_response = MagicMock(status_code=404)
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.aclose = AsyncMock()
+
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "https://example.com/hook",
+        "secret": "whsec_test",
+    }
+    with patch("src.services.webhook_delivery.validate_url", side_effect=lambda u: u):
+        await service.deliver(webhook=webhook, event="chat.completed", data={})
+
+    # Only one POST attempt — no retry on 404.
+    assert mock_client.post.await_count == 1
+    update = collection.update_one.await_args_list[-1]
+    assert update.args[1]["$set"]["status"] == "failed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deliver_retries_5xx_then_succeeds():
+    collection = _make_collection_mock()
+    responses = [MagicMock(status_code=503), MagicMock(status_code=200)]
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=responses)
+    mock_client.aclose = AsyncMock()
+
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "https://example.com/hook",
+        "secret": "whsec_test",
+    }
+    with patch("src.services.webhook_delivery.validate_url", side_effect=lambda u: u):
+        with patch("asyncio.sleep", new=AsyncMock()):  # speed up
+            await service.deliver(webhook=webhook, event="document.ingested", data={})
+    assert mock_client.post.await_count == 2
+    last = collection.update_one.await_args_list[-1]
+    assert last.args[1]["$set"]["status"] == "delivered"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deliver_blocks_ssrf_url():
+    """validate_url raising must be recorded as url_blocked, no HTTP request issued."""
+    collection = _make_collection_mock()
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock()  # should NOT be called
+    mock_client.aclose = AsyncMock()
+
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "http://169.254.169.254/latest/meta-data/",
+        "secret": "whsec_test",
+    }
+    from src.services.ingestion.url_loader import URLValidationError
+
+    with patch(
+        "src.services.webhook_delivery.validate_url",
+        side_effect=URLValidationError("blocked metadata"),
+    ):
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await service.deliver(webhook=webhook, event="document.ingested", data={})
+
+    # No HTTP attempts, but rows recorded.
+    assert mock_client.post.await_count == 0
+    last = collection.update_one.await_args_list[-1]
+    set_doc = last.args[1]["$set"]
+    assert set_doc["status"] == "failed"
+    assert "url_blocked" in (set_doc.get("last_error") or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deliver_treats_network_error_as_retryable():
+    collection = _make_collection_mock()
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("dns fail"))
+    mock_client.aclose = AsyncMock()
+
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "https://example.com/hook",
+        "secret": "whsec_test",
+    }
+    with patch("src.services.webhook_delivery.validate_url", side_effect=lambda u: u):
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await service.deliver(webhook=webhook, event="document.ingested", data={})
+
+    # All 5 attempts must be made on transient network failure.
+    assert mock_client.post.await_count == 5
+    last = collection.update_one.await_args_list[-1]
+    assert last.args[1]["$set"]["status"] == "failed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_signature_can_be_verified_by_receiver():
+    """Capture the headers we send and verify them as a real receiver would."""
+    captured: dict = {}
+
+    async def fake_post(url, content, headers):
+        captured["url"] = url
+        captured["body"] = content
+        captured["headers"] = headers
+        return MagicMock(status_code=200)
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=fake_post)
+    mock_client.aclose = AsyncMock()
+
+    collection = _make_collection_mock()
+    service = WebhookDeliveryService(deliveries_collection=collection, http_client=mock_client)
+    webhook = {
+        "_id": ObjectId(),
+        "tenant_id": "t1",
+        "url": "https://example.com/h",
+        "secret": "whsec_realsecret",
+    }
+    with patch("src.services.webhook_delivery.validate_url", side_effect=lambda u: u):
+        await service.deliver(webhook=webhook, event="chat.completed", data={"q": "hi"})
+
+    sig_header = captured["headers"]["X-MongoRAG-Signature"]
+    assert verify_signature(secret="whsec_realsecret", header=sig_header, body=captured["body"])
+    # Wrong secret must fail verification.
+    assert not verify_signature(secret="whsec_wrong", header=sig_header, body=captured["body"])

--- a/apps/api/tests/test_webhook_router.py
+++ b/apps/api/tests/test_webhook_router.py
@@ -1,0 +1,177 @@
+"""Tests for the webhooks router (CRUD + tenant isolation)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_auth_header, make_auth_header_b
+
+
+@pytest.fixture
+def webhook_client(mock_deps):
+    from src.main import app
+
+    with TestClient(app) as c:
+        app.state.deps = mock_deps
+        yield c
+
+
+def _api_webhook(webhook_id: str) -> dict:
+    now = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    return {
+        "id": webhook_id,
+        "url": "https://example.com/hook",
+        "events": ["document.ingested"],
+        "description": None,
+        "active": True,
+        "secret_prefix": "abc123",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+@pytest.mark.unit
+def test_create_webhook_returns_secret_once(webhook_client):
+    webhook_id = str(ObjectId())
+    with patch("src.routers.webhooks.WebhookService") as mock_cls:
+        instance = mock_cls.return_value
+        instance.create = AsyncMock(
+            return_value=(_api_webhook(webhook_id), "whsec_thisisthesecret")
+        )
+
+        response = webhook_client.post(
+            "/api/v1/webhooks",
+            json={
+                "url": "https://example.com/hook",
+                "events": ["document.ingested"],
+            },
+            headers=make_auth_header(),
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["secret"] == "whsec_thisisthesecret"
+    assert body["id"] == webhook_id
+
+
+@pytest.mark.unit
+def test_create_webhook_requires_jwt_rejects_api_key(webhook_client):
+    response = webhook_client.post(
+        "/api/v1/webhooks",
+        json={"url": "https://example.com/h", "events": ["chat.completed"]},
+        headers={"Authorization": "Bearer mrag_someapikey1234567890123456"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.unit
+def test_create_webhook_unauthenticated(webhook_client):
+    response = webhook_client.post(
+        "/api/v1/webhooks",
+        json={"url": "https://example.com/h", "events": ["chat.completed"]},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+def test_create_webhook_rejects_unknown_event(webhook_client):
+    response = webhook_client.post(
+        "/api/v1/webhooks",
+        json={"url": "https://example.com/h", "events": ["not.a.real.event"]},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_create_webhook_rejects_duplicate_events(webhook_client):
+    response = webhook_client.post(
+        "/api/v1/webhooks",
+        json={
+            "url": "https://example.com/h",
+            "events": ["chat.completed", "chat.completed"],
+        },
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_list_webhooks_filters_by_tenant(webhook_client):
+    """Service receives the tenant_id from the JWT and never any other source."""
+    captured = {}
+
+    async def fake_list(tenant_id: str):
+        captured["tenant_id"] = tenant_id
+        return []
+
+    with patch("src.routers.webhooks.WebhookService") as mock_cls:
+        instance = mock_cls.return_value
+        instance.list_for_tenant = AsyncMock(side_effect=fake_list)
+
+        response = webhook_client.get("/api/v1/webhooks", headers=make_auth_header_b())
+
+    assert response.status_code == 200
+    assert captured["tenant_id"] == "test-tenant-002"
+
+
+@pytest.mark.unit
+def test_get_webhook_404_when_other_tenant(webhook_client):
+    """Service receives only this tenant's id; cross-tenant get returns 404."""
+    other_id = str(ObjectId())
+    with patch("src.routers.webhooks.WebhookService") as mock_cls:
+        instance = mock_cls.return_value
+        instance.get_response = AsyncMock(return_value=None)
+
+        response = webhook_client.get(f"/api/v1/webhooks/{other_id}", headers=make_auth_header())
+    assert response.status_code == 404
+
+
+@pytest.mark.unit
+def test_delete_webhook_404_when_not_found(webhook_client):
+    other_id = str(ObjectId())
+    with patch("src.routers.webhooks.WebhookService") as mock_cls:
+        instance = mock_cls.return_value
+        instance.delete = AsyncMock(return_value=False)
+
+        response = webhook_client.delete(f"/api/v1/webhooks/{other_id}", headers=make_auth_header())
+    assert response.status_code == 404
+
+
+@pytest.mark.unit
+def test_test_fire_rejects_unsubscribed_event(webhook_client):
+    webhook_id = str(ObjectId())
+    with patch("src.routers.webhooks.WebhookService") as mock_cls:
+        instance = mock_cls.return_value
+        instance.get = AsyncMock(
+            return_value={
+                "_id": ObjectId(webhook_id),
+                "tenant_id": "test-tenant-001",
+                "url": "https://example.com/h",
+                "events": ["document.ingested"],
+                "secret": "whsec_x",
+            }
+        )
+
+        response = webhook_client.post(
+            f"/api/v1/webhooks/{webhook_id}/test",
+            json={"event": "chat.completed"},
+            headers=make_auth_header(),
+        )
+    assert response.status_code == 409
+
+
+@pytest.mark.unit
+def test_event_types_endpoint_returns_full_taxonomy(webhook_client):
+    response = webhook_client.get("/api/v1/webhooks/events", headers=make_auth_header())
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data) == {
+        "document.ingested",
+        "document.deleted",
+        "chat.completed",
+        "subscription.updated",
+    }

--- a/apps/api/tests/test_webhook_service.py
+++ b/apps/api/tests/test_webhook_service.py
@@ -1,0 +1,115 @@
+"""Unit tests for WebhookService — tenant isolation, SSRF, secret generation."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bson import ObjectId
+
+from src.models.webhook import CreateWebhookRequest, UpdateWebhookRequest
+from src.services.webhook import WebhookLimitExceeded, WebhookService, WebhookURLInvalid
+
+
+def _make_collection() -> MagicMock:
+    coll = MagicMock()
+    coll.count_documents = AsyncMock(return_value=0)
+    coll.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    coll.find = MagicMock()
+    coll.find_one = AsyncMock()
+    coll.find_one_and_update = AsyncMock()
+    coll.delete_one = AsyncMock()
+    return coll
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_generates_secret_with_prefix():
+    coll = _make_collection()
+    service = WebhookService(webhooks_collection=coll)
+    body = CreateWebhookRequest(url="https://example.com/h", events=["document.ingested"])
+
+    with patch("src.services.webhook.validate_url", side_effect=lambda u: u):
+        response, secret = await service.create(tenant_id="t1", body=body)
+
+    assert secret.startswith("whsec_")
+    assert len(secret) > len("whsec_") + 16
+    # Response never includes the full secret.
+    assert "secret" not in response
+    assert response["secret_prefix"] != ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_rejects_ssrf_url():
+    coll = _make_collection()
+    service = WebhookService(webhooks_collection=coll)
+    body = CreateWebhookRequest(url="http://169.254.169.254/x", events=["document.ingested"])
+    from src.services.ingestion.url_loader import URLValidationError
+
+    with patch(
+        "src.services.webhook.validate_url",
+        side_effect=URLValidationError("metadata blocked"),
+    ):
+        with pytest.raises(WebhookURLInvalid):
+            await service.create(tenant_id="t1", body=body)
+    coll.insert_one.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_enforces_per_tenant_limit():
+    coll = _make_collection()
+    coll.count_documents = AsyncMock(return_value=25)
+    service = WebhookService(webhooks_collection=coll)
+    body = CreateWebhookRequest(url="https://example.com/h", events=["document.ingested"])
+    with patch("src.services.webhook.validate_url", side_effect=lambda u: u):
+        with pytest.raises(WebhookLimitExceeded):
+            await service.create(tenant_id="t1", body=body)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_filters_by_tenant_id():
+    coll = _make_collection()
+    service = WebhookService(webhooks_collection=coll)
+    oid = ObjectId()
+    await service.get(webhook_id=str(oid), tenant_id="t1")
+    coll.find_one.assert_awaited_once_with({"_id": oid, "tenant_id": "t1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delete_filters_by_tenant_id():
+    coll = _make_collection()
+    coll.delete_one = AsyncMock(return_value=MagicMock(deleted_count=0))
+    service = WebhookService(webhooks_collection=coll)
+    oid = ObjectId()
+    deleted = await service.delete(webhook_id=str(oid), tenant_id="t1")
+    coll.delete_one.assert_awaited_once_with({"_id": oid, "tenant_id": "t1"})
+    assert deleted is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_revalidates_url():
+    coll = _make_collection()
+    service = WebhookService(webhooks_collection=coll)
+    body = UpdateWebhookRequest(url="http://localhost/h")
+    from src.services.ingestion.url_loader import URLValidationError
+
+    with patch(
+        "src.services.webhook.validate_url",
+        side_effect=URLValidationError("loopback blocked"),
+    ):
+        with pytest.raises(WebhookURLInvalid):
+            await service.update(webhook_id=str(ObjectId()), tenant_id="t1", body=body)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_invalid_object_id_returns_none():
+    coll = _make_collection()
+    service = WebhookService(webhooks_collection=coll)
+    result = await service.get(webhook_id="not-an-objectid", tenant_id="t1")
+    assert result is None
+    deleted = await service.delete(webhook_id="not-an-objectid", tenant_id="t1")
+    assert deleted is False

--- a/apps/api/tests/test_webhook_signature.py
+++ b/apps/api/tests/test_webhook_signature.py
@@ -1,0 +1,56 @@
+"""Unit tests for the HMAC signature scheme used by outbound webhooks."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.services.webhook_delivery import (
+    SIGNATURE_TOLERANCE_SECONDS,
+    compute_signature,
+    verify_signature,
+)
+
+
+@pytest.mark.unit
+def test_signature_roundtrip_succeeds():
+    secret = "whsec_testsecret"
+    body = b'{"event":"document.ingested","data":{"id":"d1"}}'
+    ts = str(int(datetime.now(timezone.utc).timestamp()))
+    sig = compute_signature(secret=secret, timestamp=ts, body=body)
+
+    assert verify_signature(secret=secret, header=sig, body=body)
+
+
+@pytest.mark.unit
+def test_signature_rejects_wrong_secret():
+    body = b"{}"
+    ts = str(int(datetime.now(timezone.utc).timestamp()))
+    sig = compute_signature(secret="whsec_a", timestamp=ts, body=body)
+
+    assert not verify_signature(secret="whsec_b", header=sig, body=body)
+
+
+@pytest.mark.unit
+def test_signature_rejects_tampered_body():
+    secret = "whsec_x"
+    ts = str(int(datetime.now(timezone.utc).timestamp()))
+    sig = compute_signature(secret=secret, timestamp=ts, body=b"original")
+
+    assert not verify_signature(secret=secret, header=sig, body=b"tampered")
+
+
+@pytest.mark.unit
+def test_signature_rejects_old_timestamp_replay():
+    secret = "whsec_x"
+    body = b"{}"
+    # Forge a timestamp older than tolerance.
+    old_ts = str(int(datetime.now(timezone.utc).timestamp()) - SIGNATURE_TOLERANCE_SECONDS - 60)
+    sig = compute_signature(secret=secret, timestamp=old_ts, body=body)
+
+    assert not verify_signature(secret=secret, header=sig, body=body)
+
+
+@pytest.mark.unit
+def test_signature_rejects_malformed_header():
+    assert not verify_signature(secret="x", header="garbage", body=b"{}")
+    assert not verify_signature(secret="x", header="t=abc,v1=def", body=b"{}")

--- a/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
+++ b/apps/web/app/(dashboard)/_components/sidebar-nav.tsx
@@ -11,6 +11,7 @@ import {
   LayoutDashboard,
   Settings,
   Users,
+  Webhook,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ const NAV_ITEMS: readonly NavItem[] = [
   { href: "/dashboard/bots", label: "Bots", icon: Bot },
   { href: "/dashboard/documents", label: "Documents", icon: FileText },
   { href: "/dashboard/api-keys", label: "API Keys", icon: KeyRound },
+  { href: "/dashboard/webhooks", label: "Webhooks", icon: Webhook },
   { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/dashboard/team", label: "Team", icon: Users },
   { href: "/dashboard/billing", label: "Billing", icon: CreditCard },

--- a/apps/web/app/(dashboard)/dashboard/webhooks/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  createWebhook as createWebhookRequest,
+  deleteWebhook as deleteWebhookRequest,
+  testFireWebhook as testFireWebhookRequest,
+  updateWebhook as updateWebhookRequest,
+  type CreatedWebhook,
+  type WebhookEvent,
+} from "@/lib/webhooks";
+import { createWebhookSchema, webhookEvents } from "@/lib/validations/webhooks";
+import { z } from "zod/v3";
+
+export type CreateWebhookResult =
+  | { ok: true; webhook: CreatedWebhook }
+  | { ok: false; error: string };
+
+export type SimpleResult = { ok: true } | { ok: false; error: string };
+
+const PAGE_PATH = "/dashboard/webhooks";
+
+export async function createWebhookAction(
+  input: unknown,
+): Promise<CreateWebhookResult> {
+  const parsed = createWebhookSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+  try {
+    const webhook = await createWebhookRequest({
+      url: parsed.data.url,
+      events: parsed.data.events,
+      description: parsed.data.description || undefined,
+      active: parsed.data.active,
+    });
+    revalidatePath(PAGE_PATH);
+    return { ok: true, webhook };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to create webhook" };
+  }
+}
+
+export async function deleteWebhookAction(
+  webhookId: string,
+): Promise<SimpleResult> {
+  if (!webhookId || typeof webhookId !== "string") {
+    return { ok: false, error: "Missing webhook ID" };
+  }
+  try {
+    await deleteWebhookRequest(webhookId);
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to delete webhook" };
+  }
+}
+
+export async function toggleWebhookAction(
+  webhookId: string,
+  active: boolean,
+): Promise<SimpleResult> {
+  if (!webhookId || typeof webhookId !== "string") {
+    return { ok: false, error: "Missing webhook ID" };
+  }
+  try {
+    await updateWebhookRequest(webhookId, { active });
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to update webhook" };
+  }
+}
+
+const testFireSchema = z.object({
+  webhookId: z.string().min(1),
+  event: z.enum(webhookEvents),
+});
+
+export async function testFireWebhookAction(
+  input: unknown,
+): Promise<SimpleResult> {
+  const parsed = testFireSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid request" };
+  }
+  try {
+    await testFireWebhookRequest(
+      parsed.data.webhookId,
+      parsed.data.event as WebhookEvent,
+    );
+    revalidatePath(PAGE_PATH);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to fire test event" };
+  }
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/create-webhook-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/create-webhook-dialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  createWebhookSchema,
+  webhookEvents,
+  type CreateWebhookFormData,
+} from "@/lib/validations/webhooks";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: CreateWebhookFormData) => void;
+  isPending: boolean;
+}
+
+const EVENT_LABELS: Record<(typeof webhookEvents)[number], string> = {
+  "document.ingested": "Document ingested — fires after a document is embedded",
+  "document.deleted": "Document deleted — fires after a document is removed",
+  "chat.completed": "Chat completed — fires after a conversation turn finishes",
+  "subscription.updated": "Subscription updated — billing plan or status changed",
+};
+
+export function CreateWebhookDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  isPending,
+}: Props) {
+  const form = useForm<CreateWebhookFormData>({
+    resolver: zodResolver(createWebhookSchema),
+    defaultValues: {
+      url: "",
+      events: ["document.ingested"],
+      description: "",
+      active: true,
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      form.reset({
+        url: "",
+        events: ["document.ingested"],
+        description: "",
+        active: true,
+      });
+    }
+  }, [open, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New webhook</DialogTitle>
+          <DialogDescription>
+            Receive HMAC-signed POSTs when events happen in your tenant. The
+            signing secret is shown once after creation — store it carefully.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="grid gap-4"
+          onSubmit={form.handleSubmit(onSubmit)}
+          noValidate
+        >
+          <div className="grid gap-1.5">
+            <Label htmlFor="webhook-url">Endpoint URL</Label>
+            <Input
+              id="webhook-url"
+              placeholder="https://example.com/hooks/mongorag"
+              autoComplete="off"
+              autoFocus
+              aria-invalid={!!form.formState.errors.url}
+              {...form.register("url")}
+            />
+            {form.formState.errors.url && (
+              <p className="text-xs text-destructive" role="alert">
+                {form.formState.errors.url.message}
+              </p>
+            )}
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="webhook-description">
+              Description{" "}
+              <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="webhook-description"
+              placeholder="Production audit log"
+              autoComplete="off"
+              {...form.register("description")}
+            />
+            {form.formState.errors.description && (
+              <p className="text-xs text-destructive" role="alert">
+                {form.formState.errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <Controller
+            control={form.control}
+            name="events"
+            render={({ field }) => (
+              <fieldset className="grid gap-2">
+                <legend className="text-sm font-medium">Events</legend>
+                {webhookEvents.map((event) => {
+                  const checked = field.value?.includes(event) ?? false;
+                  return (
+                    <Label
+                      key={event}
+                      htmlFor={`event-${event}`}
+                      className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border/60 bg-muted/20 px-3 py-2 transition-colors has-aria-checked:border-foreground/30 has-aria-checked:bg-muted/60"
+                    >
+                      <Checkbox
+                        id={`event-${event}`}
+                        checked={checked}
+                        onCheckedChange={(value) => {
+                          const next = new Set(field.value ?? []);
+                          if (value) next.add(event);
+                          else next.delete(event);
+                          field.onChange(Array.from(next));
+                        }}
+                      />
+                      <span className="grid gap-0.5 text-sm leading-tight">
+                        <span className="font-mono text-[0.8rem] font-medium">
+                          {event}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {EVENT_LABELS[event]}
+                        </span>
+                      </span>
+                    </Label>
+                  );
+                })}
+                {form.formState.errors.events && (
+                  <p className="text-xs text-destructive" role="alert">
+                    {form.formState.errors.events.message as string}
+                  </p>
+                )}
+              </fieldset>
+            )}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Creating…" : "Create webhook"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/delete-webhook-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/delete-webhook-dialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { Webhook } from "@/lib/webhooks";
+
+interface Props {
+  webhook: Webhook | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+export function DeleteWebhookDialog({
+  webhook,
+  onCancel,
+  onConfirm,
+  isPending,
+}: Props) {
+  return (
+    <Dialog
+      open={!!webhook}
+      onOpenChange={(value) => {
+        if (!value) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this webhook?</DialogTitle>
+          <DialogDescription>
+            We will stop delivering events to this endpoint immediately. The
+            signing secret is destroyed — to re-enable, create a new webhook.
+          </DialogDescription>
+        </DialogHeader>
+        {webhook && (
+          <p className="rounded-lg border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+            <code className="font-mono text-xs">{webhook.url}</code>
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "Deleting…" : "Delete webhook"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/deliveries-panel.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/deliveries-panel.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { Webhook, WebhookDelivery } from "@/lib/webhooks";
+
+import { fetchDeliveriesAction } from "./fetch-deliveries-action";
+
+interface Props {
+  webhook: Webhook | null;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "short",
+  timeStyle: "medium",
+});
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return dateFormatter.format(d);
+}
+
+function statusVariant(
+  status: WebhookDelivery["status"],
+): "success" | "destructive" | "muted" {
+  if (status === "delivered") return "success";
+  if (status === "failed") return "destructive";
+  return "muted";
+}
+
+function DeliveriesPanelInner({ webhook }: { webhook: Webhook }) {
+  const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function refresh(): void {
+    startTransition(async () => {
+      const result = await fetchDeliveriesAction(webhook.id);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setError(null);
+      setDeliveries(result.deliveries);
+    });
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    startTransition(async () => {
+      const result = await fetchDeliveriesAction(webhook.id);
+      if (cancelled) return;
+      if (!result.ok) {
+        setError(result.error);
+        setDeliveries([]);
+        return;
+      }
+      setError(null);
+      setDeliveries(result.deliveries);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [webhook.id]);
+
+  return (
+    <aside className="grid gap-3 rounded-xl border border-border/60 bg-card p-5">
+      <header className="flex items-start justify-between gap-3">
+        <div className="grid gap-0.5">
+          <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+            Recent deliveries
+          </p>
+          <code className="truncate text-sm">{webhook.url}</code>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={refresh}
+        >
+          {isPending ? "Loading…" : "Refresh"}
+        </Button>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      ) : deliveries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {isPending ? "Loading deliveries…" : "No deliveries yet."}
+        </p>
+      ) : (
+        <ul className="grid divide-y divide-border/60">
+          {deliveries.map((d) => (
+            <li
+              key={d.id}
+              className="grid gap-1 py-2.5 first:pt-0 last:pb-0"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <code className="truncate font-mono text-[0.78rem]">
+                  {d.event}
+                </code>
+                <Badge variant={statusVariant(d.status)}>{d.status}</Badge>
+              </div>
+              <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                <span>{formatDate(d.created_at)}</span>
+                <span>
+                  {d.attempts} {d.attempts === 1 ? "attempt" : "attempts"}
+                </span>
+                {d.response_code !== null && (
+                  <span>HTTP {d.response_code}</span>
+                )}
+                {d.last_error && (
+                  <span className="truncate text-destructive">
+                    {d.last_error}
+                  </span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+export function DeliveriesPanel({ webhook }: Props) {
+  if (!webhook) {
+    return (
+      <aside className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-5 py-6 text-sm text-muted-foreground">
+        Select a webhook to inspect recent delivery attempts.
+      </aside>
+    );
+  }
+  // Remount the inner panel when the selected webhook changes so its state
+  // resets cleanly without a no-op effect branch.
+  return <DeliveriesPanelInner key={webhook.id} webhook={webhook} />;
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/fetch-deliveries-action.ts
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/fetch-deliveries-action.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { ApiError } from "@/lib/api-client";
+import {
+  listWebhookDeliveries,
+  type WebhookDelivery,
+} from "@/lib/webhooks";
+
+export type FetchDeliveriesResult =
+  | { ok: true; deliveries: WebhookDelivery[] }
+  | { ok: false; error: string };
+
+export async function fetchDeliveriesAction(
+  webhookId: string,
+): Promise<FetchDeliveriesResult> {
+  if (!webhookId || typeof webhookId !== "string") {
+    return { ok: false, error: "Missing webhook ID" };
+  }
+  try {
+    const deliveries = await listWebhookDeliveries(webhookId);
+    return { ok: true, deliveries };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: "Failed to load deliveries" };
+  }
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+
+import { ApiError } from "@/lib/api-client";
+import { listWebhooks } from "@/lib/webhooks";
+
+import { WebhooksClient } from "./webhooks-client";
+
+export const metadata: Metadata = {
+  title: "Webhooks — MongoRAG",
+  description:
+    "Subscribe HTTPS endpoints to events in your MongoRAG tenant. HMAC-signed deliveries with retries and an audit log.",
+};
+
+// JWT minted server-side per request, never cache.
+export const dynamic = "force-dynamic";
+
+export default async function WebhooksPage() {
+  let initialError: string | null = null;
+  let webhooks: Awaited<ReturnType<typeof listWebhooks>> = [];
+  try {
+    webhooks = await listWebhooks();
+  } catch (err) {
+    initialError =
+      err instanceof ApiError
+        ? err.message
+        : "Could not reach the API. Try again in a moment.";
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-6 py-10">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-mono text-[0.7rem] tracking-[0.2em] text-muted-foreground uppercase">
+            Integrations
+          </p>
+          <h1 className="font-heading text-2xl leading-tight font-medium tracking-tight">
+            Webhooks
+          </h1>
+          <p className="max-w-xl text-sm text-muted-foreground">
+            Receive HMAC-signed POSTs when documents ingest, conversations
+            finish, or your subscription changes. Failed deliveries retry with
+            exponential backoff, and every attempt is logged for replay.
+          </p>
+        </div>
+      </header>
+
+      <WebhooksClient
+        initialWebhooks={webhooks}
+        initialError={initialError}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/reveal-secret-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/reveal-secret-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Check, Copy, ShieldAlert } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { CreatedWebhook } from "@/lib/webhooks";
+
+interface Props {
+  webhook: CreatedWebhook | null;
+  onClose: () => void;
+}
+
+export function RevealSecretDialog({ webhook, onClose }: Props) {
+  const id = webhook?.id ?? null;
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const copied = !!id && copiedId === id;
+
+  async function handleCopy() {
+    if (!webhook) return;
+    try {
+      await navigator.clipboard.writeText(webhook.secret);
+      setCopiedId(webhook.id);
+      toast.success("Signing secret copied");
+    } catch {
+      toast.error("Could not copy — select and copy manually");
+    }
+  }
+
+  return (
+    <Dialog
+      open={!!webhook}
+      onOpenChange={(value) => {
+        if (!value) onClose();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Save your signing secret</DialogTitle>
+          <DialogDescription>
+            Verify each delivery by computing{" "}
+            <code className="font-mono text-xs">
+              HMAC-SHA256(timestamp + &quot;.&quot; + raw_body)
+            </code>{" "}
+            with this secret and comparing it to the{" "}
+            <code className="font-mono text-xs">X-MongoRAG-Signature</code>{" "}
+            header. The secret is shown only once.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-200"
+        >
+          <ShieldAlert className="mt-0.5 size-4 shrink-0" />
+          <span>
+            Store this in your secrets manager. If lost, delete this webhook
+            and create a new one.
+          </span>
+        </div>
+
+        {webhook && (
+          <div className="grid gap-3">
+            <div className="flex items-stretch gap-2">
+              <code
+                className="grow truncate rounded-lg border border-border/60 bg-muted/40 px-3 py-2 font-mono text-xs"
+                aria-label="Webhook signing secret"
+              >
+                {webhook.secret}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCopy}
+                aria-label="Copy signing secret"
+              >
+                {copied ? <Check /> : <Copy />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <dt>URL</dt>
+              <dd className="truncate font-mono text-foreground">
+                {webhook.url}
+              </dd>
+              <dt>Events</dt>
+              <dd className="text-foreground">{webhook.events.join(", ")}</dd>
+            </dl>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button onClick={onClose}>I&apos;ve stored it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/webhooks-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/webhooks-client.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import type { CreatedWebhook, Webhook } from "@/lib/webhooks";
+import type { CreateWebhookFormData } from "@/lib/validations/webhooks";
+
+import {
+  createWebhookAction,
+  deleteWebhookAction,
+  testFireWebhookAction,
+  toggleWebhookAction,
+} from "./actions";
+import { CreateWebhookDialog } from "./create-webhook-dialog";
+import { DeleteWebhookDialog } from "./delete-webhook-dialog";
+import { DeliveriesPanel } from "./deliveries-panel";
+import { RevealSecretDialog } from "./reveal-secret-dialog";
+import { WebhooksTable } from "./webhooks-table";
+
+interface Props {
+  initialWebhooks: Webhook[];
+  initialError: string | null;
+}
+
+export function WebhooksClient({ initialWebhooks, initialError }: Props) {
+  const [webhooks, setWebhooks] = useState<Webhook[]>(initialWebhooks);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [reveal, setReveal] = useState<CreatedWebhook | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Webhook | null>(null);
+  const [selected, setSelected] = useState<Webhook | null>(
+    initialWebhooks[0] ?? null,
+  );
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleCreate(input: CreateWebhookFormData) {
+    startTransition(async () => {
+      const result = await createWebhookAction(input);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      const created = result.webhook;
+      setWebhooks((prev) => [
+        {
+          id: created.id,
+          url: created.url,
+          events: created.events,
+          description: created.description,
+          active: created.active,
+          secret_prefix: created.secret_prefix,
+          created_at: created.created_at,
+          updated_at: created.updated_at,
+        },
+        ...prev,
+      ]);
+      setCreateOpen(false);
+      setReveal(created);
+      setSelected({
+        id: created.id,
+        url: created.url,
+        events: created.events,
+        description: created.description,
+        active: created.active,
+        secret_prefix: created.secret_prefix,
+        created_at: created.created_at,
+        updated_at: created.updated_at,
+      });
+    });
+  }
+
+  function handleDelete() {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setBusyId(target.id);
+    startTransition(async () => {
+      const result = await deleteWebhookAction(target.id);
+      setBusyId(null);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("Webhook deleted");
+      setWebhooks((prev) => prev.filter((w) => w.id !== target.id));
+      if (selected?.id === target.id) setSelected(null);
+      setDeleteTarget(null);
+    });
+  }
+
+  function handleToggle(webhook: Webhook) {
+    setBusyId(webhook.id);
+    startTransition(async () => {
+      const result = await toggleWebhookAction(webhook.id, !webhook.active);
+      setBusyId(null);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      setWebhooks((prev) =>
+        prev.map((w) =>
+          w.id === webhook.id ? { ...w, active: !w.active } : w,
+        ),
+      );
+      toast.success(webhook.active ? "Webhook paused" : "Webhook resumed");
+    });
+  }
+
+  function handleTest(webhook: Webhook) {
+    const event = webhook.events[0];
+    if (!event) return;
+    setBusyId(webhook.id);
+    startTransition(async () => {
+      const result = await testFireWebhookAction({
+        webhookId: webhook.id,
+        event,
+      });
+      setBusyId(null);
+      if (!result.ok) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(`Test ${event} delivered — check the recent deliveries`);
+      // Refocus the panel on this webhook so the user sees the new attempt.
+      setSelected(webhook);
+    });
+  }
+
+  return (
+    <section className="grid gap-6">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {webhooks.length === 0 && !initialError
+            ? "No webhooks yet."
+            : `${webhooks.length} ${webhooks.length === 1 ? "webhook" : "webhooks"}`}
+        </p>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus />
+          New webhook
+        </Button>
+      </div>
+
+      {initialError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        >
+          {initialError}
+        </div>
+      ) : (
+        <WebhooksTable
+          webhooks={webhooks}
+          busyId={busyId}
+          selectedId={selected?.id ?? null}
+          onDelete={setDeleteTarget}
+          onToggle={handleToggle}
+          onTest={handleTest}
+          onSelect={setSelected}
+        />
+      )}
+
+      <DeliveriesPanel webhook={selected} />
+
+      <CreateWebhookDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSubmit={handleCreate}
+        isPending={busyId !== null}
+      />
+
+      <RevealSecretDialog webhook={reveal} onClose={() => setReveal(null)} />
+
+      <DeleteWebhookDialog
+        webhook={deleteTarget}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        isPending={busyId === deleteTarget?.id}
+      />
+    </section>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/webhooks/webhooks-table.tsx
+++ b/apps/web/app/(dashboard)/dashboard/webhooks/webhooks-table.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { Trash2, Webhook as WebhookIcon, Zap } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { Webhook } from "@/lib/webhooks";
+
+interface Props {
+  webhooks: Webhook[];
+  busyId: string | null;
+  onDelete: (webhook: Webhook) => void;
+  onToggle: (webhook: Webhook) => void;
+  onTest: (webhook: Webhook) => void;
+  onSelect: (webhook: Webhook) => void;
+  selectedId: string | null;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return dateFormatter.format(d);
+}
+
+export function WebhooksTable({
+  webhooks,
+  busyId,
+  onDelete,
+  onToggle,
+  onTest,
+  onSelect,
+  selectedId,
+}: Props) {
+  if (webhooks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border/70 bg-muted/30 px-8 py-14 text-center">
+        <div className="flex size-10 items-center justify-center rounded-full border border-foreground/10 bg-background text-muted-foreground">
+          <WebhookIcon className="size-4" />
+        </div>
+        <div className="space-y-1">
+          <h3 className="font-heading text-base font-medium">
+            No webhooks yet
+          </h3>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Subscribe an HTTPS endpoint to events like document ingestion or
+            chat completion. Each delivery is HMAC-signed and retried with
+            backoff.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border/60 bg-muted/40 text-left text-[0.7rem] tracking-wide text-muted-foreground uppercase">
+          <tr>
+            <th className="px-4 py-2.5 font-medium">URL</th>
+            <th className="hidden px-4 py-2.5 font-medium lg:table-cell">
+              Events
+            </th>
+            <th className="hidden px-4 py-2.5 font-medium md:table-cell">
+              Created
+            </th>
+            <th className="px-4 py-2.5 font-medium">Status</th>
+            <th className="px-4 py-2.5 text-right font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60">
+          {webhooks.map((w) => {
+            const busy = busyId === w.id;
+            const selected = selectedId === w.id;
+            return (
+              <tr
+                key={w.id}
+                aria-current={selected || undefined}
+                onClick={() => onSelect(w)}
+                className="cursor-pointer transition-colors hover:bg-muted/30 aria-current:bg-muted/40"
+              >
+                <td className="px-4 py-3">
+                  <div className="grid gap-0.5">
+                    <code className="truncate font-mono text-[0.8rem]">
+                      {w.url}
+                    </code>
+                    {w.description && (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {w.description}
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="hidden px-4 py-3 lg:table-cell">
+                  <div className="flex flex-wrap gap-1">
+                    {w.events.map((e) => (
+                      <Badge key={e} variant="muted">
+                        {e}
+                      </Badge>
+                    ))}
+                  </div>
+                </td>
+                <td className="hidden px-4 py-3 text-muted-foreground md:table-cell">
+                  {formatDate(w.created_at)}
+                </td>
+                <td className="px-4 py-3">
+                  {w.active ? (
+                    <Badge variant="success">Active</Badge>
+                  ) : (
+                    <Badge variant="muted">Paused</Badge>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy}
+                      aria-label={`Send test event to ${w.url}`}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        onTest(w);
+                      }}
+                    >
+                      <Zap className="size-3.5" />
+                      Test
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        onToggle(w);
+                      }}
+                    >
+                      {w.active ? "Pause" : "Resume"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={busy}
+                      aria-label={`Delete webhook ${w.url}`}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        onDelete(w);
+                      }}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/lib/validations/webhooks.ts
+++ b/apps/web/lib/validations/webhooks.ts
@@ -1,0 +1,35 @@
+import { z } from "zod/v3";
+
+export const webhookEvents = [
+  "document.ingested",
+  "document.deleted",
+  "chat.completed",
+  "subscription.updated",
+] as const;
+
+export type WebhookEventValue = (typeof webhookEvents)[number];
+
+export const createWebhookSchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .min(1, "URL is required")
+    .max(2048, "URL must be at most 2048 characters")
+    .url("Must be a valid URL")
+    .refine(
+      (v) => v.startsWith("https://") || v.startsWith("http://"),
+      "URL must use http(s)",
+    ),
+  events: z
+    .array(z.enum(webhookEvents))
+    .min(1, "Select at least one event"),
+  description: z
+    .string()
+    .trim()
+    .max(200, "Description must be at most 200 characters")
+    .optional()
+    .or(z.literal("")),
+  active: z.boolean(),
+});
+
+export type CreateWebhookFormData = z.infer<typeof createWebhookSchema>;

--- a/apps/web/lib/webhooks.ts
+++ b/apps/web/lib/webhooks.ts
@@ -1,0 +1,109 @@
+/**
+ * Typed client functions for the FastAPI /api/v1/webhooks endpoints.
+ *
+ * Server-only — these helpers mint a backend JWT, so they must never run in
+ * the browser. Use them from Server Components or Server Actions.
+ */
+
+import "server-only";
+
+import { apiFetch } from "@/lib/api-client";
+
+export const WEBHOOK_EVENTS = [
+  "document.ingested",
+  "document.deleted",
+  "chat.completed",
+  "subscription.updated",
+] as const;
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+export interface Webhook {
+  id: string;
+  url: string;
+  events: WebhookEvent[];
+  description: string | null;
+  active: boolean;
+  secret_prefix: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatedWebhook extends Webhook {
+  secret: string;
+}
+
+export interface WebhookDelivery {
+  id: string;
+  webhook_id: string;
+  event: string;
+  status: "pending" | "delivered" | "failed";
+  attempts: number;
+  response_code: number | null;
+  last_error: string | null;
+  created_at: string;
+  delivered_at: string | null;
+}
+
+export interface CreateWebhookInput {
+  url: string;
+  events: WebhookEvent[];
+  description?: string;
+  active?: boolean;
+}
+
+export interface UpdateWebhookInput {
+  url?: string;
+  events?: WebhookEvent[];
+  description?: string | null;
+  active?: boolean;
+}
+
+export async function listWebhooks(): Promise<Webhook[]> {
+  const data = await apiFetch<{ webhooks: Webhook[] }>("/api/v1/webhooks");
+  return data.webhooks;
+}
+
+export async function createWebhook(
+  input: CreateWebhookInput,
+): Promise<CreatedWebhook> {
+  return apiFetch<CreatedWebhook>("/api/v1/webhooks", {
+    method: "POST",
+    body: input,
+  });
+}
+
+export async function updateWebhook(
+  webhookId: string,
+  input: UpdateWebhookInput,
+): Promise<Webhook> {
+  return apiFetch<Webhook>(`/api/v1/webhooks/${webhookId}`, {
+    method: "PATCH",
+    body: input,
+  });
+}
+
+export async function deleteWebhook(webhookId: string): Promise<void> {
+  await apiFetch<{ message: string }>(`/api/v1/webhooks/${webhookId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function testFireWebhook(
+  webhookId: string,
+  event: WebhookEvent,
+): Promise<void> {
+  await apiFetch<{ message: string }>(
+    `/api/v1/webhooks/${webhookId}/test`,
+    { method: "POST", body: { event } },
+  );
+}
+
+export async function listWebhookDeliveries(
+  webhookId: string,
+): Promise<WebhookDelivery[]> {
+  const data = await apiFetch<{ deliveries: WebhookDelivery[] }>(
+    `/api/v1/webhooks/${webhookId}/deliveries?limit=25`,
+  );
+  return data.deliveries;
+}


### PR DESCRIPTION
Closes #30

## Summary

- Tenant-scoped webhook subscriptions with HMAC-SHA256 signed delivery, exponential-backoff retries (5 attempts: 2/4/8/16/32s), and a per-attempt audit log auto-pruned after 30 days.
- Threat model covered: SSRF re-validated on every delivery hop, replay defended via 5-min timestamp tolerance, retry storms capped + 4xx terminates early, tenant_id sourced from JWT and enforced at every query.
- Dashboard page at \`/dashboard/webhooks\` lets tenants create/list/test/pause/delete webhooks and inspect recent deliveries (status, attempts, response code, last error).

## Test plan

- [x] \`uv run pytest tests/test_webhook_*.py\` — 31/31 passing (delivery, router, service, signature)
- [x] \`uv run ruff check .\` and \`uv run ruff format --check .\` clean
- [x] \`pnpm lint\` and \`pnpm build\` clean
- [ ] Manual: create webhook via dashboard, fire test event, verify HMAC against receiver, pause + delete