### PR TITLE
refactor(api): drop SupabaseClaims.tenant_id

### DIFF
--- a/apps/api/src/core/supabase_auth.py
+++ b/apps/api/src/core/supabase_auth.py
@@ -38,11 +38,17 @@ _SYMMETRIC_ALGS = ("HS256",)
 
 @dataclass
 class SupabaseClaims:
-    """The minimal set of claims we extract from a verified Supabase JWT."""
+    """The minimal set of claims we extract from a verified Supabase JWT.
+
+    `tenant_id` is intentionally NOT carried here. Tenant identity is
+    resolved server-side from Postgres ``public.profiles`` keyed by
+    ``sub`` — JWT claims are request input and must never be the source
+    of truth for the tenant boundary. See
+    ``[[concept-principal-tenant-isolation]]``.
+    """
 
     sub: str
     email: Optional[str]
-    tenant_id: Optional[str]
     raw: dict[str, Any]
 
 
@@ -120,7 +126,10 @@ async def verify_supabase_jwt(token: str, settings: Settings) -> SupabaseClaims:
         settings: Application settings (must have Supabase configured).
 
     Returns:
-        SupabaseClaims with `sub`, optional `email`, optional `tenant_id`.
+        SupabaseClaims with `sub` and optional `email`. `tenant_id` is
+        deliberately NOT extracted from the token; callers must resolve
+        the tenant from Postgres ``public.profiles`` keyed by ``sub``
+        (see ``[[concept-principal-tenant-isolation]]``).
 
     Raises:
         ValueError: On any verification failure (invalid signature, wrong
@@ -205,9 +214,8 @@ async def verify_supabase_jwt(token: str, settings: Settings) -> SupabaseClaims:
         raise ValueError("Token missing sub claim")
 
     email = payload.get("email") if isinstance(payload.get("email"), str) else None
-    tenant_id = _extract_tenant_id(payload)
 
-    return SupabaseClaims(sub=sub, email=email, tenant_id=tenant_id, raw=payload)
+    return SupabaseClaims(sub=sub, email=email, raw=payload)
 
 
 def _select_jwk(jwks: dict[str, Any], kid: str) -> Optional[dict[str, Any]]:
@@ -215,27 +223,4 @@ def _select_jwk(jwks: dict[str, Any], kid: str) -> Optional[dict[str, Any]]:
     for entry in jwks.get("keys", []):
         if isinstance(entry, dict) and entry.get("kid") == kid:
             return entry
-    return None
-
-
-def _extract_tenant_id(payload: dict[str, Any]) -> Optional[str]:
-    """Pull `tenant_id` from the standard Supabase metadata locations.
-
-    Looks in this order:
-        1. top-level `tenant_id`
-        2. `app_metadata.tenant_id` (server-controlled — preferred)
-        3. `user_metadata.tenant_id` (user-editable — accepted as a fallback
-           but should not be the source of truth in production)
-    """
-    direct = payload.get("tenant_id")
-    if isinstance(direct, str) and direct:
-        return direct
-
-    for bucket in ("app_metadata", "user_metadata"):
-        meta = payload.get(bucket)
-        if isinstance(meta, dict):
-            tid = meta.get("tenant_id")
-            if isinstance(tid, str) and tid:
-                return tid
-
     return None

--- a/apps/api/src/core/supabase_auth.py
+++ b/apps/api/src/core/supabase_auth.py
@@ -126,7 +126,9 @@ async def verify_supabase_jwt(token: str, settings: Settings) -> SupabaseClaims:
         settings: Application settings (must have Supabase configured).
 
     Returns:
-        SupabaseClaims with `sub` and optional `email`. `tenant_id` is
+        SupabaseClaims with `sub`, optional `email`, and `raw` (the full
+        verified JWT payload, retained for callers that need additional
+        non-tenant claims such as `app_metadata`). `tenant_id` is
         deliberately NOT extracted from the token; callers must resolve
         the tenant from Postgres ``public.profiles`` keyed by ``sub``
         (see ``[[concept-principal-tenant-isolation]]``).

--- a/apps/api/tests/test_supabase_auth.py
+++ b/apps/api/tests/test_supabase_auth.py
@@ -56,16 +56,16 @@ def _supabase_hs256_token(secret: str, **claims) -> str:
 @pytest.mark.unit
 async def test_valid_hs256_supabase_token_extracts_claims():
     settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
-    token = _supabase_hs256_token(
-        "supabase-shared-secret-32-chars-aa",
-        app_metadata={"tenant_id": MOCK_TENANT_ID},
-    )
+    token = _supabase_hs256_token("supabase-shared-secret-32-chars-aa")
 
     claims = await verify_supabase_jwt(token, settings)
 
     assert claims.sub == "supabase-user-1"
     assert claims.email == "user@example.com"
-    assert claims.tenant_id == MOCK_TENANT_ID
+    # `tenant_id` is intentionally NOT a field on SupabaseClaims — tenant
+    # identity is resolved server-side from `public.profiles`, never from
+    # the token. See concept-principal-tenant-isolation.
+    assert not hasattr(claims, "tenant_id")
 
 
 @pytest.mark.unit
@@ -153,32 +153,6 @@ async def test_hs256_token_without_configured_secret_rejected():
         await verify_supabase_jwt(token, settings)
 
 
-@pytest.mark.unit
-async def test_tenant_id_falls_back_to_user_metadata():
-    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
-    token = _supabase_hs256_token(
-        "supabase-shared-secret-32-chars-aa",
-        user_metadata={"tenant_id": "from-user-metadata"},
-    )
-
-    claims = await verify_supabase_jwt(token, settings)
-    assert claims.tenant_id == "from-user-metadata"
-
-
-@pytest.mark.unit
-async def test_app_metadata_wins_over_user_metadata():
-    """app_metadata is server-controlled and must be preferred."""
-    settings = _make_settings(supabase_jwt_secret="supabase-shared-secret-32-chars-aa")
-    token = _supabase_hs256_token(
-        "supabase-shared-secret-32-chars-aa",
-        app_metadata={"tenant_id": "from-app-metadata"},
-        user_metadata={"tenant_id": "user-supplied"},
-    )
-
-    claims = await verify_supabase_jwt(token, settings)
-    assert claims.tenant_id == "from-app-metadata"
-
-
 # ---------------------------------------------------------------------------
 # JWKS path
 # ---------------------------------------------------------------------------
@@ -221,7 +195,6 @@ async def test_rs256_token_verified_via_jwks(monkeypatch):
             "aud": AUDIENCE,
             "exp": int(time.time()) + 600,
             "email": "rs@example.com",
-            "app_metadata": {"tenant_id": "tenant-rs"},
         },
         pem,
         algorithm="RS256",
