### PR TITLE
refactor(api): drop deps from _resolve_jwt + isinstance guard

### DIFF
--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -75,7 +75,7 @@ async def get_tenant_id(
         tenant_id = await _resolve_api_key(token, request, deps)
     else:
         pool = getattr(request.app.state, "pg_pool", None)
-        tenant_id = await _resolve_jwt(token, deps, pool)
+        tenant_id = await _resolve_jwt(token, pool)
 
     request.state.tenant_id = tenant_id
     set_request_context(tenant_id=tenant_id)
@@ -150,13 +150,13 @@ async def get_tenant_id_from_jwt(
         )
 
     pool = getattr(request.app.state, "pg_pool", None)
-    tenant_id = await _resolve_jwt(token, deps, pool)
+    tenant_id = await _resolve_jwt(token, pool)
     request.state.tenant_id = tenant_id
     set_request_context(tenant_id=tenant_id)
     return tenant_id
 
 
-async def _resolve_jwt(token: str, deps: AgentDependencies, pool: Optional[asyncpg.Pool]) -> str:
+async def _resolve_jwt(token: str, pool: Optional[asyncpg.Pool]) -> str:
     """Validate a JWT (Supabase or legacy NextAuth) and return its tenant_id.
 
     Routing rule: if the token's unverified `iss` matches the configured
@@ -168,7 +168,7 @@ async def _resolve_jwt(token: str, deps: AgentDependencies, pool: Optional[async
     The Supabase path needs ``pool`` to look up the caller's profile in
     Postgres. The NextAuth path is self-contained (settings only).
     """
-    settings = deps.settings if isinstance(deps.settings, Settings) else load_settings()
+    settings = load_settings()
 
     if _looks_like_supabase_token(token, settings):
         try:

--- a/apps/api/src/core/tenant.py
+++ b/apps/api/src/core/tenant.py
@@ -128,12 +128,13 @@ async def _resolve_api_key_mongo(raw_key: str, deps: AgentDependencies) -> str:
 async def get_tenant_id_from_jwt(
     request: Request,
     authorization: Optional[str] = Header(default=None),
-    deps: AgentDependencies = Depends(get_deps),
 ) -> str:
     """Extract tenant_id from JWT only. Rejects API keys.
 
     Used by endpoints that must only be reachable from a dashboard session
-    (e.g., key management), not from a programmatic API key.
+    (e.g., key management), not from a programmatic API key. The JWT path
+    no longer needs ``AgentDependencies`` (post-#75) — Settings load directly
+    and the Postgres pool is read off ``request.app.state``.
     """
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(


### PR DESCRIPTION
## Summary

- New signature: `_resolve_jwt(token: str, pool: Optional[asyncpg.Pool]) -> str` (was `(token, deps, pool)`)
- Calls `load_settings()` directly instead of reaching through `deps.settings`
- Drops the `isinstance(deps.settings, Settings) else load_settings()` ternary that was a `MagicMock`-survival pattern from older tests

This mirrors the same cleanup PR #78 applied to `authz.py` — `_resolve_jwt` only ever read `deps.settings`, so the `AgentDependencies` injection was dead weight. Current tests inject a real `Settings` via `app.dependency_overrides`, so the defensive `isinstance` ternary is no longer load-bearing.

Net win: fewer cross-module deps, simpler signatures, less defensive code in production.

## Files

- `apps/api/src/core/tenant.py` — 4 lines changed at lines 78, 153, 159, 171

## Test plan

- [x] `uv run pytest -m unit -k "tenant or jwt"` — 90 passed
- [x] `uv run ruff check src/core/tenant.py` clean
- [x] `uv run ruff format --check src/core/tenant.py` clean

> Note: `tests/test_tenant_filter_audit.py::test_every_mongo_call_in_apps_api_is_tenant_scoped` fails for `services/webhook_delivery.py:176` — that failure is **pre-existing on main** (verified by stashing this PR's diff and re-running) and unrelated to this refactor. Worth filing as its own issue.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)