### PR TITLE
chore(api): drop AttributeError from uuid.UUID parse

### DIFF
--- a/apps/api/src/auth/profiles.py
+++ b/apps/api/src/auth/profiles.py
@@ -34,7 +34,7 @@ async def lookup_profile(pool: asyncpg.Pool, sub: str) -> Optional[ProfileRow]:
     """
     try:
         sub_uuid = uuid.UUID(sub)
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, TypeError):
         return None
 
     row = await pool.fetchrow(


### PR DESCRIPTION
## Summary
- `uuid.UUID()` does not raise `AttributeError` for any documented input — `ValueError` covers malformed strings and `TypeError` covers non-string inputs
- One-line tidiness change, no behavioral impact

## Test plan
- [x] `uv run pytest -m unit -k profiles` — 5 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check src/auth/profiles.py` — clean

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)