@@ -256,7 +229,6 @@ async def test_rs256_token_verified_via_jwks(monkeypatch):
 
     claims = await verify_supabase_jwt(token, settings)
     assert claims.sub == "supabase-user-2"
-    assert claims.tenant_id == "tenant-rs"
     assert captured == [settings.supabase_jwks_url]
 
 
@@ -300,7 +272,6 @@ async def test_jwks_cache_reused_within_ttl(monkeypatch):
                 "iss": ISSUER,
                 "aud": AUDIENCE,
                 "exp": int(time.time()) + 600,
-                "app_metadata": {"tenant_id": "t"},
             },
             pem,
             algorithm="RS256",


### PR DESCRIPTION
## Summary

- Removes `tenant_id` from `SupabaseClaims` and deletes the `_extract_tenant_id` parser in `apps/api/src/core/supabase_auth.py`
- Drops obsolete tests that exercised JWT-claim tenant resolution

This is the **Option 2 (removal)** path from #74, the preferred outcome. After #73 (PR #78), tenant identity is resolved server-side from Postgres `public.profiles` keyed by `sub` — no production reader of `claims.tenant_id` remained, so the field and parser were dead code with footgun potential. A future contributor reading `claims.tenant_id` and trusting it would have silently broken the [concept-principal-tenant-isolation](.obsidian/wiki/concept-principal-tenant-isolation.md) invariant.

## Why removal over annotation

Annotation (Option 1) keeps the footgun loaded; removal eliminates the entire codepath. JWT claims are request input by definition and must not surface as a `tenant_id` field that looks authoritative.

## Test plan

- [x] `uv run pytest -m unit -k supabase` → 19 passed (15 supabase + 4 authz)
- [x] `uv run ruff check src/core/supabase_auth.py tests/test_supabase_auth.py` clean
- [x] `uv run ruff format --check ...` clean
- [x] `grep -rn "claims\.tenant_id\|_extract_tenant_id"` returns only the intentional docstring reference

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)