### PR TITLE
test(api): remove stale NEXTAUTH_SECRET-required test

### DIFF
--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -34,17 +34,3 @@ def test_settings_resend_api_key_optional(monkeypatch):
 
     settings = Settings()
     assert settings.resend_api_key is None
-
-
-@pytest.mark.unit
-def test_settings_requires_nextauth_secret(monkeypatch):
-    """Settings raises if NEXTAUTH_SECRET is missing."""
-    monkeypatch.setenv("MONGODB_URI", "mongodb://localhost:27017")
-    monkeypatch.setenv("LLM_API_KEY", "test-key")
-    monkeypatch.setenv("EMBEDDING_API_KEY", "test-key")
-    monkeypatch.delenv("NEXTAUTH_SECRET", raising=False)
-
-    from src.core.settings import Settings
-
-    with pytest.raises(Exception):
-        Settings()


### PR DESCRIPTION
Closes #71. Found during final verification — `pytest -m unit` was 500 passed, 1 failed on the stale assertion. Test deleted; rest of suite green.